### PR TITLE
reject weak keys

### DIFF
--- a/jwa/hs/hs.go
+++ b/jwa/hs/hs.go
@@ -15,6 +15,10 @@ var hs256 = &Algorithm{
 	hash: crypto.SHA256,
 }
 
+// New256 returns HS256 (HMAC using SHA-256) signature algorithm.
+//
+// New256 doesn't accept weak keys less than 256 bit.
+// If you want to use weak keys, use New256Weak instead.
 func New256() sig.Algorithm {
 	return hs256
 }
@@ -24,6 +28,10 @@ var hs384 = &Algorithm{
 	hash: crypto.SHA384,
 }
 
+// New384 returns HS384 (HMAC using SHA-384) signature algorithm.
+//
+// New384 doesn't accept weak keys less than 384 bit.
+// If you want to use weak keys, use New384Weak instead.
 func New384() sig.Algorithm {
 	return hs384
 }
@@ -33,8 +41,51 @@ var hs512 = &Algorithm{
 	hash: crypto.SHA512,
 }
 
+// New512 returns HS512 (HMAC using SHA-512) signature algorithm.
+//
+// New512 doesn't accept weak keys less than 512 bit.
+// If you want to use weak keys, use New512Weak instead.
 func New512() sig.Algorithm {
 	return hs512
+}
+
+var hs256w = &Algorithm{
+	alg:  jwa.HS256,
+	hash: crypto.SHA256,
+	weak: true,
+}
+
+// New256Weak is same as New256, but it accepts the weak keys.
+//
+// Deprecated: Use New256 instead.
+func New256Weak() sig.Algorithm {
+	return hs256w
+}
+
+var hs384w = &Algorithm{
+	alg:  jwa.HS384,
+	hash: crypto.SHA384,
+	weak: true,
+}
+
+// New384Weak is same as New384, but it accepts the weak keys.
+//
+// Deprecated: Use New384 instead.
+func New384Weak() sig.Algorithm {
+	return hs384w
+}
+
+var hs512w = &Algorithm{
+	alg:  jwa.HS256,
+	hash: crypto.SHA512,
+	weak: true,
+}
+
+// New512Weak is same as New512, but it accepts the weak keys.
+//
+// Deprecated: Use New512 instead.
+func New512Weak() sig.Algorithm {
+	return hs512w
 }
 
 func init() {
@@ -45,6 +96,11 @@ func init() {
 
 var _ sig.Algorithm = (*Algorithm)(nil)
 
+// Algorithm is HMAC using SHA-2.
+//
+// By default, using weak keys that have the smaller size than the hash output fails.
+// If you want to use weak keys, use New256Weak, New384Weak, and New512Weak instead of
+// New256, New384, and New512.
 type Algorithm struct {
 	alg  jwa.SignatureAlgorithm
 	hash crypto.Hash
@@ -53,6 +109,7 @@ type Algorithm struct {
 
 var _ sig.Key = (*Key)(nil)
 
+// Key is a key for signing.
 type Key struct {
 	hash crypto.Hash
 	key  []byte

--- a/jwa/hs/hs_test.go
+++ b/jwa/hs/hs_test.go
@@ -2,6 +2,7 @@ package hs
 
 import (
 	"crypto/hmac"
+	"crypto/rand"
 	_ "crypto/sha256"
 	_ "crypto/sha512"
 	"encoding/hex"
@@ -373,5 +374,23 @@ func TestVerify_Mismatch(t *testing.T) {
 			t.Errorf("test %d: want sig.ErrSignatureMismatch, got %v", i, err)
 			continue
 		}
+	}
+}
+
+func TestWeakKeys(t *testing.T) {
+	priv := make([]byte, 31)
+	_, err := rand.Read(priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	key := New256().NewKey(priv, nil)
+	if _, err := key.Sign([]byte("payload")); err == nil {
+		t.Error("want some error, but not")
+	}
+
+	key = New256Weak().NewKey(priv, nil)
+	if _, err := key.Sign([]byte("payload")); err != nil {
+		t.Error(err)
 	}
 }

--- a/jwa/hs/hs_test.go
+++ b/jwa/hs/hs_test.go
@@ -19,7 +19,7 @@ var tests = []struct {
 }{
 	// Tests from RFC 4231
 	{
-		New256,
+		New256Weak,
 		[]byte{
 			0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b,
 			0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b,
@@ -29,13 +29,13 @@ var tests = []struct {
 		"b0344c61d8db38535ca8afceaf0bf12b881dc200c9833da726e9376c2e32cff7",
 	},
 	{
-		New256,
+		New256Weak,
 		[]byte("Jefe"),
 		[]byte("what do ya want for nothing?"),
 		"5bdcc146bf60754e6a042426089575c75a003f089d2739839dec58b964ec3843",
 	},
 	{
-		New256,
+		New256Weak,
 		[]byte{
 			0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa,
 			0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa,
@@ -53,7 +53,7 @@ var tests = []struct {
 		"773ea91e36800e46854db8ebd09181a72959098b3ef8c122d9635514ced565fe",
 	},
 	{
-		New256,
+		New256Weak,
 		[]byte{
 			0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
 			0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10,
@@ -271,19 +271,19 @@ var tests = []struct {
 
 	// HMAC without key is dumb but should probably not fail.
 	{
-		New256,
+		New256Weak,
 		[]byte{},
 		[]byte("message"),
 		"eb08c1f56d5ddee07f7bdf80468083da06b64cf4fac64fe3a90883df5feacae4",
 	},
 	{
-		New384,
+		New384Weak,
 		[]byte{},
 		[]byte("message"),
 		"a1302a8028a419bb834bfae53c5e98ab48e07aed9ef8b980a821df28685902003746ade315072edd8ce009a1d23705ec",
 	},
 	{
-		New512,
+		New512Weak,
 		[]byte{},
 		[]byte("message"),
 		"08fce52f6395d59c2a3fb8abb281d74ad6f112b9a9c787bcea290d94dadbc82b2ca3e5e12bf2277c7fedbb0154d5493e41bb7459f63c8e39554ea3651b812492",

--- a/jwa/none/none.go
+++ b/jwa/none/none.go
@@ -8,6 +8,9 @@ import (
 
 var none = &Algorithm{}
 
+// New returns a new signature algorithm that does nothing.
+//
+// Deprecated: Never use none algorithm.
 func New() sig.Algorithm {
 	return none
 }

--- a/jwa/ps/ps.go
+++ b/jwa/ps/ps.go
@@ -16,6 +16,10 @@ var ps256 = &Algorithm{
 	hash: crypto.SHA256,
 }
 
+// New256 returns PS256 signature algorithm.
+//
+// New256 doesn't accept weak keys less than 2048 bit.
+// If you want to use weak keys, use New256Weak instead.
 func New256() sig.Algorithm {
 	return ps256
 }
@@ -25,6 +29,10 @@ var ps384 = &Algorithm{
 	hash: crypto.SHA384,
 }
 
+// New384 returns PS384 signature algorithm.
+//
+// New384 doesn't accept weak keys less than 2048 bit.
+// If you want to use weak keys, use New384Weak instead.
 func New384() sig.Algorithm {
 	return ps384
 }
@@ -34,8 +42,51 @@ var ps512 = &Algorithm{
 	hash: crypto.SHA512,
 }
 
+// New512 returns PS512 signature algorithm.
+//
+// New512 doesn't accept weak keys less than 2048 bit.
+// If you want to use weak keys, use New512Weak instead.
 func New512() sig.Algorithm {
 	return ps512
+}
+
+var ps256w = &Algorithm{
+	alg:  jwa.RS256,
+	hash: crypto.SHA256,
+	weak: true,
+}
+
+// New256Weak is same as New256, but it accepts the weak keys.
+//
+// Deprecated: Use New256 instead.
+func New256Weak() sig.Algorithm {
+	return ps256w
+}
+
+var ps384w = &Algorithm{
+	alg:  jwa.RS384,
+	hash: crypto.SHA384,
+	weak: true,
+}
+
+// New384Weak is same as New384, but it accepts the weak keys.
+//
+// Deprecated: Use New384 instead.
+func New384Weak() sig.Algorithm {
+	return ps384w
+}
+
+var ps512w = &Algorithm{
+	alg:  jwa.RS512,
+	hash: crypto.SHA512,
+	weak: true,
+}
+
+// New512Weak is same as New512, but it accepts the weak keys.
+//
+// Deprecated: Use New512 instead.
+func New512Weak() sig.Algorithm {
+	return ps512w
 }
 
 func init() {

--- a/jwa/ps/ps_test.go
+++ b/jwa/ps/ps_test.go
@@ -1,6 +1,7 @@
 package ps
 
 import (
+	"crypto/rand"
 	"crypto/rsa"
 	"math/big"
 	"testing"
@@ -119,5 +120,22 @@ func TestSignAndVerify(t *testing.T) {
 			t.Errorf("test %d: %v", i, err)
 			continue
 		}
+	}
+}
+
+func TestWeakKeys(t *testing.T) {
+	rsakey, err := rsa.GenerateKey(rand.Reader, 2047)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	key := New256().NewKey(rsakey, rsakey.Public())
+	if _, err := key.Sign([]byte("payload")); err == nil {
+		t.Error("want some error, but not")
+	}
+
+	key = New256Weak().NewKey(rsakey, rsakey.Public())
+	if _, err := key.Sign([]byte("payload")); err != nil {
+		t.Error(err)
 	}
 }

--- a/jwa/rs/rs.go
+++ b/jwa/rs/rs.go
@@ -15,6 +15,10 @@ var rs256 = &Algorithm{
 	hash: crypto.SHA256,
 }
 
+// New256 returns RS256 signature algorithm.
+//
+// New256 doesn't accept weak keys less than 2048 bit.
+// If you want to use weak keys, use New256Weak instead.
 func New256() sig.Algorithm {
 	return rs256
 }
@@ -24,6 +28,10 @@ var rs384 = &Algorithm{
 	hash: crypto.SHA384,
 }
 
+// New384 returns RS384 signature algorithm.
+//
+// New384 doesn't accept weak keys less than 2048 bit.
+// If you want to use weak keys, use New384Weak instead.
 func New384() sig.Algorithm {
 	return rs384
 }
@@ -33,8 +41,51 @@ var rs512 = &Algorithm{
 	hash: crypto.SHA512,
 }
 
+// New512 returns RS512 signature algorithm.
+//
+// New512 doesn't accept weak keys less than 2048 bit.
+// If you want to use weak keys, use New512Weak instead.
 func New512() sig.Algorithm {
 	return rs512
+}
+
+var rs256w = &Algorithm{
+	alg:  jwa.RS256,
+	hash: crypto.SHA256,
+	weak: true,
+}
+
+// New256Weak is same as New256, but it accepts the weak keys.
+//
+// Deprecated: Use New256 instead.
+func New256Weak() sig.Algorithm {
+	return rs256w
+}
+
+var rs384w = &Algorithm{
+	alg:  jwa.RS384,
+	hash: crypto.SHA384,
+	weak: true,
+}
+
+// New384Weak is same as New384, but it accepts the weak keys.
+//
+// Deprecated: Use New384 instead.
+func New384Weak() sig.Algorithm {
+	return rs384w
+}
+
+var rs512w = &Algorithm{
+	alg:  jwa.RS512,
+	hash: crypto.SHA512,
+	weak: true,
+}
+
+// New512Weak is same as New512, but it accepts the weak keys.
+//
+// Deprecated: Use New512 instead.
+func New512Weak() sig.Algorithm {
+	return rs512w
 }
 
 func init() {
@@ -45,6 +96,11 @@ func init() {
 
 var _ sig.Algorithm = (*Algorithm)(nil)
 
+// Algorithm is RSASSA-PKCS1-v1_5.
+//
+// By default, using weak keys less 2048 bits fails.
+// If you want to use weak keys, use New256Weak, New384Weak, and New512Weak instead of
+// New256, New384, and New512.
 type Algorithm struct {
 	alg  jwa.SignatureAlgorithm
 	hash crypto.Hash

--- a/jwa/rs/rs_test.go
+++ b/jwa/rs/rs_test.go
@@ -2,6 +2,7 @@ package rs
 
 import (
 	"crypto/hmac"
+	"crypto/rand"
 	"crypto/rsa"
 	"math/big"
 	"testing"
@@ -122,5 +123,22 @@ func TestVerify(t *testing.T) {
 			t.Errorf("test %d: %v", i, err)
 			continue
 		}
+	}
+}
+
+func TestWeakKeys(t *testing.T) {
+	rsakey, err := rsa.GenerateKey(rand.Reader, 2047)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	key := New256().NewKey(rsakey, rsakey.Public())
+	if _, err := key.Sign([]byte("payload")); err == nil {
+		t.Error("want some error, but not")
+	}
+
+	key = New256Weak().NewKey(rsakey, rsakey.Public())
+	if _, err := key.Sign([]byte("payload")); err != nil {
+		t.Error(err)
 	}
 }

--- a/jws/jws_test.go
+++ b/jws/jws_test.go
@@ -275,7 +275,7 @@ func TestSign(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		k := jwa.HS256.New().NewKey(key.PrivateKey, key.PrivateKey)
+		k := jwa.HS256.New().NewKey(key.PrivateKey, key.PublicKey)
 		h := &Header{Algorithm: jwa.HS256, Type: "JWT"}
 		payload := []byte(`{"iss":"joe",` + "\r\n" +
 			` "exp":1300819380,` + "\r\n" +

--- a/sig/sig.go
+++ b/sig/sig.go
@@ -68,3 +68,25 @@ func (key *invalidKey) Error() string {
 	}
 	return "sig: invalid key type for algorithm " + key.alg + ": " + priv + ", " + pub
 }
+
+type errKey struct {
+	err error
+}
+
+// NewInvalidKey returns a new key that returns an error for all
+// Sign and Verify operations.
+func NewErrorKey(err error) Key {
+	return &errKey{
+		err: err,
+	}
+}
+
+// Sign implements Key.
+func (key *errKey) Sign(payload []byte) (signature []byte, err error) {
+	return nil, key.err
+}
+
+// Verify implements Key.
+func (key *errKey) Verify(payload, signature []byte) error {
+	return key.err
+}


### PR DESCRIPTION
RFC 7518 says:

> A key of the same size as the hash output (for instance, 256 bits for "HS256") or larger MUST be used with this algorithm. (from Section 3.2. HMAC with SHA-2 Functions)

> A key of size 2048 bits or larger MUST be used with this algorithm. (from [3.3](https://www.rfc-editor.org/rfc/rfc7518.html#section-3.3).  Digital Signature with RSASSA-PKCS1-v1_5)
