### PR TITLE
inlining carry propagate

### DIFF
--- a/internal/edwards448/field/fe.go
+++ b/internal/edwards448/field/fe.go
@@ -118,7 +118,29 @@ func (v *Element) Add(a, b *Element) *Element {
 	v.l5 = a.l5 + b.l5
 	v.l6 = a.l6 + b.l6
 	v.l7 = a.l7 + b.l7
-	return v.carryPropagate()
+
+	// propagate carry
+	c0 := v.l0 >> 56
+	c1 := v.l1 >> 56
+	c2 := v.l2 >> 56
+	c3 := v.l3 >> 56
+	c4 := v.l4 >> 56
+	c5 := v.l5 >> 56
+	c6 := v.l6 >> 56
+	c7 := v.l7 >> 56
+
+	// c7 is at most 64 - 56 = 8 bits,
+	// so the final l0 will be at most 57 bits. Similarly for the rest.
+	v.l0 = v.l0&maskLow56Bits + c7
+	v.l1 = v.l1&maskLow56Bits + c0
+	v.l2 = v.l2&maskLow56Bits + c1
+	v.l3 = v.l3&maskLow56Bits + c2
+	v.l4 = v.l4&maskLow56Bits + c3 + c7
+	v.l5 = v.l5&maskLow56Bits + c4
+	v.l6 = v.l6&maskLow56Bits + c5
+	v.l7 = v.l7&maskLow56Bits + c6
+
+	return v
 }
 
 // Subtract sets v = a - b, and returns v.
@@ -133,12 +155,66 @@ func (v *Element) Sub(a, b *Element) *Element {
 	v.l5 = (a.l5 + 2*0xFF_FFFF_FFFF_FFFF) - b.l5
 	v.l6 = (a.l6 + 2*0xFF_FFFF_FFFF_FFFF) - b.l6
 	v.l7 = (a.l7 + 2*0xFF_FFFF_FFFF_FFFF) - b.l7
-	return v.carryPropagate()
+
+	// propagate carry
+	c0 := v.l0 >> 56
+	c1 := v.l1 >> 56
+	c2 := v.l2 >> 56
+	c3 := v.l3 >> 56
+	c4 := v.l4 >> 56
+	c5 := v.l5 >> 56
+	c6 := v.l6 >> 56
+	c7 := v.l7 >> 56
+
+	// c7 is at most 64 - 56 = 8 bits,
+	// so the final l0 will be at most 57 bits. Similarly for the rest.
+	v.l0 = v.l0&maskLow56Bits + c7
+	v.l1 = v.l1&maskLow56Bits + c0
+	v.l2 = v.l2&maskLow56Bits + c1
+	v.l3 = v.l3&maskLow56Bits + c2
+	v.l4 = v.l4&maskLow56Bits + c3 + c7
+	v.l5 = v.l5&maskLow56Bits + c4
+	v.l6 = v.l6&maskLow56Bits + c5
+	v.l7 = v.l7&maskLow56Bits + c6
+
+	return v
 }
 
 // Negate sets v = -a, and returns v.
 func (v *Element) Negate(a *Element) *Element {
-	return v.Sub(feZero, a)
+	// We first add 2 * p, to guarantee the subtraction won't underflow, and
+	// then subtract b (which can be up to 2^448 + 2^232 + 2^8).
+	v.l0 = 2*0xFF_FFFF_FFFF_FFFF - a.l0
+	v.l1 = 2*0xFF_FFFF_FFFF_FFFF - a.l1
+	v.l2 = 2*0xFF_FFFF_FFFF_FFFF - a.l2
+	v.l3 = 2*0xFF_FFFF_FFFF_FFFF - a.l3
+	v.l4 = 2*0xFF_FFFF_FFFF_FFFE - a.l4
+	v.l5 = 2*0xFF_FFFF_FFFF_FFFF - a.l5
+	v.l6 = 2*0xFF_FFFF_FFFF_FFFF - a.l6
+	v.l7 = 2*0xFF_FFFF_FFFF_FFFF - a.l7
+
+	// propagate carry
+	c0 := v.l0 >> 56
+	c1 := v.l1 >> 56
+	c2 := v.l2 >> 56
+	c3 := v.l3 >> 56
+	c4 := v.l4 >> 56
+	c5 := v.l5 >> 56
+	c6 := v.l6 >> 56
+	c7 := v.l7 >> 56
+
+	// c7 is at most 64 - 56 = 8 bits,
+	// so the final l0 will be at most 57 bits. Similarly for the rest.
+	v.l0 = v.l0&maskLow56Bits + c7
+	v.l1 = v.l1&maskLow56Bits + c0
+	v.l2 = v.l2&maskLow56Bits + c1
+	v.l3 = v.l3&maskLow56Bits + c2
+	v.l4 = v.l4&maskLow56Bits + c3 + c7
+	v.l5 = v.l5&maskLow56Bits + c4
+	v.l6 = v.l6&maskLow56Bits + c5
+	v.l7 = v.l7&maskLow56Bits + c6
+
+	return v
 }
 
 // Set sets v = a, and returns v.
