### PR TITLE
Bearer is now case-sensitive.

### DIFF
--- a/oauth2/oauth2.go
+++ b/oauth2/oauth2.go
@@ -9,15 +9,10 @@ import (
 func ExtractBearer(req *http.Request) (bearer string, ok bool) {
 	const prefix = "Bearer "
 	credentials := req.Header.Get("Authorization")
-	if len(credentials) < len(prefix) {
-		return "", false
-	}
 
 	// RFC 6750 says "Unless otherwise noted, all the protocol
-	// parameter names and values are case sensitive.",
-	// so "Bearer" should be case sensitive.
-	// However some clients sends "bearer", and we accept them.
-	if !strings.EqualFold(credentials[:len(prefix)], prefix) {
+	// parameter names and values are case sensitive."
+	if !strings.HasPrefix(credentials, prefix) {
 		return "", false
 	}
 

--- a/oauth2/oauth2_test.go
+++ b/oauth2/oauth2_test.go
@@ -18,9 +18,16 @@ func TestExtractBearer(t *testing.T) {
 			ok:  true,
 		},
 		{
-			in:  "bearer some-token",
-			out: "some-token",
-			ok:  true,
+			in: "",
+			ok: false,
+		},
+		{
+			in: "Bearer",
+			ok: false,
+		},
+		{
+			in: "bearer some-token",
+			ok: false,
 		},
 		{
 			in: "bearer",


### PR DESCRIPTION
The Authorization header is a security header
and should be strictly followed by RFCs.