### PR TITLE
optimize padding of package acbc

### DIFF
--- a/jwa/acbc/acbc.go
+++ b/jwa/acbc/acbc.go
@@ -186,11 +186,8 @@ func padding(data []byte, size int) []byte {
 
 	// fill pad
 	copy(ret, data)
-	for i := 1; i <= size; i++ {
-		t := uint(paddingLen) - uint(i)
-		// if i <= paddingLen then the MSB of t is zero
-		mask := byte(int32(^t) >> 31)
-		ret[l-i] = ^mask&ret[l-i] | mask&pad
+	for i := len(data); i < l; i++ {
+		ret[i] = pad
 	}
 	return ret
 }


### PR DESCRIPTION
I've implemented constant time adding pads, but we don't need it.
We know the plaintext in this case, so the pads are not secret.