### PR TITLE
rypto: make private key equals methods constant time

### DIFF
--- a/ed448/ed448.go
+++ b/ed448/ed448.go
@@ -11,6 +11,7 @@ import (
 	"bytes"
 	"crypto"
 	cryptorand "crypto/rand"
+	"crypto/subtle"
 	"errors"
 	"io"
 	"strconv"
@@ -58,7 +59,7 @@ func (priv PrivateKey) Equal(x crypto.PrivateKey) bool {
 	if !ok {
 		return false
 	}
-	return bytes.Equal(priv, xx)
+	return subtle.ConstantTimeCompare(priv, xx) == 1
 }
 
 // Seed returns the private key seed corresponding to priv. It is provided for

--- a/x25519/x25519.go
+++ b/x25519/x25519.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"crypto"
 	cryptorand "crypto/rand"
+	"crypto/subtle"
 	"io"
 	"strconv"
 
@@ -54,7 +55,7 @@ func (priv PrivateKey) Equal(x crypto.PrivateKey) bool {
 	if !ok {
 		return false
 	}
-	return bytes.Equal(priv, xx)
+	return subtle.ConstantTimeCompare(priv, xx) == 1
 }
 
 // Seed returns the private key seed corresponding to priv. It is provided for

--- a/x448/x448.go
+++ b/x448/x448.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"crypto"
 	cryptorand "crypto/rand"
+	"crypto/subtle"
 	"errors"
 	"io"
 	"strconv"
@@ -63,7 +64,7 @@ func (priv PrivateKey) Equal(x crypto.PrivateKey) bool {
 	if !ok {
 		return false
 	}
-	return bytes.Equal(priv, xx)
+	return subtle.ConstantTimeCompare(priv, xx) == 1
 }
 
 // Seed returns the private key seed corresponding to priv. It is provided for


### PR DESCRIPTION
Use constant time logic when comparing the private components of Ed448,
X448, and X25519 in order to prevent leaking timing information.
This leak has minimal impact, since we generally do not consider
attacker controlled private key attacks to be in scope, but it's better
to make these APIs safe to use by default when it is trivial to do so.

We still don't use constant time comparisons when comparing the public
components of keys, since they are already public by design.

https://go-review.googlesource.com/c/go/+/417396