@@ -664,7 +740,29 @@ func (v *Element) Mul(a, b *Element) *Element {
 	rr6 := r6.lo&maskLow56Bits + c5
 	rr7 := r7.lo&maskLow56Bits + c6
 	*v = Element{rr0, rr1, rr2, rr3, rr4, rr5, rr6, rr7}
-	return v.carryPropagate()
+
+	// propagate carry
+	c0 = v.l0 >> 56
+	c1 = v.l1 >> 56
+	c2 = v.l2 >> 56
+	c3 = v.l3 >> 56
+	c4 = v.l4 >> 56
+	c5 = v.l5 >> 56
+	c6 = v.l6 >> 56
+	c7 = v.l7 >> 56
+
+	// c7 is at most 64 - 56 = 8 bits,
+	// so the final l0 will be at most 57 bits. Similarly for the rest.
+	v.l0 = v.l0&maskLow56Bits + c7
+	v.l1 = v.l1&maskLow56Bits + c0
+	v.l2 = v.l2&maskLow56Bits + c1
+	v.l3 = v.l3&maskLow56Bits + c2
+	v.l4 = v.l4&maskLow56Bits + c3 + c7
+	v.l5 = v.l5&maskLow56Bits + c4
+	v.l6 = v.l6&maskLow56Bits + c5
+	v.l7 = v.l7&maskLow56Bits + c6
+
+	return v
 }
 
 //                                      a7   a6   a5   a4   a3   a2   a1   a0  =
@@ -830,7 +928,29 @@ func (v *Element) Square(a *Element) *Element {
 	rr6 := r6.lo&maskLow56Bits + c5
 	rr7 := r7.lo&maskLow56Bits + c6
 	*v = Element{rr0, rr1, rr2, rr3, rr4, rr5, rr6, rr7}
-	return v.carryPropagate()
+
+	// propagate carry
+	c0 = v.l0 >> 56
+	c1 = v.l1 >> 56
+	c2 = v.l2 >> 56
+	c3 = v.l3 >> 56
+	c4 = v.l4 >> 56
+	c5 = v.l5 >> 56
+	c6 = v.l6 >> 56
+	c7 = v.l7 >> 56
+
+	// c7 is at most 64 - 56 = 8 bits,
+	// so the final l0 will be at most 57 bits. Similarly for the rest.
+	v.l0 = v.l0&maskLow56Bits + c7
+	v.l1 = v.l1&maskLow56Bits + c0
+	v.l2 = v.l2&maskLow56Bits + c1
+	v.l3 = v.l3&maskLow56Bits + c2
+	v.l4 = v.l4&maskLow56Bits + c3 + c7
+	v.l5 = v.l5&maskLow56Bits + c4
+	v.l6 = v.l6&maskLow56Bits + c5
+	v.l7 = v.l7&maskLow56Bits + c6
+
+	return v
 }
 
 // Inv sets v = 1/z mod p, and returns v.


### PR DESCRIPTION
```
name          old time/op  new time/op  delta
Add-10        5.05ns ± 2%  4.63ns ± 1%   -8.44%  (p=0.000 n=10+10)
Sub-10        5.36ns ± 0%  4.93ns ± 1%   -8.06%  (p=0.000 n=8+10)
Negate-10     5.49ns ± 0%  4.00ns ± 0%  -27.03%  (p=0.000 n=9+9)
SetBytes-10   6.77ns ± 0%  6.81ns ± 1%   +0.69%  (p=0.041 n=9+10)
Equal1-10     20.0ns ± 0%  20.1ns ± 0%   +0.62%  (p=0.000 n=10+8)
Equal2-10     20.0ns ± 0%  20.1ns ± 0%   +0.71%  (p=0.000 n=9+10)
Mul32-10      5.57ns ± 0%  5.56ns ± 0%   -0.03%  (p=0.049 n=10+9)
Mul-10        42.6ns ± 0%  42.3ns ± 1%   -0.87%  (p=0.002 n=9+10)
Square-10     31.4ns ± 0%  30.8ns ± 0%   -1.81%  (p=0.000 n=10+10)
Inv-10        14.5µs ± 0%  14.5µs ± 2%     ~     (p=0.897 n=10+10)
SqrtRatio-10  14.6µs ± 1%  14.4µs ± 1%   -1.33%  (p=0.000 n=10+10)
```

```
name               old time/op  new time/op  delta
KeyGeneration-10    273µs ± 2%   265µs ± 1%  -2.95%  (p=0.000 n=10+9)
NewKeyFromSeed-10   268µs ± 1%   263µs ± 0%  -1.83%  (p=0.000 n=10+9)
Sign-10             288µs ± 1%   283µs ± 1%  -1.67%  (p=0.000 n=9+10)
Verify-10           536µs ± 1%   523µs ± 1%  -2.48%  (p=0.000 n=10+9)
```