### PR TITLE
Introduce new verify and parse interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,8 @@ Go Authentication Toolkit
 - [RFC 8812 CBOR Object Signing and Encryption (COSE) and JSON Object Signing and Encryption (JOSE) Registrations for Web Authentication (WebAuthn) Algorithms](https://datatracker.ietf.org/doc/html/rfc8812)
 - [OpenID Connect Core 1.0](https://openid.net/specs/openid-connect-core-1_0.html)
 - [OpenID Connect Discovery 1.0](https://openid.net/specs/openid-connect-discovery-1_0.html)
+
+## Related Works
+
+- [github.com/golang-jwt/jwt](https://github.com/golang-jwt/jwt)
+- [github.com/lestrrat-go/jwx](https://github.com/lestrrat-go/jwx)

--- a/jws/example_test.go
+++ b/jws/example_test.go
@@ -1,97 +1,97 @@
 package jws_test
 
-import (
-	"fmt"
-	"log"
+// import (
+// 	"fmt"
+// 	"log"
 
-	"github.com/shogo82148/goat/jwa"
-	"github.com/shogo82148/goat/jwk"
-	"github.com/shogo82148/goat/jws"
-	"github.com/shogo82148/goat/sig"
-)
+// 	"github.com/shogo82148/goat/jwa"
+// 	"github.com/shogo82148/goat/jwk"
+// 	"github.com/shogo82148/goat/jws"
+// 	"github.com/shogo82148/goat/sig"
+// )
 
-func ExampleParse() {
-	rawKey := `{"kty":"OKP","crv":"Ed25519",` +
-		`"x":"11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo"}`
-	key, err := jwk.ParseKey([]byte(rawKey))
-	if err != nil {
-		log.Fatal(err)
-	}
-	raw := "eyJhbGciOiJFZERTQSJ9" +
-		"." +
-		"RXhhbXBsZSBvZiBFZDI1NTE5IHNpZ25pbmc" +
-		"." +
-		"hgyY0il_MGCjP0JzlnLWG1PPOt7-09PGcvMg3AIbQR6dWbhijcNR4ki4iylGjg5BhVsPt" +
-		"9g7sVvpAr_MuM0KAg"
+// func ExampleParse() {
+// 	rawKey := `{"kty":"OKP","crv":"Ed25519",` +
+// 		`"x":"11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo"}`
+// 	key, err := jwk.ParseKey([]byte(rawKey))
+// 	if err != nil {
+// 		log.Fatal(err)
+// 	}
+// 	raw := "eyJhbGciOiJFZERTQSJ9" +
+// 		"." +
+// 		"RXhhbXBsZSBvZiBFZDI1NTE5IHNpZ25pbmc" +
+// 		"." +
+// 		"hgyY0il_MGCjP0JzlnLWG1PPOt7-09PGcvMg3AIbQR6dWbhijcNR4ki4iylGjg5BhVsPt" +
+// 		"9g7sVvpAr_MuM0KAg"
 
-	msg, err := jws.Parse([]byte(raw))
-	if err != nil {
-		log.Fatal(err)
-	}
+// 	msg, err := jws.Parse([]byte(raw))
+// 	if err != nil {
+// 		log.Fatal(err)
+// 	}
 
-	_, payload, err := msg.Verify(jws.FindKeyFunc(func(header, _ *jws.Header) (sig.SigningKey, error) {
-		alg := header.Algorithm().New()
-		return alg.NewSigningKey(key), nil
-	}))
-	if err != nil {
-		log.Fatal(err)
-	}
-	fmt.Println(string(payload))
-	// Output:
-	// Example of Ed25519 signing
-}
+// 	_, payload, err := msg.Verify(jws.FindKeyFunc(func(header, _ *jws.Header) (sig.SigningKey, error) {
+// 		alg := header.Algorithm().New()
+// 		return alg.NewSigningKey(key), nil
+// 	}))
+// 	if err != nil {
+// 		log.Fatal(err)
+// 	}
+// 	fmt.Println(string(payload))
+// 	// Output:
+// 	// Example of Ed25519 signing
+// }
 
-func ExampleMessage_Verify() {
-	rawKey := `{"kty":"OKP","crv":"Ed25519",` +
-		`"x":"11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo"}`
-	key, err := jwk.ParseKey([]byte(rawKey))
-	if err != nil {
-		log.Fatal(err)
-	}
-	raw := "eyJhbGciOiJFZERTQSJ9" +
-		"." +
-		"RXhhbXBsZSBvZiBFZDI1NTE5IHNpZ25pbmc" +
-		"." +
-		"hgyY0il_MGCjP0JzlnLWG1PPOt7-09PGcvMg3AIbQR6dWbhijcNR4ki4iylGjg5BhVsPt" +
-		"9g7sVvpAr_MuM0KAg"
+// func ExampleMessage_Verify() {
+// 	rawKey := `{"kty":"OKP","crv":"Ed25519",` +
+// 		`"x":"11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo"}`
+// 	key, err := jwk.ParseKey([]byte(rawKey))
+// 	if err != nil {
+// 		log.Fatal(err)
+// 	}
+// 	raw := "eyJhbGciOiJFZERTQSJ9" +
+// 		"." +
+// 		"RXhhbXBsZSBvZiBFZDI1NTE5IHNpZ25pbmc" +
+// 		"." +
+// 		"hgyY0il_MGCjP0JzlnLWG1PPOt7-09PGcvMg3AIbQR6dWbhijcNR4ki4iylGjg5BhVsPt" +
+// 		"9g7sVvpAr_MuM0KAg"
 
-	msg, err := jws.Parse([]byte(raw))
-	if err != nil {
-		log.Fatal(err)
-	}
+// 	msg, err := jws.Parse([]byte(raw))
+// 	if err != nil {
+// 		log.Fatal(err)
+// 	}
 
-	_, payload, err := msg.Verify(jws.FindKeyFunc(func(header, _ *jws.Header) (sig.SigningKey, error) {
-		alg := header.Algorithm().New()
-		return alg.NewSigningKey(key), nil
-	}))
-	if err != nil {
-		log.Fatal(err)
-	}
-	fmt.Println(string(payload))
-	// Output:
-	// Example of Ed25519 signing
-}
+// 	_, payload, err := msg.Verify(jws.FindKeyFunc(func(header, _ *jws.Header) (sig.SigningKey, error) {
+// 		alg := header.Algorithm().New()
+// 		return alg.NewSigningKey(key), nil
+// 	}))
+// 	if err != nil {
+// 		log.Fatal(err)
+// 	}
+// 	fmt.Println(string(payload))
+// 	// Output:
+// 	// Example of Ed25519 signing
+// }
 
-func ExampleMessage_Compact() {
-	rawKey := `{"kty":"OKP","crv":"Ed25519",` +
-		`"d":"nWGxne_9WmC6hEr0kuwsxERJxWl7MmkZcDusAxyuf2A",` +
-		`"x":"11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo"}`
-	key, err := jwk.ParseKey([]byte(rawKey))
-	if err != nil {
-		log.Fatal(err)
-	}
-	header := jws.NewHeader()
-	header.SetAlgorithm(jwa.EdDSA)
-	msg := jws.NewMessage([]byte("Example of Ed25519 signing"))
-	if err := msg.Sign(header, nil, jwa.EdDSA.New().NewSigningKey(key)); err != nil {
-		log.Fatal(err)
-	}
+// func ExampleMessage_Compact() {
+// 	rawKey := `{"kty":"OKP","crv":"Ed25519",` +
+// 		`"d":"nWGxne_9WmC6hEr0kuwsxERJxWl7MmkZcDusAxyuf2A",` +
+// 		`"x":"11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo"}`
+// 	key, err := jwk.ParseKey([]byte(rawKey))
+// 	if err != nil {
+// 		log.Fatal(err)
+// 	}
+// 	header := jws.NewHeader()
+// 	header.SetAlgorithm(jwa.EdDSA)
+// 	msg := jws.NewMessage([]byte("Example of Ed25519 signing"))
+// 	if err := msg.Sign(header, nil, jwa.EdDSA.New().NewSigningKey(key)); err != nil {
+// 		log.Fatal(err)
+// 	}
 
-	data, err := msg.Compact()
-	if err != nil {
-		log.Fatal(err)
-	}
-	fmt.Println(string(data))
-	// Output:
-	// eyJhbGciOiJFZERTQSJ9.RXhhbXBsZSBvZiBFZDI1NTE5IHNpZ25pbmc.hgyY0il_MGCjP0JzlnLWG1PPOt7-09PGcvMg3AIbQR6dWbhijcNR4ki4iylGjg5BhVsPt9g7sVvpAr_MuM0KAg
-}
+// 	data, err := msg.Compact()
+// 	if err != nil {
+// 		log.Fatal(err)
+// 	}
+// 	fmt.Println(string(data))
+// 	// Output:
+// 	// eyJhbGciOiJFZERTQSJ9.RXhhbXBsZSBvZiBFZDI1NTE5IHNpZ25pbmc.hgyY0il_MGCjP0JzlnLWG1PPOt7-09PGcvMg3AIbQR6dWbhijcNR4ki4iylGjg5BhVsPt9g7sVvpAr_MuM0KAg
+// }

--- a/jws/example_test.go
+++ b/jws/example_test.go
@@ -1,97 +1,101 @@
 package jws_test
 
-// import (
-// 	"fmt"
-// 	"log"
+import (
+	"context"
+	"fmt"
+	"log"
 
-// 	"github.com/shogo82148/goat/jwa"
-// 	"github.com/shogo82148/goat/jwk"
-// 	"github.com/shogo82148/goat/jws"
-// 	"github.com/shogo82148/goat/sig"
-// )
+	"github.com/shogo82148/goat/jwa"
+	"github.com/shogo82148/goat/jwk"
+	"github.com/shogo82148/goat/jws"
+)
 
-// func ExampleParse() {
-// 	rawKey := `{"kty":"OKP","crv":"Ed25519",` +
-// 		`"x":"11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo"}`
-// 	key, err := jwk.ParseKey([]byte(rawKey))
-// 	if err != nil {
-// 		log.Fatal(err)
-// 	}
-// 	raw := "eyJhbGciOiJFZERTQSJ9" +
-// 		"." +
-// 		"RXhhbXBsZSBvZiBFZDI1NTE5IHNpZ25pbmc" +
-// 		"." +
-// 		"hgyY0il_MGCjP0JzlnLWG1PPOt7-09PGcvMg3AIbQR6dWbhijcNR4ki4iylGjg5BhVsPt" +
-// 		"9g7sVvpAr_MuM0KAg"
+func ExampleParse() {
+	rawKey := `{"kty":"OKP","crv":"Ed25519",` +
+		`"x":"11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo"}`
+	key, err := jwk.ParseKey([]byte(rawKey))
+	if err != nil {
+		log.Fatal(err)
+	}
+	v := &jws.Verifier{
+		AlgorithmVerfier: jws.AllowedAlgorithms{jwa.EdDSA},
+		KeyFinder:        &jws.JWKKeyFinder{JWK: key},
+	}
 
-// 	msg, err := jws.Parse([]byte(raw))
-// 	if err != nil {
-// 		log.Fatal(err)
-// 	}
+	raw := "eyJhbGciOiJFZERTQSJ9" +
+		"." +
+		"RXhhbXBsZSBvZiBFZDI1NTE5IHNpZ25pbmc" +
+		"." +
+		"hgyY0il_MGCjP0JzlnLWG1PPOt7-09PGcvMg3AIbQR6dWbhijcNR4ki4iylGjg5BhVsPt" +
+		"9g7sVvpAr_MuM0KAg"
 
-// 	_, payload, err := msg.Verify(jws.FindKeyFunc(func(header, _ *jws.Header) (sig.SigningKey, error) {
-// 		alg := header.Algorithm().New()
-// 		return alg.NewSigningKey(key), nil
-// 	}))
-// 	if err != nil {
-// 		log.Fatal(err)
-// 	}
-// 	fmt.Println(string(payload))
-// 	// Output:
-// 	// Example of Ed25519 signing
-// }
+	msg, err := jws.Parse([]byte(raw))
+	if err != nil {
+		log.Fatal(err)
+	}
 
-// func ExampleMessage_Verify() {
-// 	rawKey := `{"kty":"OKP","crv":"Ed25519",` +
-// 		`"x":"11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo"}`
-// 	key, err := jwk.ParseKey([]byte(rawKey))
-// 	if err != nil {
-// 		log.Fatal(err)
-// 	}
-// 	raw := "eyJhbGciOiJFZERTQSJ9" +
-// 		"." +
-// 		"RXhhbXBsZSBvZiBFZDI1NTE5IHNpZ25pbmc" +
-// 		"." +
-// 		"hgyY0il_MGCjP0JzlnLWG1PPOt7-09PGcvMg3AIbQR6dWbhijcNR4ki4iylGjg5BhVsPt" +
-// 		"9g7sVvpAr_MuM0KAg"
+	_, payload, err := v.Verify(context.Background(), msg)
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println(string(payload))
+	// Output:
+	// Example of Ed25519 signing
+}
 
-// 	msg, err := jws.Parse([]byte(raw))
-// 	if err != nil {
-// 		log.Fatal(err)
-// 	}
+func ExampleVerifier_Verify() {
+	rawKey := `{"kty":"OKP","crv":"Ed25519",` +
+		`"x":"11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo"}`
+	key, err := jwk.ParseKey([]byte(rawKey))
+	if err != nil {
+		log.Fatal(err)
+	}
+	v := &jws.Verifier{
+		AlgorithmVerfier: jws.AllowedAlgorithms{jwa.EdDSA},
+		KeyFinder:        &jws.JWKKeyFinder{JWK: key},
+	}
 
-// 	_, payload, err := msg.Verify(jws.FindKeyFunc(func(header, _ *jws.Header) (sig.SigningKey, error) {
-// 		alg := header.Algorithm().New()
-// 		return alg.NewSigningKey(key), nil
-// 	}))
-// 	if err != nil {
-// 		log.Fatal(err)
-// 	}
-// 	fmt.Println(string(payload))
-// 	// Output:
-// 	// Example of Ed25519 signing
-// }
+	raw := "eyJhbGciOiJFZERTQSJ9" +
+		"." +
+		"RXhhbXBsZSBvZiBFZDI1NTE5IHNpZ25pbmc" +
+		"." +
+		"hgyY0il_MGCjP0JzlnLWG1PPOt7-09PGcvMg3AIbQR6dWbhijcNR4ki4iylGjg5BhVsPt" +
+		"9g7sVvpAr_MuM0KAg"
 
-// func ExampleMessage_Compact() {
-// 	rawKey := `{"kty":"OKP","crv":"Ed25519",` +
-// 		`"d":"nWGxne_9WmC6hEr0kuwsxERJxWl7MmkZcDusAxyuf2A",` +
-// 		`"x":"11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo"}`
-// 	key, err := jwk.ParseKey([]byte(rawKey))
-// 	if err != nil {
-// 		log.Fatal(err)
-// 	}
-// 	header := jws.NewHeader()
-// 	header.SetAlgorithm(jwa.EdDSA)
-// 	msg := jws.NewMessage([]byte("Example of Ed25519 signing"))
-// 	if err := msg.Sign(header, nil, jwa.EdDSA.New().NewSigningKey(key)); err != nil {
-// 		log.Fatal(err)
-// 	}
+	msg, err := jws.Parse([]byte(raw))
+	if err != nil {
+		log.Fatal(err)
+	}
 
-// 	data, err := msg.Compact()
-// 	if err != nil {
-// 		log.Fatal(err)
-// 	}
-// 	fmt.Println(string(data))
-// 	// Output:
-// 	// eyJhbGciOiJFZERTQSJ9.RXhhbXBsZSBvZiBFZDI1NTE5IHNpZ25pbmc.hgyY0il_MGCjP0JzlnLWG1PPOt7-09PGcvMg3AIbQR6dWbhijcNR4ki4iylGjg5BhVsPt9g7sVvpAr_MuM0KAg
-// }
+	_, payload, err := v.Verify(context.Background(), msg)
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println(string(payload))
+	// Output:
+	// Example of Ed25519 signing
+}
+
+func ExampleMessage_Compact() {
+	rawKey := `{"kty":"OKP","crv":"Ed25519",` +
+		`"d":"nWGxne_9WmC6hEr0kuwsxERJxWl7MmkZcDusAxyuf2A",` +
+		`"x":"11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo"}`
+	key, err := jwk.ParseKey([]byte(rawKey))
+	if err != nil {
+		log.Fatal(err)
+	}
+	header := jws.NewHeader()
+	header.SetAlgorithm(jwa.EdDSA)
+	msg := jws.NewMessage([]byte("Example of Ed25519 signing"))
+	if err := msg.Sign(header, nil, jwa.EdDSA.New().NewSigningKey(key)); err != nil {
+		log.Fatal(err)
+	}
+
+	data, err := msg.Compact()
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println(string(data))
+	// Output:
+	// eyJhbGciOiJFZERTQSJ9.RXhhbXBsZSBvZiBFZDI1NTE5IHNpZ25pbmc.hgyY0il_MGCjP0JzlnLWG1PPOt7-09PGcvMg3AIbQR6dWbhijcNR4ki4iylGjg5BhVsPt9g7sVvpAr_MuM0KAg
+}

--- a/jws/fuzz_test.go
+++ b/jws/fuzz_test.go
@@ -1,363 +1,375 @@
 package jws
 
-// import (
-// 	"bytes"
-// 	"errors"
-// 	"testing"
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
 
-// 	_ "github.com/shogo82148/goat/jwa/eddsa" // for Ed25519
-// 	_ "github.com/shogo82148/goat/jwa/es"    // for ECDSA
-// 	_ "github.com/shogo82148/goat/jwa/hs"    // for HMAC SHA-256
-// 	_ "github.com/shogo82148/goat/jwa/rs"    // for RSASSA-PKCS1-v1_5 SHA-256
-// 	"github.com/shogo82148/goat/jwk"
-// 	"github.com/shogo82148/goat/sig"
-// )
+	_ "github.com/shogo82148/goat/jwa/eddsa" // for Ed25519
+	_ "github.com/shogo82148/goat/jwa/es"    // for ECDSA
+	_ "github.com/shogo82148/goat/jwa/hs"    // for HMAC SHA-256
+	_ "github.com/shogo82148/goat/jwa/rs"    // for RSASSA-PKCS1-v1_5 SHA-256
+	"github.com/shogo82148/goat/jwk"
+	"github.com/shogo82148/goat/sig"
+)
 
-// func FuzzJWS(f *testing.F) {
-// 	f.Add(
-// 		`{`+
-// 			`"payload":`+
-// 			`"eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGF`+
-// 			`tcGxlLmNvbS9pc19yb290Ijp0cnVlfQ",`+
-// 			`"signatures":[`+
-// 			`{"protected":"eyJhbGciOiJSUzI1NiJ9",`+
-// 			`"header":`+
-// 			`{"kid":"2010-12-29"},`+
-// 			`"signature":`+
-// 			`"cC4hiUPoj9Eetdgtv3hF80EGrhuB__dzERat0XF9g2VtQgr9PJbu3XOiZj5RZ`+
-// 			`mh7AAuHIm4Bh-0Qc_lF5YKt_O8W2Fp5jujGbds9uJdbF9CUAr7t1dnZcAcQjb`+
-// 			`KBYNX4BAynRFdiuB--f_nZLgrnbyTyWzO75vRK5h6xBArLIARNPvkSjtQBMHl`+
-// 			`b1L07Qe7K0GarZRmB_eSN9383LcOLn6_dO--xi12jzDwusC-eOkHWEsqtFZES`+
-// 			`c6BfI7noOPqvhJ1phCnvWh6IeYI2w9QOYEUipUTI8np6LbgGY9Fs98rqVt5AX`+
-// 			`LIhWkWywlVmtVrBp0igcN_IoypGlUPQGe77Rw"},`+
-// 			`{"protected":"eyJhbGciOiJFUzI1NiJ9",`+
-// 			`"header":`+
-// 			`{"kid":"e9bc097a-ce51-4036-9562-d2ade882db0d"},`+
-// 			`"signature":`+
-// 			`"DtEhU3ljbEg8L38VWAfUAqOyKAM6-Xx-F4GawxaepmXFCgfTjDxw5djxLa8IS`+
-// 			`lSApmWQxfKTUJqPP3-Kg6NU1Q"}]`+
-// 			`}`,
-// 		`{"kty":"RSA",`+
-// 			`"n":"ofgWCuLjybRlzo0tZWJjNiuSfb4p4fAkd_wWJcyQoTbji9k0l8W26mPddx`+
-// 			`HmfHQp-Vaw-4qPCJrcS2mJPMEzP1Pt0Bm4d4QlL-yRT-SFd2lZS-pCgNMs`+
-// 			`D1W_YpRPEwOWvG6b32690r2jZ47soMZo9wGzjb_7OMg0LOL-bSf63kpaSH`+
-// 			`SXndS5z5rexMdbBYUsLA9e-KXBdQOS-UTo7WTBEMa2R2CapHg665xsmtdV`+
-// 			`MTBQY4uDZlxvb3qCo5ZwKh9kG4LT6_I5IhlJH7aGhyxXFvUK-DWNmoudF8`+
-// 			`NAco9_h9iaGNj8q2ethFkMLs91kzk2PAcDTW9gb54h4FRWyuXpoQ",`+
-// 			`"e":"AQAB",`+
-// 			`"d":"Eq5xpGnNCivDflJsRQBXHx1hdR1k6Ulwe2JZD50LpXyWPEAeP88vLNO97I`+
-// 			`jlA7_GQ5sLKMgvfTeXZx9SE-7YwVol2NXOoAJe46sui395IW_GO-pWJ1O0`+
-// 			`BkTGoVEn2bKVRUCgu-GjBVaYLU6f3l9kJfFNS3E0QbVdxzubSu3Mkqzjkn`+
-// 			`439X0M_V51gfpRLI9JYanrC4D4qAdGcopV_0ZHHzQlBjudU2QvXt4ehNYT`+
-// 			`CBr6XCLQUShb1juUO1ZdiYoFaFQT5Tw8bGUl_x_jTj3ccPDVZFD9pIuhLh`+
-// 			`BOneufuBiB4cS98l2SR_RQyGWSeWjnczT0QU91p1DhOVRuOopznQ",`+
-// 			`"p":"4BzEEOtIpmVdVEZNCqS7baC4crd0pqnRH_5IB3jw3bcxGn6QLvnEtfdUdi`+
-// 			`YrqBdss1l58BQ3KhooKeQTa9AB0Hw_Py5PJdTJNPY8cQn7ouZ2KKDcmnPG`+
-// 			`BY5t7yLc1QlQ5xHdwW1VhvKn-nXqhJTBgIPgtldC-KDV5z-y2XDwGUc",`+
-// 			`"q":"uQPEfgmVtjL0Uyyx88GZFF1fOunH3-7cepKmtH4pxhtCoHqpWmT8YAmZxa`+
-// 			`ewHgHAjLYsp1ZSe7zFYHj7C6ul7TjeLQeZD_YwD66t62wDmpe_HlB-TnBA`+
-// 			`-njbglfIsRLtXlnDzQkv5dTltRJ11BKBBypeeF6689rjcJIDEz9RWdc",`+
-// 			`"dp":"BwKfV3Akq5_MFZDFZCnW-wzl-CCo83WoZvnLQwCTeDv8uzluRSnm71I3Q`+
-// 			`CLdhrqE2e9YkxvuxdBfpT_PI7Yz-FOKnu1R6HsJeDCjn12Sk3vmAktV2zb`+
-// 			`34MCdy7cpdTh_YVr7tss2u6vneTwrA86rZtu5Mbr1C1XsmvkxHQAdYo0",`+
-// 			`"dq":"h_96-mK1R_7glhsum81dZxjTnYynPbZpHziZjeeHcXYsXaaMwkOlODsWa`+
-// 			`7I9xXDoRwbKgB719rrmI2oKr6N3Do9U0ajaHF-NKJnwgjMd2w9cjz3_-ky`+
-// 			`NlxAr2v4IKhGNpmM5iIgOS1VZnOZ68m6_pbLBSp3nssTdlqvd0tIiTHU",`+
-// 			`"qi":"IYd7DHOhrWvxkwPQsRM2tOgrjbcrfvtQJipd-DlcxyVuuM9sQLdgjVk2o`+
-// 			`y26F0EmpScGLq2MowX7fhd_QJQ3ydy5cY7YIBi87w93IKLEdfnbJtoOPLU`+
-// 			`W0ITrJReOgo1cq9SbsxYawBgfp_gh6A5603k2-ZQwVK0JKSHuLFkuQ3U"`+
-// 			`}`,
-// 	)
+func FuzzJWS(f *testing.F) {
+	f.Add(
+		`{`+
+			`"payload":`+
+			`"eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGF`+
+			`tcGxlLmNvbS9pc19yb290Ijp0cnVlfQ",`+
+			`"signatures":[`+
+			`{"protected":"eyJhbGciOiJSUzI1NiJ9",`+
+			`"header":`+
+			`{"kid":"2010-12-29"},`+
+			`"signature":`+
+			`"cC4hiUPoj9Eetdgtv3hF80EGrhuB__dzERat0XF9g2VtQgr9PJbu3XOiZj5RZ`+
+			`mh7AAuHIm4Bh-0Qc_lF5YKt_O8W2Fp5jujGbds9uJdbF9CUAr7t1dnZcAcQjb`+
+			`KBYNX4BAynRFdiuB--f_nZLgrnbyTyWzO75vRK5h6xBArLIARNPvkSjtQBMHl`+
+			`b1L07Qe7K0GarZRmB_eSN9383LcOLn6_dO--xi12jzDwusC-eOkHWEsqtFZES`+
+			`c6BfI7noOPqvhJ1phCnvWh6IeYI2w9QOYEUipUTI8np6LbgGY9Fs98rqVt5AX`+
+			`LIhWkWywlVmtVrBp0igcN_IoypGlUPQGe77Rw"},`+
+			`{"protected":"eyJhbGciOiJFUzI1NiJ9",`+
+			`"header":`+
+			`{"kid":"e9bc097a-ce51-4036-9562-d2ade882db0d"},`+
+			`"signature":`+
+			`"DtEhU3ljbEg8L38VWAfUAqOyKAM6-Xx-F4GawxaepmXFCgfTjDxw5djxLa8IS`+
+			`lSApmWQxfKTUJqPP3-Kg6NU1Q"}]`+
+			`}`,
+		`{"kty":"RSA",`+
+			`"n":"ofgWCuLjybRlzo0tZWJjNiuSfb4p4fAkd_wWJcyQoTbji9k0l8W26mPddx`+
+			`HmfHQp-Vaw-4qPCJrcS2mJPMEzP1Pt0Bm4d4QlL-yRT-SFd2lZS-pCgNMs`+
+			`D1W_YpRPEwOWvG6b32690r2jZ47soMZo9wGzjb_7OMg0LOL-bSf63kpaSH`+
+			`SXndS5z5rexMdbBYUsLA9e-KXBdQOS-UTo7WTBEMa2R2CapHg665xsmtdV`+
+			`MTBQY4uDZlxvb3qCo5ZwKh9kG4LT6_I5IhlJH7aGhyxXFvUK-DWNmoudF8`+
+			`NAco9_h9iaGNj8q2ethFkMLs91kzk2PAcDTW9gb54h4FRWyuXpoQ",`+
+			`"e":"AQAB",`+
+			`"d":"Eq5xpGnNCivDflJsRQBXHx1hdR1k6Ulwe2JZD50LpXyWPEAeP88vLNO97I`+
+			`jlA7_GQ5sLKMgvfTeXZx9SE-7YwVol2NXOoAJe46sui395IW_GO-pWJ1O0`+
+			`BkTGoVEn2bKVRUCgu-GjBVaYLU6f3l9kJfFNS3E0QbVdxzubSu3Mkqzjkn`+
+			`439X0M_V51gfpRLI9JYanrC4D4qAdGcopV_0ZHHzQlBjudU2QvXt4ehNYT`+
+			`CBr6XCLQUShb1juUO1ZdiYoFaFQT5Tw8bGUl_x_jTj3ccPDVZFD9pIuhLh`+
+			`BOneufuBiB4cS98l2SR_RQyGWSeWjnczT0QU91p1DhOVRuOopznQ",`+
+			`"p":"4BzEEOtIpmVdVEZNCqS7baC4crd0pqnRH_5IB3jw3bcxGn6QLvnEtfdUdi`+
+			`YrqBdss1l58BQ3KhooKeQTa9AB0Hw_Py5PJdTJNPY8cQn7ouZ2KKDcmnPG`+
+			`BY5t7yLc1QlQ5xHdwW1VhvKn-nXqhJTBgIPgtldC-KDV5z-y2XDwGUc",`+
+			`"q":"uQPEfgmVtjL0Uyyx88GZFF1fOunH3-7cepKmtH4pxhtCoHqpWmT8YAmZxa`+
+			`ewHgHAjLYsp1ZSe7zFYHj7C6ul7TjeLQeZD_YwD66t62wDmpe_HlB-TnBA`+
+			`-njbglfIsRLtXlnDzQkv5dTltRJ11BKBBypeeF6689rjcJIDEz9RWdc",`+
+			`"dp":"BwKfV3Akq5_MFZDFZCnW-wzl-CCo83WoZvnLQwCTeDv8uzluRSnm71I3Q`+
+			`CLdhrqE2e9YkxvuxdBfpT_PI7Yz-FOKnu1R6HsJeDCjn12Sk3vmAktV2zb`+
+			`34MCdy7cpdTh_YVr7tss2u6vneTwrA86rZtu5Mbr1C1XsmvkxHQAdYo0",`+
+			`"dq":"h_96-mK1R_7glhsum81dZxjTnYynPbZpHziZjeeHcXYsXaaMwkOlODsWa`+
+			`7I9xXDoRwbKgB719rrmI2oKr6N3Do9U0ajaHF-NKJnwgjMd2w9cjz3_-ky`+
+			`NlxAr2v4IKhGNpmM5iIgOS1VZnOZ68m6_pbLBSp3nssTdlqvd0tIiTHU",`+
+			`"qi":"IYd7DHOhrWvxkwPQsRM2tOgrjbcrfvtQJipd-DlcxyVuuM9sQLdgjVk2o`+
+			`y26F0EmpScGLq2MowX7fhd_QJQ3ydy5cY7YIBi87w93IKLEdfnbJtoOPLU`+
+			`W0ITrJReOgo1cq9SbsxYawBgfp_gh6A5603k2-ZQwVK0JKSHuLFkuQ3U"`+
+			`}`,
+	)
 
-// 	f.Add(
-// 		`{`+
-// 			`"payload":`+
-// 			`"eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGF`+
-// 			`tcGxlLmNvbS9pc19yb290Ijp0cnVlfQ",`+
-// 			`"signatures":[`+
-// 			`{"protected":"eyJhbGciOiJSUzI1NiJ9",`+
-// 			`"header":`+
-// 			`{"kid":"2010-12-29"},`+
-// 			`"signature":`+
-// 			`"cC4hiUPoj9Eetdgtv3hF80EGrhuB__dzERat0XF9g2VtQgr9PJbu3XOiZj5RZ`+
-// 			`mh7AAuHIm4Bh-0Qc_lF5YKt_O8W2Fp5jujGbds9uJdbF9CUAr7t1dnZcAcQjb`+
-// 			`KBYNX4BAynRFdiuB--f_nZLgrnbyTyWzO75vRK5h6xBArLIARNPvkSjtQBMHl`+
-// 			`b1L07Qe7K0GarZRmB_eSN9383LcOLn6_dO--xi12jzDwusC-eOkHWEsqtFZES`+
-// 			`c6BfI7noOPqvhJ1phCnvWh6IeYI2w9QOYEUipUTI8np6LbgGY9Fs98rqVt5AX`+
-// 			`LIhWkWywlVmtVrBp0igcN_IoypGlUPQGe77Rw"},`+
-// 			`{"protected":"eyJhbGciOiJFUzI1NiJ9",`+
-// 			`"header":`+
-// 			`{"kid":"e9bc097a-ce51-4036-9562-d2ade882db0d"},`+
-// 			`"signature":`+
-// 			`"DtEhU3ljbEg8L38VWAfUAqOyKAM6-Xx-F4GawxaepmXFCgfTjDxw5djxLa8IS`+
-// 			`lSApmWQxfKTUJqPP3-Kg6NU1Q"}]`+
-// 			`}`,
-// 		`{"kty":"EC",`+
-// 			`"crv":"P-256",`+
-// 			`"x":"f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvRVEU",`+
-// 			`"y":"x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0",`+
-// 			`"d":"jpsQnnGQmL-YBIffH1136cspYG6-0iY7X1fCE9-E9LI"`+
-// 			`}`,
-// 	)
+	f.Add(
+		`{`+
+			`"payload":`+
+			`"eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGF`+
+			`tcGxlLmNvbS9pc19yb290Ijp0cnVlfQ",`+
+			`"signatures":[`+
+			`{"protected":"eyJhbGciOiJSUzI1NiJ9",`+
+			`"header":`+
+			`{"kid":"2010-12-29"},`+
+			`"signature":`+
+			`"cC4hiUPoj9Eetdgtv3hF80EGrhuB__dzERat0XF9g2VtQgr9PJbu3XOiZj5RZ`+
+			`mh7AAuHIm4Bh-0Qc_lF5YKt_O8W2Fp5jujGbds9uJdbF9CUAr7t1dnZcAcQjb`+
+			`KBYNX4BAynRFdiuB--f_nZLgrnbyTyWzO75vRK5h6xBArLIARNPvkSjtQBMHl`+
+			`b1L07Qe7K0GarZRmB_eSN9383LcOLn6_dO--xi12jzDwusC-eOkHWEsqtFZES`+
+			`c6BfI7noOPqvhJ1phCnvWh6IeYI2w9QOYEUipUTI8np6LbgGY9Fs98rqVt5AX`+
+			`LIhWkWywlVmtVrBp0igcN_IoypGlUPQGe77Rw"},`+
+			`{"protected":"eyJhbGciOiJFUzI1NiJ9",`+
+			`"header":`+
+			`{"kid":"e9bc097a-ce51-4036-9562-d2ade882db0d"},`+
+			`"signature":`+
+			`"DtEhU3ljbEg8L38VWAfUAqOyKAM6-Xx-F4GawxaepmXFCgfTjDxw5djxLa8IS`+
+			`lSApmWQxfKTUJqPP3-Kg6NU1Q"}]`+
+			`}`,
+		`{"kty":"EC",`+
+			`"crv":"P-256",`+
+			`"x":"f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvRVEU",`+
+			`"y":"x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0",`+
+			`"d":"jpsQnnGQmL-YBIffH1136cspYG6-0iY7X1fCE9-E9LI"`+
+			`}`,
+	)
 
-// 	f.Add(
-// 		`{`+
-// 			`"payload":`+
-// 			`"eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGF`+
-// 			`tcGxlLmNvbS9pc19yb290Ijp0cnVlfQ",`+
-// 			`"protected":"eyJhbGciOiJFUzI1NiJ9",`+
-// 			`"header":`+
-// 			`{"kid":"e9bc097a-ce51-4036-9562-d2ade882db0d"},`+
-// 			`"signature":`+
-// 			`"DtEhU3ljbEg8L38VWAfUAqOyKAM6-Xx-F4GawxaepmXFCgfTjDxw5djxLa8IS`+
-// 			`lSApmWQxfKTUJqPP3-Kg6NU1Q"`+
-// 			`}`,
-// 		`{"kty":"EC",`+
-// 			`"crv":"P-256",`+
-// 			`"x":"f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvRVEU",`+
-// 			`"y":"x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0",`+
-// 			`"d":"jpsQnnGQmL-YBIffH1136cspYG6-0iY7X1fCE9-E9LI"`+
-// 			`}`,
-// 	)
+	f.Add(
+		`{`+
+			`"payload":`+
+			`"eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGF`+
+			`tcGxlLmNvbS9pc19yb290Ijp0cnVlfQ",`+
+			`"protected":"eyJhbGciOiJFUzI1NiJ9",`+
+			`"header":`+
+			`{"kid":"e9bc097a-ce51-4036-9562-d2ade882db0d"},`+
+			`"signature":`+
+			`"DtEhU3ljbEg8L38VWAfUAqOyKAM6-Xx-F4GawxaepmXFCgfTjDxw5djxLa8IS`+
+			`lSApmWQxfKTUJqPP3-Kg6NU1Q"`+
+			`}`,
+		`{"kty":"EC",`+
+			`"crv":"P-256",`+
+			`"x":"f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvRVEU",`+
+			`"y":"x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0",`+
+			`"d":"jpsQnnGQmL-YBIffH1136cspYG6-0iY7X1fCE9-E9LI"`+
+			`}`,
+	)
 
-// 	f.Add(
-// 		`{`+
-// 			`"payload":`+
-// 			`"eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGF`+
-// 			`tcGxlLmNvbS9pc19yb290Ijp0cnVlfQ",`+
-// 			`"protected":"eyJhbGciOiJFUzI1NiJ9",`+
-// 			`"header":`+
-// 			`{"kid":"e9bc097a-ce51-4036-9562-d2ade882db0d"},`+
-// 			`"signature":`+
-// 			`"DtEhU3ljbEg8L38VWAfUAqOyKAM6-Xx-F4GawxaepmXFCgfTjDxw5djxLa8IS`+
-// 			`lSApmWQxfKTUJqPP3-Kg6NU1Q"`+
-// 			`}`,
-// 		`{"kty":"EC",`+
-// 			`"crv":"P-256",`+
-// 			`"x":"f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvRVEU",`+
-// 			`"y":"x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0",`+
-// 			`"d":"jpsQnnGQmL-YBIffH1136cspYG6-0iY7X1fCE9-E9LI"`+
-// 			`}`,
-// 	)
+	f.Add(
+		`{`+
+			`"payload":`+
+			`"eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGF`+
+			`tcGxlLmNvbS9pc19yb290Ijp0cnVlfQ",`+
+			`"protected":"eyJhbGciOiJFUzI1NiJ9",`+
+			`"header":`+
+			`{"kid":"e9bc097a-ce51-4036-9562-d2ade882db0d"},`+
+			`"signature":`+
+			`"DtEhU3ljbEg8L38VWAfUAqOyKAM6-Xx-F4GawxaepmXFCgfTjDxw5djxLa8IS`+
+			`lSApmWQxfKTUJqPP3-Kg6NU1Q"`+
+			`}`,
+		`{"kty":"EC",`+
+			`"crv":"P-256",`+
+			`"x":"f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvRVEU",`+
+			`"y":"x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0",`+
+			`"d":"jpsQnnGQmL-YBIffH1136cspYG6-0iY7X1fCE9-E9LI"`+
+			`}`,
+	)
 
-// 	f.Add(
-// 		`{`+
-// 			`"protected":`+
-// 			`"eyJhbGciOiJIUzI1NiIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19",`+
-// 			`"payload":`+
-// 			`"$.02",`+
-// 			`"signature":`+
-// 			`"A5dxf2s96_n5FLueVuW1Z_vh161FwXZC4YLPff6dmDY"`+
-// 			`}`,
-// 		`{`+
-// 			`"kty":"oct",`+
-// 			`"k":"AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75`+
-// 			`aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow"`+
-// 			`}`,
-// 	)
+	// TODO: support b64 option
+	// f.Add(
+	// 	`{`+
+	// 		`"protected":`+
+	// 		`"eyJhbGciOiJIUzI1NiIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19",`+
+	// 		`"payload":`+
+	// 		`"$.02",`+
+	// 		`"signature":`+
+	// 		`"A5dxf2s96_n5FLueVuW1Z_vh161FwXZC4YLPff6dmDY"`+
+	// 		`}`,
+	// 	`{`+
+	// 		`"kty":"oct",`+
+	// 		`"k":"AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75`+
+	// 		`aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow"`+
+	// 		`}`,
+	// )
 
-// 	f.Fuzz(func(t *testing.T, raw, rawKey string) {
-// 		var msg1 Message
-// 		if err := msg1.UnmarshalJSON([]byte(raw)); err != nil {
-// 			return
-// 		}
+	f.Fuzz(func(t *testing.T, raw, rawKey string) {
+		var msg1 Message
+		if err := msg1.UnmarshalJSON([]byte(raw)); err != nil {
+			return
+		}
 
-// 		key, err := jwk.ParseKey([]byte(rawKey))
-// 		if err != nil {
-// 			return
-// 		}
+		key, err := jwk.ParseKey([]byte(rawKey))
+		if err != nil {
+			return
+		}
+		var header1 *Header
+		v := &Verifier{
+			AlgorithmVerfier: UnsecureAnyAlgorithm,
+			KeyFinder: FindKeyFunc(func(_ context.Context, protected, unprotected *Header) (sig.SigningKey, error) {
+				alg := protected.Algorithm()
+				if !alg.Available() {
+					return nil, errors.New("unknown algorithm")
+				}
+				header1 = unprotected
+				sigKey := alg.New().NewSigningKey(key)
+				return sigKey, nil
+			}),
+		}
 
-// 		var header1 *Header
-// 		protected1, payload1, err := msg1.Verify(FindKeyFunc(func(protected, header *Header) (sig.SigningKey, error) {
-// 			if !protected.Algorithm().Available() {
-// 				return nil, errors.New("algorithm not available")
-// 			}
-// 			header1 = header
-// 			return protected.Algorithm().New().NewSigningKey(key), nil
-// 		}))
-// 		if err != nil {
-// 			return
-// 		}
+		protected1, payload1, err := v.Verify(context.Background(), &msg1)
+		if err != nil {
+			return
+		}
 
-// 		if key.PrivateKey() == nil {
-// 			return // the key doesn't support signing, we skip it.
-// 		}
+		if key.PrivateKey() == nil {
+			return // the key doesn't support signing, we skip it.
+		}
 
-// 		msg2 := NewMessage(payload1)
-// 		if err := msg2.Sign(protected1, header1, protected1.Algorithm().New().NewSigningKey(key)); err != nil {
-// 			t.Fatal(err)
-// 		}
+		msg2 := NewMessage(payload1)
+		if err := msg2.Sign(protected1, header1, protected1.Algorithm().New().NewSigningKey(key)); err != nil {
+			t.Fatal(err)
+		}
 
-// 		data, err := msg2.MarshalJSON()
-// 		if err != nil {
-// 			t.Fatal(err)
-// 		}
+		data, err := msg2.MarshalJSON()
+		if err != nil {
+			t.Fatal(err)
+		}
 
-// 		var msg3 Message
-// 		if err := msg3.UnmarshalJSON(data); err != nil {
-// 			t.Fatal(err)
-// 		}
-// 		_, payload3, err := msg1.Verify(FindKeyFunc(func(protected, header *Header) (sig.SigningKey, error) {
-// 			if !protected.Algorithm().Available() {
-// 				return nil, errors.New("algorithm not available")
-// 			}
-// 			return protected.Algorithm().New().NewSigningKey(key), nil
-// 		}))
-// 		if err != nil {
-// 			return
-// 		}
-// 		if string(payload1) != string(payload3) {
-// 			t.Errorf("want %s, got %s", string(payload1), string(payload3))
-// 		}
-// 	})
-// }
+		var msg3 Message
+		if err := msg3.UnmarshalJSON(data); err != nil {
+			t.Fatal(err)
+		}
+		_, payload3, err := v.Verify(context.Background(), &msg3)
+		if err != nil {
+			return
+		}
+		if string(payload1) != string(payload3) {
+			t.Errorf("want %s, got %s", string(payload1), string(payload3))
+		}
+	})
+}
 
-// func FuzzJWSCompact(f *testing.F) {
-// 	f.Add(
-// 		"eyJ0eXAiOiJKV1QiLA0KICJhbGciOiJIUzI1NiJ9"+
-// 			"."+
-// 			"eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFt"+
-// 			"cGxlLmNvbS9pc19yb290Ijp0cnVlfQ"+
-// 			"."+
-// 			"dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk",
-// 		`{"kty":"oct",`+
-// 			`"k":"AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75`+
-// 			`aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow"`+
-// 			`}`,
-// 	)
-// 	f.Add(
-// 		"eyJhbGciOiJSUzI1NiJ9"+
-// 			"."+
-// 			"eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFt"+
-// 			"cGxlLmNvbS9pc19yb290Ijp0cnVlfQ"+
-// 			"."+
-// 			"cC4hiUPoj9Eetdgtv3hF80EGrhuB__dzERat0XF9g2VtQgr9PJbu3XOiZj5RZmh7"+
-// 			"AAuHIm4Bh-0Qc_lF5YKt_O8W2Fp5jujGbds9uJdbF9CUAr7t1dnZcAcQjbKBYNX4"+
-// 			"BAynRFdiuB--f_nZLgrnbyTyWzO75vRK5h6xBArLIARNPvkSjtQBMHlb1L07Qe7K"+
-// 			"0GarZRmB_eSN9383LcOLn6_dO--xi12jzDwusC-eOkHWEsqtFZESc6BfI7noOPqv"+
-// 			"hJ1phCnvWh6IeYI2w9QOYEUipUTI8np6LbgGY9Fs98rqVt5AXLIhWkWywlVmtVrB"+
-// 			"p0igcN_IoypGlUPQGe77Rw",
-// 		`{"kty":"RSA",`+
-// 			`"n":"ofgWCuLjybRlzo0tZWJjNiuSfb4p4fAkd_wWJcyQoTbji9k0l8W26mPddx`+
-// 			`HmfHQp-Vaw-4qPCJrcS2mJPMEzP1Pt0Bm4d4QlL-yRT-SFd2lZS-pCgNMs`+
-// 			`D1W_YpRPEwOWvG6b32690r2jZ47soMZo9wGzjb_7OMg0LOL-bSf63kpaSH`+
-// 			`SXndS5z5rexMdbBYUsLA9e-KXBdQOS-UTo7WTBEMa2R2CapHg665xsmtdV`+
-// 			`MTBQY4uDZlxvb3qCo5ZwKh9kG4LT6_I5IhlJH7aGhyxXFvUK-DWNmoudF8`+
-// 			`NAco9_h9iaGNj8q2ethFkMLs91kzk2PAcDTW9gb54h4FRWyuXpoQ",`+
-// 			`"e":"AQAB",`+
-// 			`"d":"Eq5xpGnNCivDflJsRQBXHx1hdR1k6Ulwe2JZD50LpXyWPEAeP88vLNO97I`+
-// 			`jlA7_GQ5sLKMgvfTeXZx9SE-7YwVol2NXOoAJe46sui395IW_GO-pWJ1O0`+
-// 			`BkTGoVEn2bKVRUCgu-GjBVaYLU6f3l9kJfFNS3E0QbVdxzubSu3Mkqzjkn`+
-// 			`439X0M_V51gfpRLI9JYanrC4D4qAdGcopV_0ZHHzQlBjudU2QvXt4ehNYT`+
-// 			`CBr6XCLQUShb1juUO1ZdiYoFaFQT5Tw8bGUl_x_jTj3ccPDVZFD9pIuhLh`+
-// 			`BOneufuBiB4cS98l2SR_RQyGWSeWjnczT0QU91p1DhOVRuOopznQ",`+
-// 			`"p":"4BzEEOtIpmVdVEZNCqS7baC4crd0pqnRH_5IB3jw3bcxGn6QLvnEtfdUdi`+
-// 			`YrqBdss1l58BQ3KhooKeQTa9AB0Hw_Py5PJdTJNPY8cQn7ouZ2KKDcmnPG`+
-// 			`BY5t7yLc1QlQ5xHdwW1VhvKn-nXqhJTBgIPgtldC-KDV5z-y2XDwGUc",`+
-// 			`"q":"uQPEfgmVtjL0Uyyx88GZFF1fOunH3-7cepKmtH4pxhtCoHqpWmT8YAmZxa`+
-// 			`ewHgHAjLYsp1ZSe7zFYHj7C6ul7TjeLQeZD_YwD66t62wDmpe_HlB-TnBA`+
-// 			`-njbglfIsRLtXlnDzQkv5dTltRJ11BKBBypeeF6689rjcJIDEz9RWdc",`+
-// 			`"dp":"BwKfV3Akq5_MFZDFZCnW-wzl-CCo83WoZvnLQwCTeDv8uzluRSnm71I3Q`+
-// 			`CLdhrqE2e9YkxvuxdBfpT_PI7Yz-FOKnu1R6HsJeDCjn12Sk3vmAktV2zb`+
-// 			`34MCdy7cpdTh_YVr7tss2u6vneTwrA86rZtu5Mbr1C1XsmvkxHQAdYo0",`+
-// 			`"dq":"h_96-mK1R_7glhsum81dZxjTnYynPbZpHziZjeeHcXYsXaaMwkOlODsWa`+
-// 			`7I9xXDoRwbKgB719rrmI2oKr6N3Do9U0ajaHF-NKJnwgjMd2w9cjz3_-ky`+
-// 			`NlxAr2v4IKhGNpmM5iIgOS1VZnOZ68m6_pbLBSp3nssTdlqvd0tIiTHU",`+
-// 			`"qi":"IYd7DHOhrWvxkwPQsRM2tOgrjbcrfvtQJipd-DlcxyVuuM9sQLdgjVk2o`+
-// 			`y26F0EmpScGLq2MowX7fhd_QJQ3ydy5cY7YIBi87w93IKLEdfnbJtoOPLU`+
-// 			`W0ITrJReOgo1cq9SbsxYawBgfp_gh6A5603k2-ZQwVK0JKSHuLFkuQ3U"`+
-// 			`}`,
-// 	)
-// 	f.Add(
-// 		"eyJhbGciOiJFUzI1NiJ9"+
-// 			"."+
-// 			"eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFt"+
-// 			"cGxlLmNvbS9pc19yb290Ijp0cnVlfQ"+
-// 			"."+
-// 			"DtEhU3ljbEg8L38VWAfUAqOyKAM6-Xx-F4GawxaepmXFCgfTjDxw5djxLa8ISlSA"+
-// 			"pmWQxfKTUJqPP3-Kg6NU1Q",
-// 		`{"kty":"EC",`+
-// 			`"crv":"P-256",`+
-// 			`"x":"f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvRVEU",`+
-// 			`"y":"x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0",`+
-// 			`"d":"jpsQnnGQmL-YBIffH1136cspYG6-0iY7X1fCE9-E9LI"`+
-// 			`}`,
-// 	)
-// 	f.Add(
-// 		"eyJhbGciOiJFUzUxMiJ9"+
-// 			"."+
-// 			"UGF5bG9hZA"+
-// 			"."+
-// 			"AdwMgeerwtHoh-l192l60hp9wAHZFVJbLfD_UxMi70cwnZOYaRI1bKPWROc-mZZq"+
-// 			"wqT2SI-KGDKB34XO0aw_7XdtAG8GaSwFKdCAPZgoXD2YBJZCPEX3xKpRwcdOO8Kp"+
-// 			"EHwJjyqOgzDO7iKvU8vcnwNrmxYbSW9ERBXukOXolLzeO_Jn",
-// 		`{"kty":"EC",`+
-// 			`"crv":"P-521",`+
-// 			`"x":"AekpBQ8ST8a8VcfVOTNl353vSrDCLLJXmPk06wTjxrrjcBpXp5EOnYG_`+
-// 			`NjFZ6OvLFV1jSfS9tsz4qUxcWceqwQGk",`+
-// 			`"y":"ADSmRA43Z1DSNx_RvcLI87cdL07l6jQyyBXMoxVg_l2Th-x3S1WDhjDl`+
-// 			`y79ajL4Kkd0AZMaZmh9ubmf63e3kyMj2",`+
-// 			`"d":"AY5pb7A0UFiB3RELSD64fTLOSV_jazdF7fLYyuTw8lOfRhWg6Y6rUrPA`+
-// 			`xerEzgdRhajnu0ferB0d53vM9mE15j2C"`+
-// 			`}`,
-// 	)
-// 	f.Add(
-// 		"eyJhbGciOiJFZERTQSJ9"+
-// 			"."+
-// 			"RXhhbXBsZSBvZiBFZDI1NTE5IHNpZ25pbmc"+
-// 			"."+
-// 			"hgyY0il_MGCjP0JzlnLWG1PPOt7-09PGcvMg3AIbQR6dWbhijcNR4ki4iylGjg5BhVsPt"+
-// 			"9g7sVvpAr_MuM0KAg",
-// 		`{"kty":"OKP","crv":"Ed25519",`+
-// 			`"d":"nWGxne_9WmC6hEr0kuwsxERJxWl7MmkZcDusAxyuf2A",`+
-// 			`"x":"11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo"}`,
-// 	)
-// 	f.Fuzz(func(t *testing.T, data, key string) {
-// 		k, err := jwk.ParseKey([]byte(key))
-// 		if err != nil {
-// 			return
-// 		}
-// 		var sigKey sig.SigningKey
-// 		msg1, err := Parse([]byte(data))
-// 		if err != nil {
-// 			return
-// 		}
-// 		header1, payload1, err := msg1.Verify(FindKeyFunc(func(header, _ *Header) (sig.SigningKey, error) {
-// 			alg := header.Algorithm()
-// 			if !alg.Available() {
-// 				return nil, errors.New("unknown algorithm")
-// 			}
-// 			sigKey = alg.New().NewSigningKey(k)
-// 			return sigKey, nil
-// 		}))
-// 		if err != nil {
-// 			return
-// 		}
-// 		if k.PrivateKey() == nil {
-// 			return // the key doesn't support signing, we skip it.
-// 		}
+func FuzzJWSCompact(f *testing.F) {
+	f.Add(
+		"eyJ0eXAiOiJKV1QiLA0KICJhbGciOiJIUzI1NiJ9"+
+			"."+
+			"eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFt"+
+			"cGxlLmNvbS9pc19yb290Ijp0cnVlfQ"+
+			"."+
+			"dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk",
+		`{"kty":"oct",`+
+			`"k":"AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75`+
+			`aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow"`+
+			`}`,
+	)
+	f.Add(
+		"eyJhbGciOiJSUzI1NiJ9"+
+			"."+
+			"eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFt"+
+			"cGxlLmNvbS9pc19yb290Ijp0cnVlfQ"+
+			"."+
+			"cC4hiUPoj9Eetdgtv3hF80EGrhuB__dzERat0XF9g2VtQgr9PJbu3XOiZj5RZmh7"+
+			"AAuHIm4Bh-0Qc_lF5YKt_O8W2Fp5jujGbds9uJdbF9CUAr7t1dnZcAcQjbKBYNX4"+
+			"BAynRFdiuB--f_nZLgrnbyTyWzO75vRK5h6xBArLIARNPvkSjtQBMHlb1L07Qe7K"+
+			"0GarZRmB_eSN9383LcOLn6_dO--xi12jzDwusC-eOkHWEsqtFZESc6BfI7noOPqv"+
+			"hJ1phCnvWh6IeYI2w9QOYEUipUTI8np6LbgGY9Fs98rqVt5AXLIhWkWywlVmtVrB"+
+			"p0igcN_IoypGlUPQGe77Rw",
+		`{"kty":"RSA",`+
+			`"n":"ofgWCuLjybRlzo0tZWJjNiuSfb4p4fAkd_wWJcyQoTbji9k0l8W26mPddx`+
+			`HmfHQp-Vaw-4qPCJrcS2mJPMEzP1Pt0Bm4d4QlL-yRT-SFd2lZS-pCgNMs`+
+			`D1W_YpRPEwOWvG6b32690r2jZ47soMZo9wGzjb_7OMg0LOL-bSf63kpaSH`+
+			`SXndS5z5rexMdbBYUsLA9e-KXBdQOS-UTo7WTBEMa2R2CapHg665xsmtdV`+
+			`MTBQY4uDZlxvb3qCo5ZwKh9kG4LT6_I5IhlJH7aGhyxXFvUK-DWNmoudF8`+
+			`NAco9_h9iaGNj8q2ethFkMLs91kzk2PAcDTW9gb54h4FRWyuXpoQ",`+
+			`"e":"AQAB",`+
+			`"d":"Eq5xpGnNCivDflJsRQBXHx1hdR1k6Ulwe2JZD50LpXyWPEAeP88vLNO97I`+
+			`jlA7_GQ5sLKMgvfTeXZx9SE-7YwVol2NXOoAJe46sui395IW_GO-pWJ1O0`+
+			`BkTGoVEn2bKVRUCgu-GjBVaYLU6f3l9kJfFNS3E0QbVdxzubSu3Mkqzjkn`+
+			`439X0M_V51gfpRLI9JYanrC4D4qAdGcopV_0ZHHzQlBjudU2QvXt4ehNYT`+
+			`CBr6XCLQUShb1juUO1ZdiYoFaFQT5Tw8bGUl_x_jTj3ccPDVZFD9pIuhLh`+
+			`BOneufuBiB4cS98l2SR_RQyGWSeWjnczT0QU91p1DhOVRuOopznQ",`+
+			`"p":"4BzEEOtIpmVdVEZNCqS7baC4crd0pqnRH_5IB3jw3bcxGn6QLvnEtfdUdi`+
+			`YrqBdss1l58BQ3KhooKeQTa9AB0Hw_Py5PJdTJNPY8cQn7ouZ2KKDcmnPG`+
+			`BY5t7yLc1QlQ5xHdwW1VhvKn-nXqhJTBgIPgtldC-KDV5z-y2XDwGUc",`+
+			`"q":"uQPEfgmVtjL0Uyyx88GZFF1fOunH3-7cepKmtH4pxhtCoHqpWmT8YAmZxa`+
+			`ewHgHAjLYsp1ZSe7zFYHj7C6ul7TjeLQeZD_YwD66t62wDmpe_HlB-TnBA`+
+			`-njbglfIsRLtXlnDzQkv5dTltRJ11BKBBypeeF6689rjcJIDEz9RWdc",`+
+			`"dp":"BwKfV3Akq5_MFZDFZCnW-wzl-CCo83WoZvnLQwCTeDv8uzluRSnm71I3Q`+
+			`CLdhrqE2e9YkxvuxdBfpT_PI7Yz-FOKnu1R6HsJeDCjn12Sk3vmAktV2zb`+
+			`34MCdy7cpdTh_YVr7tss2u6vneTwrA86rZtu5Mbr1C1XsmvkxHQAdYo0",`+
+			`"dq":"h_96-mK1R_7glhsum81dZxjTnYynPbZpHziZjeeHcXYsXaaMwkOlODsWa`+
+			`7I9xXDoRwbKgB719rrmI2oKr6N3Do9U0ajaHF-NKJnwgjMd2w9cjz3_-ky`+
+			`NlxAr2v4IKhGNpmM5iIgOS1VZnOZ68m6_pbLBSp3nssTdlqvd0tIiTHU",`+
+			`"qi":"IYd7DHOhrWvxkwPQsRM2tOgrjbcrfvtQJipd-DlcxyVuuM9sQLdgjVk2o`+
+			`y26F0EmpScGLq2MowX7fhd_QJQ3ydy5cY7YIBi87w93IKLEdfnbJtoOPLU`+
+			`W0ITrJReOgo1cq9SbsxYawBgfp_gh6A5603k2-ZQwVK0JKSHuLFkuQ3U"`+
+			`}`,
+	)
+	f.Add(
+		"eyJhbGciOiJFUzI1NiJ9"+
+			"."+
+			"eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFt"+
+			"cGxlLmNvbS9pc19yb290Ijp0cnVlfQ"+
+			"."+
+			"DtEhU3ljbEg8L38VWAfUAqOyKAM6-Xx-F4GawxaepmXFCgfTjDxw5djxLa8ISlSA"+
+			"pmWQxfKTUJqPP3-Kg6NU1Q",
+		`{"kty":"EC",`+
+			`"crv":"P-256",`+
+			`"x":"f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvRVEU",`+
+			`"y":"x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0",`+
+			`"d":"jpsQnnGQmL-YBIffH1136cspYG6-0iY7X1fCE9-E9LI"`+
+			`}`,
+	)
+	f.Add(
+		"eyJhbGciOiJFUzUxMiJ9"+
+			"."+
+			"UGF5bG9hZA"+
+			"."+
+			"AdwMgeerwtHoh-l192l60hp9wAHZFVJbLfD_UxMi70cwnZOYaRI1bKPWROc-mZZq"+
+			"wqT2SI-KGDKB34XO0aw_7XdtAG8GaSwFKdCAPZgoXD2YBJZCPEX3xKpRwcdOO8Kp"+
+			"EHwJjyqOgzDO7iKvU8vcnwNrmxYbSW9ERBXukOXolLzeO_Jn",
+		`{"kty":"EC",`+
+			`"crv":"P-521",`+
+			`"x":"AekpBQ8ST8a8VcfVOTNl353vSrDCLLJXmPk06wTjxrrjcBpXp5EOnYG_`+
+			`NjFZ6OvLFV1jSfS9tsz4qUxcWceqwQGk",`+
+			`"y":"ADSmRA43Z1DSNx_RvcLI87cdL07l6jQyyBXMoxVg_l2Th-x3S1WDhjDl`+
+			`y79ajL4Kkd0AZMaZmh9ubmf63e3kyMj2",`+
+			`"d":"AY5pb7A0UFiB3RELSD64fTLOSV_jazdF7fLYyuTw8lOfRhWg6Y6rUrPA`+
+			`xerEzgdRhajnu0ferB0d53vM9mE15j2C"`+
+			`}`,
+	)
+	f.Add(
+		"eyJhbGciOiJFZERTQSJ9"+
+			"."+
+			"RXhhbXBsZSBvZiBFZDI1NTE5IHNpZ25pbmc"+
+			"."+
+			"hgyY0il_MGCjP0JzlnLWG1PPOt7-09PGcvMg3AIbQR6dWbhijcNR4ki4iylGjg5BhVsPt"+
+			"9g7sVvpAr_MuM0KAg",
+		`{"kty":"OKP","crv":"Ed25519",`+
+			`"d":"nWGxne_9WmC6hEr0kuwsxERJxWl7MmkZcDusAxyuf2A",`+
+			`"x":"11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo"}`,
+	)
+	f.Fuzz(func(t *testing.T, data, key string) {
+		k, err := jwk.ParseKey([]byte(key))
+		if err != nil {
+			return
+		}
+		var sigKey sig.SigningKey
+		v1 := &Verifier{
+			AlgorithmVerfier: UnsecureAnyAlgorithm,
+			KeyFinder: FindKeyFunc(func(_ context.Context, header, _ *Header) (sig.SigningKey, error) {
+				alg := header.Algorithm()
+				if !alg.Available() {
+					return nil, errors.New("unknown algorithm")
+				}
+				sigKey = alg.New().NewSigningKey(k)
+				return sigKey, nil
+			}),
+		}
 
-// 		msg2 := NewMessage(payload1)
-// 		if err := msg2.Sign(header1, nil, sigKey); err != nil {
-// 			t.Error(err)
-// 		}
-// 		resigned, err := msg2.Compact()
-// 		if err != nil {
-// 			t.Error(err)
-// 		}
+		msg1, err := Parse([]byte(data))
+		if err != nil {
+			return
+		}
+		header1, payload1, err := v1.Verify(context.Background(), msg1)
+		if err != nil {
+			return
+		}
+		if k.PrivateKey() == nil {
+			return // the key doesn't support signing, we skip it.
+		}
 
-// 		msg3, err := Parse(resigned)
-// 		if err != nil {
-// 			t.Fatal(err)
-// 		}
-// 		_, payload3, err := msg3.Verify(FindKeyFunc(func(header, _ *Header) (sig.SigningKey, error) {
-// 			return sigKey, nil
-// 		}))
-// 		if err != nil {
-// 			t.Error(err)
-// 		}
-// 		if !bytes.Equal(payload1, payload3) {
-// 			t.Error("payload mismatch")
-// 		}
-// 	})
-// }
+		msg2 := NewMessage(payload1)
+		if err := msg2.Sign(header1, nil, sigKey); err != nil {
+			t.Error(err)
+		}
+		resigned, err := msg2.Compact()
+		if err != nil {
+			t.Error(err)
+		}
+
+		v2 := &Verifier{
+			AlgorithmVerfier: UnsecureAnyAlgorithm,
+			KeyFinder: FindKeyFunc(func(_ context.Context, header, _ *Header) (sig.SigningKey, error) {
+				return sigKey, nil
+			}),
+		}
+		msg3, err := Parse(resigned)
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, payload3, err := v2.Verify(context.Background(), msg3)
+		if err != nil {
+			t.Error(err)
+		}
+		if !bytes.Equal(payload1, payload3) {
+			t.Error("payload mismatch")
+		}
+	})
+}

--- a/jws/fuzz_test.go
+++ b/jws/fuzz_test.go
@@ -1,363 +1,363 @@
 package jws
 
-import (
-	"bytes"
-	"errors"
-	"testing"
+// import (
+// 	"bytes"
+// 	"errors"
+// 	"testing"
 
-	_ "github.com/shogo82148/goat/jwa/eddsa" // for Ed25519
-	_ "github.com/shogo82148/goat/jwa/es"    // for ECDSA
-	_ "github.com/shogo82148/goat/jwa/hs"    // for HMAC SHA-256
-	_ "github.com/shogo82148/goat/jwa/rs"    // for RSASSA-PKCS1-v1_5 SHA-256
-	"github.com/shogo82148/goat/jwk"
-	"github.com/shogo82148/goat/sig"
-)
+// 	_ "github.com/shogo82148/goat/jwa/eddsa" // for Ed25519
+// 	_ "github.com/shogo82148/goat/jwa/es"    // for ECDSA
+// 	_ "github.com/shogo82148/goat/jwa/hs"    // for HMAC SHA-256
+// 	_ "github.com/shogo82148/goat/jwa/rs"    // for RSASSA-PKCS1-v1_5 SHA-256
+// 	"github.com/shogo82148/goat/jwk"
+// 	"github.com/shogo82148/goat/sig"
+// )
 
-func FuzzJWS(f *testing.F) {
-	f.Add(
-		`{`+
-			`"payload":`+
-			`"eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGF`+
-			`tcGxlLmNvbS9pc19yb290Ijp0cnVlfQ",`+
-			`"signatures":[`+
-			`{"protected":"eyJhbGciOiJSUzI1NiJ9",`+
-			`"header":`+
-			`{"kid":"2010-12-29"},`+
-			`"signature":`+
-			`"cC4hiUPoj9Eetdgtv3hF80EGrhuB__dzERat0XF9g2VtQgr9PJbu3XOiZj5RZ`+
-			`mh7AAuHIm4Bh-0Qc_lF5YKt_O8W2Fp5jujGbds9uJdbF9CUAr7t1dnZcAcQjb`+
-			`KBYNX4BAynRFdiuB--f_nZLgrnbyTyWzO75vRK5h6xBArLIARNPvkSjtQBMHl`+
-			`b1L07Qe7K0GarZRmB_eSN9383LcOLn6_dO--xi12jzDwusC-eOkHWEsqtFZES`+
-			`c6BfI7noOPqvhJ1phCnvWh6IeYI2w9QOYEUipUTI8np6LbgGY9Fs98rqVt5AX`+
-			`LIhWkWywlVmtVrBp0igcN_IoypGlUPQGe77Rw"},`+
-			`{"protected":"eyJhbGciOiJFUzI1NiJ9",`+
-			`"header":`+
-			`{"kid":"e9bc097a-ce51-4036-9562-d2ade882db0d"},`+
-			`"signature":`+
-			`"DtEhU3ljbEg8L38VWAfUAqOyKAM6-Xx-F4GawxaepmXFCgfTjDxw5djxLa8IS`+
-			`lSApmWQxfKTUJqPP3-Kg6NU1Q"}]`+
-			`}`,
-		`{"kty":"RSA",`+
-			`"n":"ofgWCuLjybRlzo0tZWJjNiuSfb4p4fAkd_wWJcyQoTbji9k0l8W26mPddx`+
-			`HmfHQp-Vaw-4qPCJrcS2mJPMEzP1Pt0Bm4d4QlL-yRT-SFd2lZS-pCgNMs`+
-			`D1W_YpRPEwOWvG6b32690r2jZ47soMZo9wGzjb_7OMg0LOL-bSf63kpaSH`+
-			`SXndS5z5rexMdbBYUsLA9e-KXBdQOS-UTo7WTBEMa2R2CapHg665xsmtdV`+
-			`MTBQY4uDZlxvb3qCo5ZwKh9kG4LT6_I5IhlJH7aGhyxXFvUK-DWNmoudF8`+
-			`NAco9_h9iaGNj8q2ethFkMLs91kzk2PAcDTW9gb54h4FRWyuXpoQ",`+
-			`"e":"AQAB",`+
-			`"d":"Eq5xpGnNCivDflJsRQBXHx1hdR1k6Ulwe2JZD50LpXyWPEAeP88vLNO97I`+
-			`jlA7_GQ5sLKMgvfTeXZx9SE-7YwVol2NXOoAJe46sui395IW_GO-pWJ1O0`+
-			`BkTGoVEn2bKVRUCgu-GjBVaYLU6f3l9kJfFNS3E0QbVdxzubSu3Mkqzjkn`+
-			`439X0M_V51gfpRLI9JYanrC4D4qAdGcopV_0ZHHzQlBjudU2QvXt4ehNYT`+
-			`CBr6XCLQUShb1juUO1ZdiYoFaFQT5Tw8bGUl_x_jTj3ccPDVZFD9pIuhLh`+
-			`BOneufuBiB4cS98l2SR_RQyGWSeWjnczT0QU91p1DhOVRuOopznQ",`+
-			`"p":"4BzEEOtIpmVdVEZNCqS7baC4crd0pqnRH_5IB3jw3bcxGn6QLvnEtfdUdi`+
-			`YrqBdss1l58BQ3KhooKeQTa9AB0Hw_Py5PJdTJNPY8cQn7ouZ2KKDcmnPG`+
-			`BY5t7yLc1QlQ5xHdwW1VhvKn-nXqhJTBgIPgtldC-KDV5z-y2XDwGUc",`+
-			`"q":"uQPEfgmVtjL0Uyyx88GZFF1fOunH3-7cepKmtH4pxhtCoHqpWmT8YAmZxa`+
-			`ewHgHAjLYsp1ZSe7zFYHj7C6ul7TjeLQeZD_YwD66t62wDmpe_HlB-TnBA`+
-			`-njbglfIsRLtXlnDzQkv5dTltRJ11BKBBypeeF6689rjcJIDEz9RWdc",`+
-			`"dp":"BwKfV3Akq5_MFZDFZCnW-wzl-CCo83WoZvnLQwCTeDv8uzluRSnm71I3Q`+
-			`CLdhrqE2e9YkxvuxdBfpT_PI7Yz-FOKnu1R6HsJeDCjn12Sk3vmAktV2zb`+
-			`34MCdy7cpdTh_YVr7tss2u6vneTwrA86rZtu5Mbr1C1XsmvkxHQAdYo0",`+
-			`"dq":"h_96-mK1R_7glhsum81dZxjTnYynPbZpHziZjeeHcXYsXaaMwkOlODsWa`+
-			`7I9xXDoRwbKgB719rrmI2oKr6N3Do9U0ajaHF-NKJnwgjMd2w9cjz3_-ky`+
-			`NlxAr2v4IKhGNpmM5iIgOS1VZnOZ68m6_pbLBSp3nssTdlqvd0tIiTHU",`+
-			`"qi":"IYd7DHOhrWvxkwPQsRM2tOgrjbcrfvtQJipd-DlcxyVuuM9sQLdgjVk2o`+
-			`y26F0EmpScGLq2MowX7fhd_QJQ3ydy5cY7YIBi87w93IKLEdfnbJtoOPLU`+
-			`W0ITrJReOgo1cq9SbsxYawBgfp_gh6A5603k2-ZQwVK0JKSHuLFkuQ3U"`+
-			`}`,
-	)
+// func FuzzJWS(f *testing.F) {
+// 	f.Add(
+// 		`{`+
+// 			`"payload":`+
+// 			`"eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGF`+
+// 			`tcGxlLmNvbS9pc19yb290Ijp0cnVlfQ",`+
+// 			`"signatures":[`+
+// 			`{"protected":"eyJhbGciOiJSUzI1NiJ9",`+
+// 			`"header":`+
+// 			`{"kid":"2010-12-29"},`+
+// 			`"signature":`+
+// 			`"cC4hiUPoj9Eetdgtv3hF80EGrhuB__dzERat0XF9g2VtQgr9PJbu3XOiZj5RZ`+
+// 			`mh7AAuHIm4Bh-0Qc_lF5YKt_O8W2Fp5jujGbds9uJdbF9CUAr7t1dnZcAcQjb`+
+// 			`KBYNX4BAynRFdiuB--f_nZLgrnbyTyWzO75vRK5h6xBArLIARNPvkSjtQBMHl`+
+// 			`b1L07Qe7K0GarZRmB_eSN9383LcOLn6_dO--xi12jzDwusC-eOkHWEsqtFZES`+
+// 			`c6BfI7noOPqvhJ1phCnvWh6IeYI2w9QOYEUipUTI8np6LbgGY9Fs98rqVt5AX`+
+// 			`LIhWkWywlVmtVrBp0igcN_IoypGlUPQGe77Rw"},`+
+// 			`{"protected":"eyJhbGciOiJFUzI1NiJ9",`+
+// 			`"header":`+
+// 			`{"kid":"e9bc097a-ce51-4036-9562-d2ade882db0d"},`+
+// 			`"signature":`+
+// 			`"DtEhU3ljbEg8L38VWAfUAqOyKAM6-Xx-F4GawxaepmXFCgfTjDxw5djxLa8IS`+
+// 			`lSApmWQxfKTUJqPP3-Kg6NU1Q"}]`+
+// 			`}`,
+// 		`{"kty":"RSA",`+
+// 			`"n":"ofgWCuLjybRlzo0tZWJjNiuSfb4p4fAkd_wWJcyQoTbji9k0l8W26mPddx`+
+// 			`HmfHQp-Vaw-4qPCJrcS2mJPMEzP1Pt0Bm4d4QlL-yRT-SFd2lZS-pCgNMs`+
+// 			`D1W_YpRPEwOWvG6b32690r2jZ47soMZo9wGzjb_7OMg0LOL-bSf63kpaSH`+
+// 			`SXndS5z5rexMdbBYUsLA9e-KXBdQOS-UTo7WTBEMa2R2CapHg665xsmtdV`+
+// 			`MTBQY4uDZlxvb3qCo5ZwKh9kG4LT6_I5IhlJH7aGhyxXFvUK-DWNmoudF8`+
+// 			`NAco9_h9iaGNj8q2ethFkMLs91kzk2PAcDTW9gb54h4FRWyuXpoQ",`+
+// 			`"e":"AQAB",`+
+// 			`"d":"Eq5xpGnNCivDflJsRQBXHx1hdR1k6Ulwe2JZD50LpXyWPEAeP88vLNO97I`+
+// 			`jlA7_GQ5sLKMgvfTeXZx9SE-7YwVol2NXOoAJe46sui395IW_GO-pWJ1O0`+
+// 			`BkTGoVEn2bKVRUCgu-GjBVaYLU6f3l9kJfFNS3E0QbVdxzubSu3Mkqzjkn`+
+// 			`439X0M_V51gfpRLI9JYanrC4D4qAdGcopV_0ZHHzQlBjudU2QvXt4ehNYT`+
+// 			`CBr6XCLQUShb1juUO1ZdiYoFaFQT5Tw8bGUl_x_jTj3ccPDVZFD9pIuhLh`+
+// 			`BOneufuBiB4cS98l2SR_RQyGWSeWjnczT0QU91p1DhOVRuOopznQ",`+
+// 			`"p":"4BzEEOtIpmVdVEZNCqS7baC4crd0pqnRH_5IB3jw3bcxGn6QLvnEtfdUdi`+
+// 			`YrqBdss1l58BQ3KhooKeQTa9AB0Hw_Py5PJdTJNPY8cQn7ouZ2KKDcmnPG`+
+// 			`BY5t7yLc1QlQ5xHdwW1VhvKn-nXqhJTBgIPgtldC-KDV5z-y2XDwGUc",`+
+// 			`"q":"uQPEfgmVtjL0Uyyx88GZFF1fOunH3-7cepKmtH4pxhtCoHqpWmT8YAmZxa`+
+// 			`ewHgHAjLYsp1ZSe7zFYHj7C6ul7TjeLQeZD_YwD66t62wDmpe_HlB-TnBA`+
+// 			`-njbglfIsRLtXlnDzQkv5dTltRJ11BKBBypeeF6689rjcJIDEz9RWdc",`+
+// 			`"dp":"BwKfV3Akq5_MFZDFZCnW-wzl-CCo83WoZvnLQwCTeDv8uzluRSnm71I3Q`+
+// 			`CLdhrqE2e9YkxvuxdBfpT_PI7Yz-FOKnu1R6HsJeDCjn12Sk3vmAktV2zb`+
+// 			`34MCdy7cpdTh_YVr7tss2u6vneTwrA86rZtu5Mbr1C1XsmvkxHQAdYo0",`+
+// 			`"dq":"h_96-mK1R_7glhsum81dZxjTnYynPbZpHziZjeeHcXYsXaaMwkOlODsWa`+
+// 			`7I9xXDoRwbKgB719rrmI2oKr6N3Do9U0ajaHF-NKJnwgjMd2w9cjz3_-ky`+
+// 			`NlxAr2v4IKhGNpmM5iIgOS1VZnOZ68m6_pbLBSp3nssTdlqvd0tIiTHU",`+
+// 			`"qi":"IYd7DHOhrWvxkwPQsRM2tOgrjbcrfvtQJipd-DlcxyVuuM9sQLdgjVk2o`+
+// 			`y26F0EmpScGLq2MowX7fhd_QJQ3ydy5cY7YIBi87w93IKLEdfnbJtoOPLU`+
+// 			`W0ITrJReOgo1cq9SbsxYawBgfp_gh6A5603k2-ZQwVK0JKSHuLFkuQ3U"`+
+// 			`}`,
+// 	)
 
-	f.Add(
-		`{`+
-			`"payload":`+
-			`"eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGF`+
-			`tcGxlLmNvbS9pc19yb290Ijp0cnVlfQ",`+
-			`"signatures":[`+
-			`{"protected":"eyJhbGciOiJSUzI1NiJ9",`+
-			`"header":`+
-			`{"kid":"2010-12-29"},`+
-			`"signature":`+
-			`"cC4hiUPoj9Eetdgtv3hF80EGrhuB__dzERat0XF9g2VtQgr9PJbu3XOiZj5RZ`+
-			`mh7AAuHIm4Bh-0Qc_lF5YKt_O8W2Fp5jujGbds9uJdbF9CUAr7t1dnZcAcQjb`+
-			`KBYNX4BAynRFdiuB--f_nZLgrnbyTyWzO75vRK5h6xBArLIARNPvkSjtQBMHl`+
-			`b1L07Qe7K0GarZRmB_eSN9383LcOLn6_dO--xi12jzDwusC-eOkHWEsqtFZES`+
-			`c6BfI7noOPqvhJ1phCnvWh6IeYI2w9QOYEUipUTI8np6LbgGY9Fs98rqVt5AX`+
-			`LIhWkWywlVmtVrBp0igcN_IoypGlUPQGe77Rw"},`+
-			`{"protected":"eyJhbGciOiJFUzI1NiJ9",`+
-			`"header":`+
-			`{"kid":"e9bc097a-ce51-4036-9562-d2ade882db0d"},`+
-			`"signature":`+
-			`"DtEhU3ljbEg8L38VWAfUAqOyKAM6-Xx-F4GawxaepmXFCgfTjDxw5djxLa8IS`+
-			`lSApmWQxfKTUJqPP3-Kg6NU1Q"}]`+
-			`}`,
-		`{"kty":"EC",`+
-			`"crv":"P-256",`+
-			`"x":"f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvRVEU",`+
-			`"y":"x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0",`+
-			`"d":"jpsQnnGQmL-YBIffH1136cspYG6-0iY7X1fCE9-E9LI"`+
-			`}`,
-	)
+// 	f.Add(
+// 		`{`+
+// 			`"payload":`+
+// 			`"eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGF`+
+// 			`tcGxlLmNvbS9pc19yb290Ijp0cnVlfQ",`+
+// 			`"signatures":[`+
+// 			`{"protected":"eyJhbGciOiJSUzI1NiJ9",`+
+// 			`"header":`+
+// 			`{"kid":"2010-12-29"},`+
+// 			`"signature":`+
+// 			`"cC4hiUPoj9Eetdgtv3hF80EGrhuB__dzERat0XF9g2VtQgr9PJbu3XOiZj5RZ`+
+// 			`mh7AAuHIm4Bh-0Qc_lF5YKt_O8W2Fp5jujGbds9uJdbF9CUAr7t1dnZcAcQjb`+
+// 			`KBYNX4BAynRFdiuB--f_nZLgrnbyTyWzO75vRK5h6xBArLIARNPvkSjtQBMHl`+
+// 			`b1L07Qe7K0GarZRmB_eSN9383LcOLn6_dO--xi12jzDwusC-eOkHWEsqtFZES`+
+// 			`c6BfI7noOPqvhJ1phCnvWh6IeYI2w9QOYEUipUTI8np6LbgGY9Fs98rqVt5AX`+
+// 			`LIhWkWywlVmtVrBp0igcN_IoypGlUPQGe77Rw"},`+
+// 			`{"protected":"eyJhbGciOiJFUzI1NiJ9",`+
+// 			`"header":`+
+// 			`{"kid":"e9bc097a-ce51-4036-9562-d2ade882db0d"},`+
+// 			`"signature":`+
+// 			`"DtEhU3ljbEg8L38VWAfUAqOyKAM6-Xx-F4GawxaepmXFCgfTjDxw5djxLa8IS`+
+// 			`lSApmWQxfKTUJqPP3-Kg6NU1Q"}]`+
+// 			`}`,
+// 		`{"kty":"EC",`+
+// 			`"crv":"P-256",`+
+// 			`"x":"f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvRVEU",`+
+// 			`"y":"x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0",`+
+// 			`"d":"jpsQnnGQmL-YBIffH1136cspYG6-0iY7X1fCE9-E9LI"`+
+// 			`}`,
+// 	)
 
-	f.Add(
-		`{`+
-			`"payload":`+
-			`"eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGF`+
-			`tcGxlLmNvbS9pc19yb290Ijp0cnVlfQ",`+
-			`"protected":"eyJhbGciOiJFUzI1NiJ9",`+
-			`"header":`+
-			`{"kid":"e9bc097a-ce51-4036-9562-d2ade882db0d"},`+
-			`"signature":`+
-			`"DtEhU3ljbEg8L38VWAfUAqOyKAM6-Xx-F4GawxaepmXFCgfTjDxw5djxLa8IS`+
-			`lSApmWQxfKTUJqPP3-Kg6NU1Q"`+
-			`}`,
-		`{"kty":"EC",`+
-			`"crv":"P-256",`+
-			`"x":"f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvRVEU",`+
-			`"y":"x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0",`+
-			`"d":"jpsQnnGQmL-YBIffH1136cspYG6-0iY7X1fCE9-E9LI"`+
-			`}`,
-	)
+// 	f.Add(
+// 		`{`+
+// 			`"payload":`+
+// 			`"eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGF`+
+// 			`tcGxlLmNvbS9pc19yb290Ijp0cnVlfQ",`+
+// 			`"protected":"eyJhbGciOiJFUzI1NiJ9",`+
+// 			`"header":`+
+// 			`{"kid":"e9bc097a-ce51-4036-9562-d2ade882db0d"},`+
+// 			`"signature":`+
+// 			`"DtEhU3ljbEg8L38VWAfUAqOyKAM6-Xx-F4GawxaepmXFCgfTjDxw5djxLa8IS`+
+// 			`lSApmWQxfKTUJqPP3-Kg6NU1Q"`+
+// 			`}`,
+// 		`{"kty":"EC",`+
+// 			`"crv":"P-256",`+
+// 			`"x":"f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvRVEU",`+
+// 			`"y":"x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0",`+
+// 			`"d":"jpsQnnGQmL-YBIffH1136cspYG6-0iY7X1fCE9-E9LI"`+
+// 			`}`,
+// 	)
 
-	f.Add(
-		`{`+
-			`"payload":`+
-			`"eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGF`+
-			`tcGxlLmNvbS9pc19yb290Ijp0cnVlfQ",`+
-			`"protected":"eyJhbGciOiJFUzI1NiJ9",`+
-			`"header":`+
-			`{"kid":"e9bc097a-ce51-4036-9562-d2ade882db0d"},`+
-			`"signature":`+
-			`"DtEhU3ljbEg8L38VWAfUAqOyKAM6-Xx-F4GawxaepmXFCgfTjDxw5djxLa8IS`+
-			`lSApmWQxfKTUJqPP3-Kg6NU1Q"`+
-			`}`,
-		`{"kty":"EC",`+
-			`"crv":"P-256",`+
-			`"x":"f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvRVEU",`+
-			`"y":"x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0",`+
-			`"d":"jpsQnnGQmL-YBIffH1136cspYG6-0iY7X1fCE9-E9LI"`+
-			`}`,
-	)
+// 	f.Add(
+// 		`{`+
+// 			`"payload":`+
+// 			`"eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGF`+
+// 			`tcGxlLmNvbS9pc19yb290Ijp0cnVlfQ",`+
+// 			`"protected":"eyJhbGciOiJFUzI1NiJ9",`+
+// 			`"header":`+
+// 			`{"kid":"e9bc097a-ce51-4036-9562-d2ade882db0d"},`+
+// 			`"signature":`+
+// 			`"DtEhU3ljbEg8L38VWAfUAqOyKAM6-Xx-F4GawxaepmXFCgfTjDxw5djxLa8IS`+
+// 			`lSApmWQxfKTUJqPP3-Kg6NU1Q"`+
+// 			`}`,
+// 		`{"kty":"EC",`+
+// 			`"crv":"P-256",`+
+// 			`"x":"f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvRVEU",`+
+// 			`"y":"x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0",`+
+// 			`"d":"jpsQnnGQmL-YBIffH1136cspYG6-0iY7X1fCE9-E9LI"`+
+// 			`}`,
+// 	)
 
-	f.Add(
-		`{`+
-			`"protected":`+
-			`"eyJhbGciOiJIUzI1NiIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19",`+
-			`"payload":`+
-			`"$.02",`+
-			`"signature":`+
-			`"A5dxf2s96_n5FLueVuW1Z_vh161FwXZC4YLPff6dmDY"`+
-			`}`,
-		`{`+
-			`"kty":"oct",`+
-			`"k":"AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75`+
-			`aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow"`+
-			`}`,
-	)
+// 	f.Add(
+// 		`{`+
+// 			`"protected":`+
+// 			`"eyJhbGciOiJIUzI1NiIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19",`+
+// 			`"payload":`+
+// 			`"$.02",`+
+// 			`"signature":`+
+// 			`"A5dxf2s96_n5FLueVuW1Z_vh161FwXZC4YLPff6dmDY"`+
+// 			`}`,
+// 		`{`+
+// 			`"kty":"oct",`+
+// 			`"k":"AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75`+
+// 			`aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow"`+
+// 			`}`,
+// 	)
 
-	f.Fuzz(func(t *testing.T, raw, rawKey string) {
-		var msg1 Message
-		if err := msg1.UnmarshalJSON([]byte(raw)); err != nil {
-			return
-		}
+// 	f.Fuzz(func(t *testing.T, raw, rawKey string) {
+// 		var msg1 Message
+// 		if err := msg1.UnmarshalJSON([]byte(raw)); err != nil {
+// 			return
+// 		}
 
-		key, err := jwk.ParseKey([]byte(rawKey))
-		if err != nil {
-			return
-		}
+// 		key, err := jwk.ParseKey([]byte(rawKey))
+// 		if err != nil {
+// 			return
+// 		}
 
-		var header1 *Header
-		protected1, payload1, err := msg1.Verify(FindKeyFunc(func(protected, header *Header) (sig.SigningKey, error) {
-			if !protected.Algorithm().Available() {
-				return nil, errors.New("algorithm not available")
-			}
-			header1 = header
-			return protected.Algorithm().New().NewSigningKey(key), nil
-		}))
-		if err != nil {
-			return
-		}
+// 		var header1 *Header
+// 		protected1, payload1, err := msg1.Verify(FindKeyFunc(func(protected, header *Header) (sig.SigningKey, error) {
+// 			if !protected.Algorithm().Available() {
+// 				return nil, errors.New("algorithm not available")
+// 			}
+// 			header1 = header
+// 			return protected.Algorithm().New().NewSigningKey(key), nil
+// 		}))
+// 		if err != nil {
+// 			return
+// 		}
 
-		if key.PrivateKey() == nil {
-			return // the key doesn't support signing, we skip it.
-		}
+// 		if key.PrivateKey() == nil {
+// 			return // the key doesn't support signing, we skip it.
+// 		}
 
-		msg2 := NewMessage(payload1)
-		if err := msg2.Sign(protected1, header1, protected1.Algorithm().New().NewSigningKey(key)); err != nil {
-			t.Fatal(err)
-		}
+// 		msg2 := NewMessage(payload1)
+// 		if err := msg2.Sign(protected1, header1, protected1.Algorithm().New().NewSigningKey(key)); err != nil {
+// 			t.Fatal(err)
+// 		}
 
-		data, err := msg2.MarshalJSON()
-		if err != nil {
-			t.Fatal(err)
-		}
+// 		data, err := msg2.MarshalJSON()
+// 		if err != nil {
+// 			t.Fatal(err)
+// 		}
 
-		var msg3 Message
-		if err := msg3.UnmarshalJSON(data); err != nil {
-			t.Fatal(err)
-		}
-		_, payload3, err := msg1.Verify(FindKeyFunc(func(protected, header *Header) (sig.SigningKey, error) {
-			if !protected.Algorithm().Available() {
-				return nil, errors.New("algorithm not available")
-			}
-			return protected.Algorithm().New().NewSigningKey(key), nil
-		}))
-		if err != nil {
-			return
-		}
-		if string(payload1) != string(payload3) {
-			t.Errorf("want %s, got %s", string(payload1), string(payload3))
-		}
-	})
-}
+// 		var msg3 Message
+// 		if err := msg3.UnmarshalJSON(data); err != nil {
+// 			t.Fatal(err)
+// 		}
+// 		_, payload3, err := msg1.Verify(FindKeyFunc(func(protected, header *Header) (sig.SigningKey, error) {
+// 			if !protected.Algorithm().Available() {
+// 				return nil, errors.New("algorithm not available")
+// 			}
+// 			return protected.Algorithm().New().NewSigningKey(key), nil
+// 		}))
+// 		if err != nil {
+// 			return
+// 		}
+// 		if string(payload1) != string(payload3) {
+// 			t.Errorf("want %s, got %s", string(payload1), string(payload3))
+// 		}
+// 	})
+// }
 
-func FuzzJWSCompact(f *testing.F) {
-	f.Add(
-		"eyJ0eXAiOiJKV1QiLA0KICJhbGciOiJIUzI1NiJ9"+
-			"."+
-			"eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFt"+
-			"cGxlLmNvbS9pc19yb290Ijp0cnVlfQ"+
-			"."+
-			"dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk",
-		`{"kty":"oct",`+
-			`"k":"AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75`+
-			`aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow"`+
-			`}`,
-	)
-	f.Add(
-		"eyJhbGciOiJSUzI1NiJ9"+
-			"."+
-			"eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFt"+
-			"cGxlLmNvbS9pc19yb290Ijp0cnVlfQ"+
-			"."+
-			"cC4hiUPoj9Eetdgtv3hF80EGrhuB__dzERat0XF9g2VtQgr9PJbu3XOiZj5RZmh7"+
-			"AAuHIm4Bh-0Qc_lF5YKt_O8W2Fp5jujGbds9uJdbF9CUAr7t1dnZcAcQjbKBYNX4"+
-			"BAynRFdiuB--f_nZLgrnbyTyWzO75vRK5h6xBArLIARNPvkSjtQBMHlb1L07Qe7K"+
-			"0GarZRmB_eSN9383LcOLn6_dO--xi12jzDwusC-eOkHWEsqtFZESc6BfI7noOPqv"+
-			"hJ1phCnvWh6IeYI2w9QOYEUipUTI8np6LbgGY9Fs98rqVt5AXLIhWkWywlVmtVrB"+
-			"p0igcN_IoypGlUPQGe77Rw",
-		`{"kty":"RSA",`+
-			`"n":"ofgWCuLjybRlzo0tZWJjNiuSfb4p4fAkd_wWJcyQoTbji9k0l8W26mPddx`+
-			`HmfHQp-Vaw-4qPCJrcS2mJPMEzP1Pt0Bm4d4QlL-yRT-SFd2lZS-pCgNMs`+
-			`D1W_YpRPEwOWvG6b32690r2jZ47soMZo9wGzjb_7OMg0LOL-bSf63kpaSH`+
-			`SXndS5z5rexMdbBYUsLA9e-KXBdQOS-UTo7WTBEMa2R2CapHg665xsmtdV`+
-			`MTBQY4uDZlxvb3qCo5ZwKh9kG4LT6_I5IhlJH7aGhyxXFvUK-DWNmoudF8`+
-			`NAco9_h9iaGNj8q2ethFkMLs91kzk2PAcDTW9gb54h4FRWyuXpoQ",`+
-			`"e":"AQAB",`+
-			`"d":"Eq5xpGnNCivDflJsRQBXHx1hdR1k6Ulwe2JZD50LpXyWPEAeP88vLNO97I`+
-			`jlA7_GQ5sLKMgvfTeXZx9SE-7YwVol2NXOoAJe46sui395IW_GO-pWJ1O0`+
-			`BkTGoVEn2bKVRUCgu-GjBVaYLU6f3l9kJfFNS3E0QbVdxzubSu3Mkqzjkn`+
-			`439X0M_V51gfpRLI9JYanrC4D4qAdGcopV_0ZHHzQlBjudU2QvXt4ehNYT`+
-			`CBr6XCLQUShb1juUO1ZdiYoFaFQT5Tw8bGUl_x_jTj3ccPDVZFD9pIuhLh`+
-			`BOneufuBiB4cS98l2SR_RQyGWSeWjnczT0QU91p1DhOVRuOopznQ",`+
-			`"p":"4BzEEOtIpmVdVEZNCqS7baC4crd0pqnRH_5IB3jw3bcxGn6QLvnEtfdUdi`+
-			`YrqBdss1l58BQ3KhooKeQTa9AB0Hw_Py5PJdTJNPY8cQn7ouZ2KKDcmnPG`+
-			`BY5t7yLc1QlQ5xHdwW1VhvKn-nXqhJTBgIPgtldC-KDV5z-y2XDwGUc",`+
-			`"q":"uQPEfgmVtjL0Uyyx88GZFF1fOunH3-7cepKmtH4pxhtCoHqpWmT8YAmZxa`+
-			`ewHgHAjLYsp1ZSe7zFYHj7C6ul7TjeLQeZD_YwD66t62wDmpe_HlB-TnBA`+
-			`-njbglfIsRLtXlnDzQkv5dTltRJ11BKBBypeeF6689rjcJIDEz9RWdc",`+
-			`"dp":"BwKfV3Akq5_MFZDFZCnW-wzl-CCo83WoZvnLQwCTeDv8uzluRSnm71I3Q`+
-			`CLdhrqE2e9YkxvuxdBfpT_PI7Yz-FOKnu1R6HsJeDCjn12Sk3vmAktV2zb`+
-			`34MCdy7cpdTh_YVr7tss2u6vneTwrA86rZtu5Mbr1C1XsmvkxHQAdYo0",`+
-			`"dq":"h_96-mK1R_7glhsum81dZxjTnYynPbZpHziZjeeHcXYsXaaMwkOlODsWa`+
-			`7I9xXDoRwbKgB719rrmI2oKr6N3Do9U0ajaHF-NKJnwgjMd2w9cjz3_-ky`+
-			`NlxAr2v4IKhGNpmM5iIgOS1VZnOZ68m6_pbLBSp3nssTdlqvd0tIiTHU",`+
-			`"qi":"IYd7DHOhrWvxkwPQsRM2tOgrjbcrfvtQJipd-DlcxyVuuM9sQLdgjVk2o`+
-			`y26F0EmpScGLq2MowX7fhd_QJQ3ydy5cY7YIBi87w93IKLEdfnbJtoOPLU`+
-			`W0ITrJReOgo1cq9SbsxYawBgfp_gh6A5603k2-ZQwVK0JKSHuLFkuQ3U"`+
-			`}`,
-	)
-	f.Add(
-		"eyJhbGciOiJFUzI1NiJ9"+
-			"."+
-			"eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFt"+
-			"cGxlLmNvbS9pc19yb290Ijp0cnVlfQ"+
-			"."+
-			"DtEhU3ljbEg8L38VWAfUAqOyKAM6-Xx-F4GawxaepmXFCgfTjDxw5djxLa8ISlSA"+
-			"pmWQxfKTUJqPP3-Kg6NU1Q",
-		`{"kty":"EC",`+
-			`"crv":"P-256",`+
-			`"x":"f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvRVEU",`+
-			`"y":"x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0",`+
-			`"d":"jpsQnnGQmL-YBIffH1136cspYG6-0iY7X1fCE9-E9LI"`+
-			`}`,
-	)
-	f.Add(
-		"eyJhbGciOiJFUzUxMiJ9"+
-			"."+
-			"UGF5bG9hZA"+
-			"."+
-			"AdwMgeerwtHoh-l192l60hp9wAHZFVJbLfD_UxMi70cwnZOYaRI1bKPWROc-mZZq"+
-			"wqT2SI-KGDKB34XO0aw_7XdtAG8GaSwFKdCAPZgoXD2YBJZCPEX3xKpRwcdOO8Kp"+
-			"EHwJjyqOgzDO7iKvU8vcnwNrmxYbSW9ERBXukOXolLzeO_Jn",
-		`{"kty":"EC",`+
-			`"crv":"P-521",`+
-			`"x":"AekpBQ8ST8a8VcfVOTNl353vSrDCLLJXmPk06wTjxrrjcBpXp5EOnYG_`+
-			`NjFZ6OvLFV1jSfS9tsz4qUxcWceqwQGk",`+
-			`"y":"ADSmRA43Z1DSNx_RvcLI87cdL07l6jQyyBXMoxVg_l2Th-x3S1WDhjDl`+
-			`y79ajL4Kkd0AZMaZmh9ubmf63e3kyMj2",`+
-			`"d":"AY5pb7A0UFiB3RELSD64fTLOSV_jazdF7fLYyuTw8lOfRhWg6Y6rUrPA`+
-			`xerEzgdRhajnu0ferB0d53vM9mE15j2C"`+
-			`}`,
-	)
-	f.Add(
-		"eyJhbGciOiJFZERTQSJ9"+
-			"."+
-			"RXhhbXBsZSBvZiBFZDI1NTE5IHNpZ25pbmc"+
-			"."+
-			"hgyY0il_MGCjP0JzlnLWG1PPOt7-09PGcvMg3AIbQR6dWbhijcNR4ki4iylGjg5BhVsPt"+
-			"9g7sVvpAr_MuM0KAg",
-		`{"kty":"OKP","crv":"Ed25519",`+
-			`"d":"nWGxne_9WmC6hEr0kuwsxERJxWl7MmkZcDusAxyuf2A",`+
-			`"x":"11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo"}`,
-	)
-	f.Fuzz(func(t *testing.T, data, key string) {
-		k, err := jwk.ParseKey([]byte(key))
-		if err != nil {
-			return
-		}
-		var sigKey sig.SigningKey
-		msg1, err := Parse([]byte(data))
-		if err != nil {
-			return
-		}
-		header1, payload1, err := msg1.Verify(FindKeyFunc(func(header, _ *Header) (sig.SigningKey, error) {
-			alg := header.Algorithm()
-			if !alg.Available() {
-				return nil, errors.New("unknown algorithm")
-			}
-			sigKey = alg.New().NewSigningKey(k)
-			return sigKey, nil
-		}))
-		if err != nil {
-			return
-		}
-		if k.PrivateKey() == nil {
-			return // the key doesn't support signing, we skip it.
-		}
+// func FuzzJWSCompact(f *testing.F) {
+// 	f.Add(
+// 		"eyJ0eXAiOiJKV1QiLA0KICJhbGciOiJIUzI1NiJ9"+
+// 			"."+
+// 			"eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFt"+
+// 			"cGxlLmNvbS9pc19yb290Ijp0cnVlfQ"+
+// 			"."+
+// 			"dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk",
+// 		`{"kty":"oct",`+
+// 			`"k":"AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75`+
+// 			`aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow"`+
+// 			`}`,
+// 	)
+// 	f.Add(
+// 		"eyJhbGciOiJSUzI1NiJ9"+
+// 			"."+
+// 			"eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFt"+
+// 			"cGxlLmNvbS9pc19yb290Ijp0cnVlfQ"+
+// 			"."+
+// 			"cC4hiUPoj9Eetdgtv3hF80EGrhuB__dzERat0XF9g2VtQgr9PJbu3XOiZj5RZmh7"+
+// 			"AAuHIm4Bh-0Qc_lF5YKt_O8W2Fp5jujGbds9uJdbF9CUAr7t1dnZcAcQjbKBYNX4"+
+// 			"BAynRFdiuB--f_nZLgrnbyTyWzO75vRK5h6xBArLIARNPvkSjtQBMHlb1L07Qe7K"+
+// 			"0GarZRmB_eSN9383LcOLn6_dO--xi12jzDwusC-eOkHWEsqtFZESc6BfI7noOPqv"+
+// 			"hJ1phCnvWh6IeYI2w9QOYEUipUTI8np6LbgGY9Fs98rqVt5AXLIhWkWywlVmtVrB"+
+// 			"p0igcN_IoypGlUPQGe77Rw",
+// 		`{"kty":"RSA",`+
+// 			`"n":"ofgWCuLjybRlzo0tZWJjNiuSfb4p4fAkd_wWJcyQoTbji9k0l8W26mPddx`+
+// 			`HmfHQp-Vaw-4qPCJrcS2mJPMEzP1Pt0Bm4d4QlL-yRT-SFd2lZS-pCgNMs`+
+// 			`D1W_YpRPEwOWvG6b32690r2jZ47soMZo9wGzjb_7OMg0LOL-bSf63kpaSH`+
+// 			`SXndS5z5rexMdbBYUsLA9e-KXBdQOS-UTo7WTBEMa2R2CapHg665xsmtdV`+
+// 			`MTBQY4uDZlxvb3qCo5ZwKh9kG4LT6_I5IhlJH7aGhyxXFvUK-DWNmoudF8`+
+// 			`NAco9_h9iaGNj8q2ethFkMLs91kzk2PAcDTW9gb54h4FRWyuXpoQ",`+
+// 			`"e":"AQAB",`+
+// 			`"d":"Eq5xpGnNCivDflJsRQBXHx1hdR1k6Ulwe2JZD50LpXyWPEAeP88vLNO97I`+
+// 			`jlA7_GQ5sLKMgvfTeXZx9SE-7YwVol2NXOoAJe46sui395IW_GO-pWJ1O0`+
+// 			`BkTGoVEn2bKVRUCgu-GjBVaYLU6f3l9kJfFNS3E0QbVdxzubSu3Mkqzjkn`+
+// 			`439X0M_V51gfpRLI9JYanrC4D4qAdGcopV_0ZHHzQlBjudU2QvXt4ehNYT`+
+// 			`CBr6XCLQUShb1juUO1ZdiYoFaFQT5Tw8bGUl_x_jTj3ccPDVZFD9pIuhLh`+
+// 			`BOneufuBiB4cS98l2SR_RQyGWSeWjnczT0QU91p1DhOVRuOopznQ",`+
+// 			`"p":"4BzEEOtIpmVdVEZNCqS7baC4crd0pqnRH_5IB3jw3bcxGn6QLvnEtfdUdi`+
+// 			`YrqBdss1l58BQ3KhooKeQTa9AB0Hw_Py5PJdTJNPY8cQn7ouZ2KKDcmnPG`+
+// 			`BY5t7yLc1QlQ5xHdwW1VhvKn-nXqhJTBgIPgtldC-KDV5z-y2XDwGUc",`+
+// 			`"q":"uQPEfgmVtjL0Uyyx88GZFF1fOunH3-7cepKmtH4pxhtCoHqpWmT8YAmZxa`+
+// 			`ewHgHAjLYsp1ZSe7zFYHj7C6ul7TjeLQeZD_YwD66t62wDmpe_HlB-TnBA`+
+// 			`-njbglfIsRLtXlnDzQkv5dTltRJ11BKBBypeeF6689rjcJIDEz9RWdc",`+
+// 			`"dp":"BwKfV3Akq5_MFZDFZCnW-wzl-CCo83WoZvnLQwCTeDv8uzluRSnm71I3Q`+
+// 			`CLdhrqE2e9YkxvuxdBfpT_PI7Yz-FOKnu1R6HsJeDCjn12Sk3vmAktV2zb`+
+// 			`34MCdy7cpdTh_YVr7tss2u6vneTwrA86rZtu5Mbr1C1XsmvkxHQAdYo0",`+
+// 			`"dq":"h_96-mK1R_7glhsum81dZxjTnYynPbZpHziZjeeHcXYsXaaMwkOlODsWa`+
+// 			`7I9xXDoRwbKgB719rrmI2oKr6N3Do9U0ajaHF-NKJnwgjMd2w9cjz3_-ky`+
+// 			`NlxAr2v4IKhGNpmM5iIgOS1VZnOZ68m6_pbLBSp3nssTdlqvd0tIiTHU",`+
+// 			`"qi":"IYd7DHOhrWvxkwPQsRM2tOgrjbcrfvtQJipd-DlcxyVuuM9sQLdgjVk2o`+
+// 			`y26F0EmpScGLq2MowX7fhd_QJQ3ydy5cY7YIBi87w93IKLEdfnbJtoOPLU`+
+// 			`W0ITrJReOgo1cq9SbsxYawBgfp_gh6A5603k2-ZQwVK0JKSHuLFkuQ3U"`+
+// 			`}`,
+// 	)
+// 	f.Add(
+// 		"eyJhbGciOiJFUzI1NiJ9"+
+// 			"."+
+// 			"eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFt"+
+// 			"cGxlLmNvbS9pc19yb290Ijp0cnVlfQ"+
+// 			"."+
+// 			"DtEhU3ljbEg8L38VWAfUAqOyKAM6-Xx-F4GawxaepmXFCgfTjDxw5djxLa8ISlSA"+
+// 			"pmWQxfKTUJqPP3-Kg6NU1Q",
+// 		`{"kty":"EC",`+
+// 			`"crv":"P-256",`+
+// 			`"x":"f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvRVEU",`+
+// 			`"y":"x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0",`+
+// 			`"d":"jpsQnnGQmL-YBIffH1136cspYG6-0iY7X1fCE9-E9LI"`+
+// 			`}`,
+// 	)
+// 	f.Add(
+// 		"eyJhbGciOiJFUzUxMiJ9"+
+// 			"."+
+// 			"UGF5bG9hZA"+
+// 			"."+
+// 			"AdwMgeerwtHoh-l192l60hp9wAHZFVJbLfD_UxMi70cwnZOYaRI1bKPWROc-mZZq"+
+// 			"wqT2SI-KGDKB34XO0aw_7XdtAG8GaSwFKdCAPZgoXD2YBJZCPEX3xKpRwcdOO8Kp"+
+// 			"EHwJjyqOgzDO7iKvU8vcnwNrmxYbSW9ERBXukOXolLzeO_Jn",
+// 		`{"kty":"EC",`+
+// 			`"crv":"P-521",`+
+// 			`"x":"AekpBQ8ST8a8VcfVOTNl353vSrDCLLJXmPk06wTjxrrjcBpXp5EOnYG_`+
+// 			`NjFZ6OvLFV1jSfS9tsz4qUxcWceqwQGk",`+
+// 			`"y":"ADSmRA43Z1DSNx_RvcLI87cdL07l6jQyyBXMoxVg_l2Th-x3S1WDhjDl`+
+// 			`y79ajL4Kkd0AZMaZmh9ubmf63e3kyMj2",`+
+// 			`"d":"AY5pb7A0UFiB3RELSD64fTLOSV_jazdF7fLYyuTw8lOfRhWg6Y6rUrPA`+
+// 			`xerEzgdRhajnu0ferB0d53vM9mE15j2C"`+
+// 			`}`,
+// 	)
+// 	f.Add(
+// 		"eyJhbGciOiJFZERTQSJ9"+
+// 			"."+
+// 			"RXhhbXBsZSBvZiBFZDI1NTE5IHNpZ25pbmc"+
+// 			"."+
+// 			"hgyY0il_MGCjP0JzlnLWG1PPOt7-09PGcvMg3AIbQR6dWbhijcNR4ki4iylGjg5BhVsPt"+
+// 			"9g7sVvpAr_MuM0KAg",
+// 		`{"kty":"OKP","crv":"Ed25519",`+
+// 			`"d":"nWGxne_9WmC6hEr0kuwsxERJxWl7MmkZcDusAxyuf2A",`+
+// 			`"x":"11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo"}`,
+// 	)
+// 	f.Fuzz(func(t *testing.T, data, key string) {
+// 		k, err := jwk.ParseKey([]byte(key))
+// 		if err != nil {
+// 			return
+// 		}
+// 		var sigKey sig.SigningKey
+// 		msg1, err := Parse([]byte(data))
+// 		if err != nil {
+// 			return
+// 		}
+// 		header1, payload1, err := msg1.Verify(FindKeyFunc(func(header, _ *Header) (sig.SigningKey, error) {
+// 			alg := header.Algorithm()
+// 			if !alg.Available() {
+// 				return nil, errors.New("unknown algorithm")
+// 			}
+// 			sigKey = alg.New().NewSigningKey(k)
+// 			return sigKey, nil
+// 		}))
+// 		if err != nil {
+// 			return
+// 		}
+// 		if k.PrivateKey() == nil {
+// 			return // the key doesn't support signing, we skip it.
+// 		}
 
-		msg2 := NewMessage(payload1)
-		if err := msg2.Sign(header1, nil, sigKey); err != nil {
-			t.Error(err)
-		}
-		resigned, err := msg2.Compact()
-		if err != nil {
-			t.Error(err)
-		}
+// 		msg2 := NewMessage(payload1)
+// 		if err := msg2.Sign(header1, nil, sigKey); err != nil {
+// 			t.Error(err)
+// 		}
+// 		resigned, err := msg2.Compact()
+// 		if err != nil {
+// 			t.Error(err)
+// 		}
 
-		msg3, err := Parse(resigned)
-		if err != nil {
-			t.Fatal(err)
-		}
-		_, payload3, err := msg3.Verify(FindKeyFunc(func(header, _ *Header) (sig.SigningKey, error) {
-			return sigKey, nil
-		}))
-		if err != nil {
-			t.Error(err)
-		}
-		if !bytes.Equal(payload1, payload3) {
-			t.Error("payload mismatch")
-		}
-	})
-}
+// 		msg3, err := Parse(resigned)
+// 		if err != nil {
+// 			t.Fatal(err)
+// 		}
+// 		_, payload3, err := msg3.Verify(FindKeyFunc(func(header, _ *Header) (sig.SigningKey, error) {
+// 			return sigKey, nil
+// 		}))
+// 		if err != nil {
+// 			t.Error(err)
+// 		}
+// 		if !bytes.Equal(payload1, payload3) {
+// 			t.Error("payload mismatch")
+// 		}
+// 	})
+// }

--- a/jws/jws.go
+++ b/jws/jws.go
@@ -70,6 +70,7 @@ func (h *Header) Algorithm() jwa.SignatureAlgorithm {
 	return h.alg
 }
 
+// SetAlgorithm sets RFC 7515 Section 4.1.1. "alg" (Algorithm) Header Parameter.
 func (h *Header) SetAlgorithm(alg jwa.SignatureAlgorithm) {
 	h.alg = alg
 }
@@ -79,6 +80,7 @@ func (h *Header) JWKSetURL() *url.URL {
 	return h.jku
 }
 
+// SetJWKSetURL sets RFC 7515 Section 4.1.2. "jku" (JWK Set URL) Header Parameter.
 func (h *Header) SetJWKSetURL(jku *url.URL) {
 	h.jku = jku
 }
@@ -88,6 +90,7 @@ func (h *Header) JWK() *jwk.Key {
 	return h.jwk
 }
 
+// SetJWK sets RFC 7515 Section 4.1.3. "jwk" (JSON Web Key) Header Parameter.
 func (h *Header) SetJWK(jwk *jwk.Key) {
 	h.jwk = jwk
 }
@@ -97,6 +100,7 @@ func (h *Header) KeyID() string {
 	return h.kid
 }
 
+// SetKeyID sets RFC 7515 Section 4.1.4. "kid" (Key ID) Header Parameter.
 func (h *Header) SetKeyID(kid string) {
 	h.kid = kid
 }
@@ -106,6 +110,7 @@ func (h *Header) X509URL() *url.URL {
 	return h.x5u
 }
 
+// SetX509URL sets RFC 7515 Section 4.1.5. "x5u" (X.509 URL) Header Parameter.
 func (h *Header) SetX509URL(x5u *url.URL) {
 	h.x5u = x5u
 }
@@ -115,6 +120,7 @@ func (h *Header) X509CertificateChain() []*x509.Certificate {
 	return h.x5c
 }
 
+// SetX509CertificateChain sets RFC 7515 Section 4.1.6. "x5c" (X.509 Certificate Chain) Header Parameter.
 func (h *Header) SetX509CertificateChain(x5c []*x509.Certificate) {
 	h.x5c = x5c
 }
@@ -124,6 +130,7 @@ func (h *Header) X509CertificateSHA1() []byte {
 	return h.x5t
 }
 
+// SetX509CertificateSHA1 sets RFC 7515 Section 4.1.7. "x5t" (X.509 Certificate SHA-1 Thumbprint) Header Parameter.
 func (h *Header) SetX509CertificateSHA1(x5t []byte) {
 	h.x5t = x5t
 }
@@ -133,6 +140,7 @@ func (h *Header) X509CertificateSHA256() []byte {
 	return h.x5tS256
 }
 
+// SetX509CertificateSHA256 sets RFC 7517 Section 4.1.8. "x5t#S256" (X.509 Certificate SHA-256 Thumbprint) Header Parameter.
 func (h *Header) SetX509CertificateSHA256(x5tS256 []byte) {
 	h.x5tS256 = x5tS256
 }
@@ -142,6 +150,7 @@ func (h *Header) Type() string {
 	return h.typ
 }
 
+// SetType sets RFC 7517 Section 4.1.9. "typ" (Type) Header Parameter.
 func (h *Header) SetType(typ string) {
 	h.typ = typ
 }
@@ -151,6 +160,7 @@ func (h *Header) ContentType() string {
 	return h.cty
 }
 
+// SetContentType sets RFC 7517 Section 4.1.10. "cty" (Content Type) Header Parameter.
 func (h *Header) SetContentType(cty string) {
 	h.cty = cty
 }
@@ -616,53 +626,14 @@ func encodeHeader(h *Header) (map[string]any, error) {
 	return e.Data(), nil
 }
 
-// KeyFinder is a wrapper for the FindKey method.
-type KeyFinder interface {
-	FindKey(protected, unprotected *Header) (key sig.SigningKey, err error)
-}
-
-type FindKeyFunc func(protected, unprotected *Header) (key sig.SigningKey, err error)
-
-func (f FindKeyFunc) FindKey(protected, unprotected *Header) (key sig.SigningKey, err error) {
-	return f(protected, unprotected)
-}
-
 // Verify verifies the JWS message.
+//
+// Deprecated: Use [Verifier.Verify] instead.
 func (msg *Message) Verify(finder KeyFinder) (*Header, []byte, error) {
-	// pre-allocate buffer
-	size := 0
-	for _, sig := range msg.Signatures {
-		if len(sig.raw) > size {
-			size = len(sig.raw)
-		}
+	v := &Verifier{
+		KeyFinder: finder,
 	}
-	size += len(msg.payload) + 1 // +1 for '.'
-	buf := make([]byte, size)
-
-	for _, sig := range msg.Signatures {
-		key, err := finder.FindKey(sig.protected, sig.header)
-		if err != nil {
-			continue
-		}
-		buf = buf[:0]
-		buf = append(buf, sig.raw...)
-		buf = append(buf, '.')
-		buf = append(buf, msg.payload...)
-		err = key.Verify(buf, sig.signature)
-		if err == nil {
-			var ret []byte
-			if sig.protected.b64 {
-				ret, err = b64Decode(msg.payload)
-				if err != nil {
-					return nil, nil, errors.New("jws: failed to verify the message")
-				}
-			} else {
-				ret = msg.payload
-			}
-			return sig.protected, ret, nil
-		}
-	}
-	return nil, nil, errors.New("jws: failed to verify the message")
+	return v.Verify(msg)
 }
 
 // Sign adds a new signature signed by key.

--- a/jws/jws.go
+++ b/jws/jws.go
@@ -626,16 +626,6 @@ func encodeHeader(h *Header) (map[string]any, error) {
 	return e.Data(), nil
 }
 
-// Verify verifies the JWS message.
-//
-// Deprecated: Use [Verifier.Verify] instead.
-func (msg *Message) Verify(finder KeyFinder) (*Header, []byte, error) {
-	v := &Verifier{
-		KeyFinder: finder,
-	}
-	return v.Verify(msg)
-}
-
 // Sign adds a new signature signed by key.
 func (msg *Message) Sign(protected, header *Header, key sig.SigningKey) error {
 	// encode the header

--- a/jws/jws_test.go
+++ b/jws/jws_test.go
@@ -3,6 +3,7 @@ package jws
 import (
 	"bytes"
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/shogo82148/goat/jwa"
@@ -306,187 +307,203 @@ func TestVerify(t *testing.T) {
 	})
 }
 
-// func TestUnmarshalJSON(t *testing.T) {
-// 	t.Run("RFC 7515 Appendix A.6. Example JWS Using General JWS JSON Serialization", func(t *testing.T) {
-// 		raw := `{` +
-// 			`"payload":` +
-// 			`"eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGF` +
-// 			`tcGxlLmNvbS9pc19yb290Ijp0cnVlfQ",` +
-// 			`"signatures":[` +
-// 			`{"protected":"eyJhbGciOiJSUzI1NiJ9",` +
-// 			`"header":` +
-// 			`{"kid":"2010-12-29"},` +
-// 			`"signature":` +
-// 			`"cC4hiUPoj9Eetdgtv3hF80EGrhuB__dzERat0XF9g2VtQgr9PJbu3XOiZj5RZ` +
-// 			`mh7AAuHIm4Bh-0Qc_lF5YKt_O8W2Fp5jujGbds9uJdbF9CUAr7t1dnZcAcQjb` +
-// 			`KBYNX4BAynRFdiuB--f_nZLgrnbyTyWzO75vRK5h6xBArLIARNPvkSjtQBMHl` +
-// 			`b1L07Qe7K0GarZRmB_eSN9383LcOLn6_dO--xi12jzDwusC-eOkHWEsqtFZES` +
-// 			`c6BfI7noOPqvhJ1phCnvWh6IeYI2w9QOYEUipUTI8np6LbgGY9Fs98rqVt5AX` +
-// 			`LIhWkWywlVmtVrBp0igcN_IoypGlUPQGe77Rw"},` +
-// 			`{"protected":"eyJhbGciOiJFUzI1NiJ9",` +
-// 			`"header":` +
-// 			`{"kid":"e9bc097a-ce51-4036-9562-d2ade882db0d"},` +
-// 			`"signature":` +
-// 			`"DtEhU3ljbEg8L38VWAfUAqOyKAM6-Xx-F4GawxaepmXFCgfTjDxw5djxLa8IS` +
-// 			`lSApmWQxfKTUJqPP3-Kg6NU1Q"}]` +
-// 			`}`
-// 		var msg Message
-// 		if err := msg.UnmarshalJSON([]byte(raw)); err != nil {
-// 			t.Fatal(err)
-// 		}
+func TestUnmarshalJSON(t *testing.T) {
+	t.Run("RFC 7515 Appendix A.6. Example JWS Using General JWS JSON Serialization", func(t *testing.T) {
+		raw := `{` +
+			`"payload":` +
+			`"eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGF` +
+			`tcGxlLmNvbS9pc19yb290Ijp0cnVlfQ",` +
+			`"signatures":[` +
+			`{"protected":"eyJhbGciOiJSUzI1NiJ9",` +
+			`"header":` +
+			`{"kid":"2010-12-29"},` +
+			`"signature":` +
+			`"cC4hiUPoj9Eetdgtv3hF80EGrhuB__dzERat0XF9g2VtQgr9PJbu3XOiZj5RZ` +
+			`mh7AAuHIm4Bh-0Qc_lF5YKt_O8W2Fp5jujGbds9uJdbF9CUAr7t1dnZcAcQjb` +
+			`KBYNX4BAynRFdiuB--f_nZLgrnbyTyWzO75vRK5h6xBArLIARNPvkSjtQBMHl` +
+			`b1L07Qe7K0GarZRmB_eSN9383LcOLn6_dO--xi12jzDwusC-eOkHWEsqtFZES` +
+			`c6BfI7noOPqvhJ1phCnvWh6IeYI2w9QOYEUipUTI8np6LbgGY9Fs98rqVt5AX` +
+			`LIhWkWywlVmtVrBp0igcN_IoypGlUPQGe77Rw"},` +
+			`{"protected":"eyJhbGciOiJFUzI1NiJ9",` +
+			`"header":` +
+			`{"kid":"e9bc097a-ce51-4036-9562-d2ade882db0d"},` +
+			`"signature":` +
+			`"DtEhU3ljbEg8L38VWAfUAqOyKAM6-Xx-F4GawxaepmXFCgfTjDxw5djxLa8IS` +
+			`lSApmWQxfKTUJqPP3-Kg6NU1Q"}]` +
+			`}`
+		var msg Message
+		if err := msg.UnmarshalJSON([]byte(raw)); err != nil {
+			t.Fatal(err)
+		}
 
-// 		_, payload, err := msg.Verify(FindKeyFunc(func(protected, header *Header) (sig.SigningKey, error) {
-// 			if header.KeyID() != "2010-12-29" {
-// 				return nil, errors.New("unknown key id")
-// 			}
-// 			rawKey := `{"kty":"RSA",` +
-// 				`"n":"ofgWCuLjybRlzo0tZWJjNiuSfb4p4fAkd_wWJcyQoTbji9k0l8W26mPddx` +
-// 				`HmfHQp-Vaw-4qPCJrcS2mJPMEzP1Pt0Bm4d4QlL-yRT-SFd2lZS-pCgNMs` +
-// 				`D1W_YpRPEwOWvG6b32690r2jZ47soMZo9wGzjb_7OMg0LOL-bSf63kpaSH` +
-// 				`SXndS5z5rexMdbBYUsLA9e-KXBdQOS-UTo7WTBEMa2R2CapHg665xsmtdV` +
-// 				`MTBQY4uDZlxvb3qCo5ZwKh9kG4LT6_I5IhlJH7aGhyxXFvUK-DWNmoudF8` +
-// 				`NAco9_h9iaGNj8q2ethFkMLs91kzk2PAcDTW9gb54h4FRWyuXpoQ",` +
-// 				`"e":"AQAB",` +
-// 				`"d":"Eq5xpGnNCivDflJsRQBXHx1hdR1k6Ulwe2JZD50LpXyWPEAeP88vLNO97I` +
-// 				`jlA7_GQ5sLKMgvfTeXZx9SE-7YwVol2NXOoAJe46sui395IW_GO-pWJ1O0` +
-// 				`BkTGoVEn2bKVRUCgu-GjBVaYLU6f3l9kJfFNS3E0QbVdxzubSu3Mkqzjkn` +
-// 				`439X0M_V51gfpRLI9JYanrC4D4qAdGcopV_0ZHHzQlBjudU2QvXt4ehNYT` +
-// 				`CBr6XCLQUShb1juUO1ZdiYoFaFQT5Tw8bGUl_x_jTj3ccPDVZFD9pIuhLh` +
-// 				`BOneufuBiB4cS98l2SR_RQyGWSeWjnczT0QU91p1DhOVRuOopznQ",` +
-// 				`"p":"4BzEEOtIpmVdVEZNCqS7baC4crd0pqnRH_5IB3jw3bcxGn6QLvnEtfdUdi` +
-// 				`YrqBdss1l58BQ3KhooKeQTa9AB0Hw_Py5PJdTJNPY8cQn7ouZ2KKDcmnPG` +
-// 				`BY5t7yLc1QlQ5xHdwW1VhvKn-nXqhJTBgIPgtldC-KDV5z-y2XDwGUc",` +
-// 				`"q":"uQPEfgmVtjL0Uyyx88GZFF1fOunH3-7cepKmtH4pxhtCoHqpWmT8YAmZxa` +
-// 				`ewHgHAjLYsp1ZSe7zFYHj7C6ul7TjeLQeZD_YwD66t62wDmpe_HlB-TnBA` +
-// 				`-njbglfIsRLtXlnDzQkv5dTltRJ11BKBBypeeF6689rjcJIDEz9RWdc",` +
-// 				`"dp":"BwKfV3Akq5_MFZDFZCnW-wzl-CCo83WoZvnLQwCTeDv8uzluRSnm71I3Q` +
-// 				`CLdhrqE2e9YkxvuxdBfpT_PI7Yz-FOKnu1R6HsJeDCjn12Sk3vmAktV2zb` +
-// 				`34MCdy7cpdTh_YVr7tss2u6vneTwrA86rZtu5Mbr1C1XsmvkxHQAdYo0",` +
-// 				`"dq":"h_96-mK1R_7glhsum81dZxjTnYynPbZpHziZjeeHcXYsXaaMwkOlODsWa` +
-// 				`7I9xXDoRwbKgB719rrmI2oKr6N3Do9U0ajaHF-NKJnwgjMd2w9cjz3_-ky` +
-// 				`NlxAr2v4IKhGNpmM5iIgOS1VZnOZ68m6_pbLBSp3nssTdlqvd0tIiTHU",` +
-// 				`"qi":"IYd7DHOhrWvxkwPQsRM2tOgrjbcrfvtQJipd-DlcxyVuuM9sQLdgjVk2o` +
-// 				`y26F0EmpScGLq2MowX7fhd_QJQ3ydy5cY7YIBi87w93IKLEdfnbJtoOPLU` +
-// 				`W0ITrJReOgo1cq9SbsxYawBgfp_gh6A5603k2-ZQwVK0JKSHuLFkuQ3U"` +
-// 				`}`
-// 			key, err := jwk.ParseKey([]byte(rawKey))
-// 			if err != nil {
-// 				return nil, err
-// 			}
-// 			return protected.Algorithm().New().NewSigningKey(key), nil
-// 		}))
-// 		if err != nil {
-// 			t.Fatal(err)
-// 		}
-// 		want := []byte(`{"iss":"joe",` + "\r\n" +
-// 			` "exp":1300819380,` + "\r\n" +
-// 			` "http://example.com/is_root":true}`)
-// 		if !bytes.Equal(payload, want) {
-// 			t.Errorf("unexpected payload: want %q, got %q", string(want), string(payload))
-// 		}
+		v := &Verifier{
+			AlgorithmVerfier: AllowedAlgorithms{jwa.RS256},
+			KeyFinder: FindKeyFunc(func(_ context.Context, protected, header *Header) (sig.SigningKey, error) {
+				if header.KeyID() != "2010-12-29" {
+					return nil, errors.New("unknown key id")
+				}
+				rawKey := `{"kty":"RSA",` +
+					`"n":"ofgWCuLjybRlzo0tZWJjNiuSfb4p4fAkd_wWJcyQoTbji9k0l8W26mPddx` +
+					`HmfHQp-Vaw-4qPCJrcS2mJPMEzP1Pt0Bm4d4QlL-yRT-SFd2lZS-pCgNMs` +
+					`D1W_YpRPEwOWvG6b32690r2jZ47soMZo9wGzjb_7OMg0LOL-bSf63kpaSH` +
+					`SXndS5z5rexMdbBYUsLA9e-KXBdQOS-UTo7WTBEMa2R2CapHg665xsmtdV` +
+					`MTBQY4uDZlxvb3qCo5ZwKh9kG4LT6_I5IhlJH7aGhyxXFvUK-DWNmoudF8` +
+					`NAco9_h9iaGNj8q2ethFkMLs91kzk2PAcDTW9gb54h4FRWyuXpoQ",` +
+					`"e":"AQAB",` +
+					`"d":"Eq5xpGnNCivDflJsRQBXHx1hdR1k6Ulwe2JZD50LpXyWPEAeP88vLNO97I` +
+					`jlA7_GQ5sLKMgvfTeXZx9SE-7YwVol2NXOoAJe46sui395IW_GO-pWJ1O0` +
+					`BkTGoVEn2bKVRUCgu-GjBVaYLU6f3l9kJfFNS3E0QbVdxzubSu3Mkqzjkn` +
+					`439X0M_V51gfpRLI9JYanrC4D4qAdGcopV_0ZHHzQlBjudU2QvXt4ehNYT` +
+					`CBr6XCLQUShb1juUO1ZdiYoFaFQT5Tw8bGUl_x_jTj3ccPDVZFD9pIuhLh` +
+					`BOneufuBiB4cS98l2SR_RQyGWSeWjnczT0QU91p1DhOVRuOopznQ",` +
+					`"p":"4BzEEOtIpmVdVEZNCqS7baC4crd0pqnRH_5IB3jw3bcxGn6QLvnEtfdUdi` +
+					`YrqBdss1l58BQ3KhooKeQTa9AB0Hw_Py5PJdTJNPY8cQn7ouZ2KKDcmnPG` +
+					`BY5t7yLc1QlQ5xHdwW1VhvKn-nXqhJTBgIPgtldC-KDV5z-y2XDwGUc",` +
+					`"q":"uQPEfgmVtjL0Uyyx88GZFF1fOunH3-7cepKmtH4pxhtCoHqpWmT8YAmZxa` +
+					`ewHgHAjLYsp1ZSe7zFYHj7C6ul7TjeLQeZD_YwD66t62wDmpe_HlB-TnBA` +
+					`-njbglfIsRLtXlnDzQkv5dTltRJ11BKBBypeeF6689rjcJIDEz9RWdc",` +
+					`"dp":"BwKfV3Akq5_MFZDFZCnW-wzl-CCo83WoZvnLQwCTeDv8uzluRSnm71I3Q` +
+					`CLdhrqE2e9YkxvuxdBfpT_PI7Yz-FOKnu1R6HsJeDCjn12Sk3vmAktV2zb` +
+					`34MCdy7cpdTh_YVr7tss2u6vneTwrA86rZtu5Mbr1C1XsmvkxHQAdYo0",` +
+					`"dq":"h_96-mK1R_7glhsum81dZxjTnYynPbZpHziZjeeHcXYsXaaMwkOlODsWa` +
+					`7I9xXDoRwbKgB719rrmI2oKr6N3Do9U0ajaHF-NKJnwgjMd2w9cjz3_-ky` +
+					`NlxAr2v4IKhGNpmM5iIgOS1VZnOZ68m6_pbLBSp3nssTdlqvd0tIiTHU",` +
+					`"qi":"IYd7DHOhrWvxkwPQsRM2tOgrjbcrfvtQJipd-DlcxyVuuM9sQLdgjVk2o` +
+					`y26F0EmpScGLq2MowX7fhd_QJQ3ydy5cY7YIBi87w93IKLEdfnbJtoOPLU` +
+					`W0ITrJReOgo1cq9SbsxYawBgfp_gh6A5603k2-ZQwVK0JKSHuLFkuQ3U"` +
+					`}`
+				key, err := jwk.ParseKey([]byte(rawKey))
+				if err != nil {
+					return nil, err
+				}
+				return protected.Algorithm().New().NewSigningKey(key), nil
+			}),
+		}
+		_, payload, err := v.Verify(context.Background(), &msg)
+		if err != nil {
+			t.Fatal(err)
+		}
+		want := []byte(`{"iss":"joe",` + "\r\n" +
+			` "exp":1300819380,` + "\r\n" +
+			` "http://example.com/is_root":true}`)
+		if !bytes.Equal(payload, want) {
+			t.Errorf("unexpected payload: want %q, got %q", string(want), string(payload))
+		}
 
-// 		_, payload, err = msg.Verify(FindKeyFunc(func(protected, header *Header) (sig.SigningKey, error) {
-// 			if header.KeyID() != "e9bc097a-ce51-4036-9562-d2ade882db0d" {
-// 				return nil, errors.New("unknown key id")
-// 			}
-// 			rawKey := `{"kty":"EC",` +
-// 				`"crv":"P-256",` +
-// 				`"x":"f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvRVEU",` +
-// 				`"y":"x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0",` +
-// 				`"d":"jpsQnnGQmL-YBIffH1136cspYG6-0iY7X1fCE9-E9LI"` +
-// 				`}`
-// 			key, err := jwk.ParseKey([]byte(rawKey))
-// 			if err != nil {
-// 				return nil, err
-// 			}
-// 			return protected.Algorithm().New().NewSigningKey(key), nil
-// 		}))
-// 		if err != nil {
-// 			t.Fatal(err)
-// 		}
-// 		if !bytes.Equal(payload, want) {
-// 			t.Errorf("unexpected payload: want %q, got %q", string(want), string(payload))
-// 		}
-// 	})
+		v = &Verifier{
+			AlgorithmVerfier: AllowedAlgorithms{jwa.ES256},
+			KeyFinder: FindKeyFunc(func(_ context.Context, protected, header *Header) (sig.SigningKey, error) {
+				if header.KeyID() != "e9bc097a-ce51-4036-9562-d2ade882db0d" {
+					return nil, errors.New("unknown key id")
+				}
+				rawKey := `{"kty":"EC",` +
+					`"crv":"P-256",` +
+					`"x":"f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvRVEU",` +
+					`"y":"x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0",` +
+					`"d":"jpsQnnGQmL-YBIffH1136cspYG6-0iY7X1fCE9-E9LI"` +
+					`}`
+				key, err := jwk.ParseKey([]byte(rawKey))
+				if err != nil {
+					return nil, err
+				}
+				return protected.Algorithm().New().NewSigningKey(key), nil
+			}),
+		}
+		_, payload, err = v.Verify(context.Background(), &msg)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(payload, want) {
+			t.Errorf("unexpected payload: want %q, got %q", string(want), string(payload))
+		}
+	})
 
-// 	t.Run("RFC 7515 Appendix A.7. Example JWS Using Flattened JWS JSON Serialization", func(t *testing.T) {
-// 		raw := `{` +
-// 			`"payload":` +
-// 			`"eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGF` +
-// 			`tcGxlLmNvbS9pc19yb290Ijp0cnVlfQ",` +
-// 			`"protected":"eyJhbGciOiJFUzI1NiJ9",` +
-// 			`"header":` +
-// 			`{"kid":"e9bc097a-ce51-4036-9562-d2ade882db0d"},` +
-// 			`"signature":` +
-// 			`"DtEhU3ljbEg8L38VWAfUAqOyKAM6-Xx-F4GawxaepmXFCgfTjDxw5djxLa8IS` +
-// 			`lSApmWQxfKTUJqPP3-Kg6NU1Q"` +
-// 			`}`
-// 		var msg Message
-// 		if err := msg.UnmarshalJSON([]byte(raw)); err != nil {
-// 			t.Fatal(err)
-// 		}
-// 		_, payload, err := msg.Verify(FindKeyFunc(func(protected, header *Header) (sig.SigningKey, error) {
-// 			if header.KeyID() != "e9bc097a-ce51-4036-9562-d2ade882db0d" {
-// 				return nil, errors.New("unknown key id")
-// 			}
-// 			rawKey := `{"kty":"EC",` +
-// 				`"crv":"P-256",` +
-// 				`"x":"f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvRVEU",` +
-// 				`"y":"x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0",` +
-// 				`"d":"jpsQnnGQmL-YBIffH1136cspYG6-0iY7X1fCE9-E9LI"` +
-// 				`}`
-// 			key, err := jwk.ParseKey([]byte(rawKey))
-// 			if err != nil {
-// 				return nil, err
-// 			}
-// 			return protected.Algorithm().New().NewSigningKey(key), nil
-// 		}))
-// 		if err != nil {
-// 			t.Fatal(err)
-// 		}
-// 		want := []byte(`{"iss":"joe",` + "\r\n" +
-// 			` "exp":1300819380,` + "\r\n" +
-// 			` "http://example.com/is_root":true}`)
-// 		if !bytes.Equal(payload, want) {
-// 			t.Errorf("unexpected payload: want %q, got %q", string(want), string(payload))
-// 		}
-// 	})
+	t.Run("RFC 7515 Appendix A.7. Example JWS Using Flattened JWS JSON Serialization", func(t *testing.T) {
+		raw := `{` +
+			`"payload":` +
+			`"eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGF` +
+			`tcGxlLmNvbS9pc19yb290Ijp0cnVlfQ",` +
+			`"protected":"eyJhbGciOiJFUzI1NiJ9",` +
+			`"header":` +
+			`{"kid":"e9bc097a-ce51-4036-9562-d2ade882db0d"},` +
+			`"signature":` +
+			`"DtEhU3ljbEg8L38VWAfUAqOyKAM6-Xx-F4GawxaepmXFCgfTjDxw5djxLa8IS` +
+			`lSApmWQxfKTUJqPP3-Kg6NU1Q"` +
+			`}`
+		var msg Message
+		if err := msg.UnmarshalJSON([]byte(raw)); err != nil {
+			t.Fatal(err)
+		}
+		v := &Verifier{
+			AlgorithmVerfier: AllowedAlgorithms{jwa.ES256},
+			KeyFinder: FindKeyFunc(func(_ context.Context, protected, header *Header) (sig.SigningKey, error) {
+				if header.KeyID() != "e9bc097a-ce51-4036-9562-d2ade882db0d" {
+					return nil, errors.New("unknown key id")
+				}
+				rawKey := `{"kty":"EC",` +
+					`"crv":"P-256",` +
+					`"x":"f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvRVEU",` +
+					`"y":"x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0",` +
+					`"d":"jpsQnnGQmL-YBIffH1136cspYG6-0iY7X1fCE9-E9LI"` +
+					`}`
+				key, err := jwk.ParseKey([]byte(rawKey))
+				if err != nil {
+					return nil, err
+				}
+				return protected.Algorithm().New().NewSigningKey(key), nil
+			}),
+		}
+		_, payload, err := v.Verify(context.Background(), &msg)
+		if err != nil {
+			t.Fatal(err)
+		}
+		want := []byte(`{"iss":"joe",` + "\r\n" +
+			` "exp":1300819380,` + "\r\n" +
+			` "http://example.com/is_root":true}`)
+		if !bytes.Equal(payload, want) {
+			t.Errorf("unexpected payload: want %q, got %q", string(want), string(payload))
+		}
+	})
 
-// 	// test for b64 header parameter.
-// 	t.Run("RFC 7797 Section 4.2. Example with Header Parameters", func(t *testing.T) {
-// 		raw := `{` +
-// 			`"protected":` +
-// 			`"eyJhbGciOiJIUzI1NiIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19",` +
-// 			`"payload":` +
-// 			`"$.02",` +
-// 			`"signature":` +
-// 			`"A5dxf2s96_n5FLueVuW1Z_vh161FwXZC4YLPff6dmDY"` +
-// 			`}`
-// 		var msg Message
-// 		if err := msg.UnmarshalJSON([]byte(raw)); err != nil {
-// 			t.Fatal(err)
-// 		}
-// 		_, payload, err := msg.Verify(FindKeyFunc(func(protected, header *Header) (sig.SigningKey, error) {
-// 			rawKey := `{` +
-// 				`"kty":"oct",` +
-// 				`"k":"AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75` +
-// 				`aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow"` +
-// 				`}`
-// 			key, err := jwk.ParseKey([]byte(rawKey))
-// 			if err != nil {
-// 				return nil, err
-// 			}
-// 			return protected.Algorithm().New().NewSigningKey(key), nil
-// 		}))
-// 		if err != nil {
-// 			t.Fatal(err)
-// 		}
-// 		want := []byte(`$.02`)
-// 		if !bytes.Equal(payload, want) {
-// 			t.Errorf("unexpected payload: want %q, got %q", string(want), string(payload))
-// 		}
-// 	})
-// }
+	// test for b64 header parameter.
+	t.Run("RFC 7797 Section 4.2. Example with Header Parameters", func(t *testing.T) {
+		raw := `{` +
+			`"protected":` +
+			`"eyJhbGciOiJIUzI1NiIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19",` +
+			`"payload":` +
+			`"$.02",` +
+			`"signature":` +
+			`"A5dxf2s96_n5FLueVuW1Z_vh161FwXZC4YLPff6dmDY"` +
+			`}`
+		var msg Message
+		if err := msg.UnmarshalJSON([]byte(raw)); err != nil {
+			t.Fatal(err)
+		}
+		v := &Verifier{
+			AlgorithmVerfier: AllowedAlgorithms{jwa.HS256},
+			KeyFinder: FindKeyFunc(func(_ context.Context, protected, header *Header) (sig.SigningKey, error) {
+				rawKey := `{` +
+					`"kty":"oct",` +
+					`"k":"AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75` +
+					`aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow"` +
+					`}`
+				key, err := jwk.ParseKey([]byte(rawKey))
+				if err != nil {
+					return nil, err
+				}
+				return protected.Algorithm().New().NewSigningKey(key), nil
+			}),
+		}
+		_, payload, err := v.Verify(context.Background(), &msg)
+		if err != nil {
+			t.Fatal(err)
+		}
+		want := []byte(`$.02`)
+		if !bytes.Equal(payload, want) {
+			t.Errorf("unexpected payload: want %q, got %q", string(want), string(payload))
+		}
+	})
+}
 
 // func TestMarshalJSON(t *testing.T) {
 // 	t.Run("RFC 7515 Appendix A.6. Example JWS Using General JWS JSON Serialization", func(t *testing.T) {

--- a/jws/jws_test.go
+++ b/jws/jws_test.go
@@ -3,6 +3,7 @@ package jws
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"testing"
 
@@ -505,358 +506,359 @@ func TestUnmarshalJSON(t *testing.T) {
 	})
 }
 
-// func TestMarshalJSON(t *testing.T) {
-// 	t.Run("RFC 7515 Appendix A.6. Example JWS Using General JWS JSON Serialization", func(t *testing.T) {
-// 		msg := NewMessage([]byte(`{"iss":"joe",` + "\r\n" +
-// 			` "exp":1300819380,` + "\r\n" +
-// 			` "http://example.com/is_root":true}`))
+func TestMarshalJSON(t *testing.T) {
+	t.Run("RFC 7515 Appendix A.6. Example JWS Using General JWS JSON Serialization", func(t *testing.T) {
+		msg := NewMessage([]byte(`{"iss":"joe",` + "\r\n" +
+			` "exp":1300819380,` + "\r\n" +
+			` "http://example.com/is_root":true}`))
 
-// 		protected1 := NewHeader()
-// 		protected1.SetAlgorithm(jwa.RS256)
-// 		header1 := NewHeader()
-// 		header1.SetKeyID("2010-12-29")
-// 		rawKey1 := `{"kty":"RSA",` +
-// 			`"n":"ofgWCuLjybRlzo0tZWJjNiuSfb4p4fAkd_wWJcyQoTbji9k0l8W26mPddx` +
-// 			`HmfHQp-Vaw-4qPCJrcS2mJPMEzP1Pt0Bm4d4QlL-yRT-SFd2lZS-pCgNMs` +
-// 			`D1W_YpRPEwOWvG6b32690r2jZ47soMZo9wGzjb_7OMg0LOL-bSf63kpaSH` +
-// 			`SXndS5z5rexMdbBYUsLA9e-KXBdQOS-UTo7WTBEMa2R2CapHg665xsmtdV` +
-// 			`MTBQY4uDZlxvb3qCo5ZwKh9kG4LT6_I5IhlJH7aGhyxXFvUK-DWNmoudF8` +
-// 			`NAco9_h9iaGNj8q2ethFkMLs91kzk2PAcDTW9gb54h4FRWyuXpoQ",` +
-// 			`"e":"AQAB",` +
-// 			`"d":"Eq5xpGnNCivDflJsRQBXHx1hdR1k6Ulwe2JZD50LpXyWPEAeP88vLNO97I` +
-// 			`jlA7_GQ5sLKMgvfTeXZx9SE-7YwVol2NXOoAJe46sui395IW_GO-pWJ1O0` +
-// 			`BkTGoVEn2bKVRUCgu-GjBVaYLU6f3l9kJfFNS3E0QbVdxzubSu3Mkqzjkn` +
-// 			`439X0M_V51gfpRLI9JYanrC4D4qAdGcopV_0ZHHzQlBjudU2QvXt4ehNYT` +
-// 			`CBr6XCLQUShb1juUO1ZdiYoFaFQT5Tw8bGUl_x_jTj3ccPDVZFD9pIuhLh` +
-// 			`BOneufuBiB4cS98l2SR_RQyGWSeWjnczT0QU91p1DhOVRuOopznQ",` +
-// 			`"p":"4BzEEOtIpmVdVEZNCqS7baC4crd0pqnRH_5IB3jw3bcxGn6QLvnEtfdUdi` +
-// 			`YrqBdss1l58BQ3KhooKeQTa9AB0Hw_Py5PJdTJNPY8cQn7ouZ2KKDcmnPG` +
-// 			`BY5t7yLc1QlQ5xHdwW1VhvKn-nXqhJTBgIPgtldC-KDV5z-y2XDwGUc",` +
-// 			`"q":"uQPEfgmVtjL0Uyyx88GZFF1fOunH3-7cepKmtH4pxhtCoHqpWmT8YAmZxa` +
-// 			`ewHgHAjLYsp1ZSe7zFYHj7C6ul7TjeLQeZD_YwD66t62wDmpe_HlB-TnBA` +
-// 			`-njbglfIsRLtXlnDzQkv5dTltRJ11BKBBypeeF6689rjcJIDEz9RWdc",` +
-// 			`"dp":"BwKfV3Akq5_MFZDFZCnW-wzl-CCo83WoZvnLQwCTeDv8uzluRSnm71I3Q` +
-// 			`CLdhrqE2e9YkxvuxdBfpT_PI7Yz-FOKnu1R6HsJeDCjn12Sk3vmAktV2zb` +
-// 			`34MCdy7cpdTh_YVr7tss2u6vneTwrA86rZtu5Mbr1C1XsmvkxHQAdYo0",` +
-// 			`"dq":"h_96-mK1R_7glhsum81dZxjTnYynPbZpHziZjeeHcXYsXaaMwkOlODsWa` +
-// 			`7I9xXDoRwbKgB719rrmI2oKr6N3Do9U0ajaHF-NKJnwgjMd2w9cjz3_-ky` +
-// 			`NlxAr2v4IKhGNpmM5iIgOS1VZnOZ68m6_pbLBSp3nssTdlqvd0tIiTHU",` +
-// 			`"qi":"IYd7DHOhrWvxkwPQsRM2tOgrjbcrfvtQJipd-DlcxyVuuM9sQLdgjVk2o` +
-// 			`y26F0EmpScGLq2MowX7fhd_QJQ3ydy5cY7YIBi87w93IKLEdfnbJtoOPLU` +
-// 			`W0ITrJReOgo1cq9SbsxYawBgfp_gh6A5603k2-ZQwVK0JKSHuLFkuQ3U"` +
-// 			`}`
-// 		key1, err := jwk.ParseKey([]byte(rawKey1))
-// 		if err != nil {
-// 			t.Fatal(err)
-// 		}
-// 		if err := msg.Sign(protected1, header1, jwa.RS256.New().NewSigningKey(key1)); err != nil {
-// 			t.Fatal(err)
-// 		}
+		protected1 := NewHeader()
+		protected1.SetAlgorithm(jwa.RS256)
+		header1 := NewHeader()
+		header1.SetKeyID("2010-12-29")
+		rawKey1 := `{"kty":"RSA",` +
+			`"n":"ofgWCuLjybRlzo0tZWJjNiuSfb4p4fAkd_wWJcyQoTbji9k0l8W26mPddx` +
+			`HmfHQp-Vaw-4qPCJrcS2mJPMEzP1Pt0Bm4d4QlL-yRT-SFd2lZS-pCgNMs` +
+			`D1W_YpRPEwOWvG6b32690r2jZ47soMZo9wGzjb_7OMg0LOL-bSf63kpaSH` +
+			`SXndS5z5rexMdbBYUsLA9e-KXBdQOS-UTo7WTBEMa2R2CapHg665xsmtdV` +
+			`MTBQY4uDZlxvb3qCo5ZwKh9kG4LT6_I5IhlJH7aGhyxXFvUK-DWNmoudF8` +
+			`NAco9_h9iaGNj8q2ethFkMLs91kzk2PAcDTW9gb54h4FRWyuXpoQ",` +
+			`"e":"AQAB",` +
+			`"d":"Eq5xpGnNCivDflJsRQBXHx1hdR1k6Ulwe2JZD50LpXyWPEAeP88vLNO97I` +
+			`jlA7_GQ5sLKMgvfTeXZx9SE-7YwVol2NXOoAJe46sui395IW_GO-pWJ1O0` +
+			`BkTGoVEn2bKVRUCgu-GjBVaYLU6f3l9kJfFNS3E0QbVdxzubSu3Mkqzjkn` +
+			`439X0M_V51gfpRLI9JYanrC4D4qAdGcopV_0ZHHzQlBjudU2QvXt4ehNYT` +
+			`CBr6XCLQUShb1juUO1ZdiYoFaFQT5Tw8bGUl_x_jTj3ccPDVZFD9pIuhLh` +
+			`BOneufuBiB4cS98l2SR_RQyGWSeWjnczT0QU91p1DhOVRuOopznQ",` +
+			`"p":"4BzEEOtIpmVdVEZNCqS7baC4crd0pqnRH_5IB3jw3bcxGn6QLvnEtfdUdi` +
+			`YrqBdss1l58BQ3KhooKeQTa9AB0Hw_Py5PJdTJNPY8cQn7ouZ2KKDcmnPG` +
+			`BY5t7yLc1QlQ5xHdwW1VhvKn-nXqhJTBgIPgtldC-KDV5z-y2XDwGUc",` +
+			`"q":"uQPEfgmVtjL0Uyyx88GZFF1fOunH3-7cepKmtH4pxhtCoHqpWmT8YAmZxa` +
+			`ewHgHAjLYsp1ZSe7zFYHj7C6ul7TjeLQeZD_YwD66t62wDmpe_HlB-TnBA` +
+			`-njbglfIsRLtXlnDzQkv5dTltRJ11BKBBypeeF6689rjcJIDEz9RWdc",` +
+			`"dp":"BwKfV3Akq5_MFZDFZCnW-wzl-CCo83WoZvnLQwCTeDv8uzluRSnm71I3Q` +
+			`CLdhrqE2e9YkxvuxdBfpT_PI7Yz-FOKnu1R6HsJeDCjn12Sk3vmAktV2zb` +
+			`34MCdy7cpdTh_YVr7tss2u6vneTwrA86rZtu5Mbr1C1XsmvkxHQAdYo0",` +
+			`"dq":"h_96-mK1R_7glhsum81dZxjTnYynPbZpHziZjeeHcXYsXaaMwkOlODsWa` +
+			`7I9xXDoRwbKgB719rrmI2oKr6N3Do9U0ajaHF-NKJnwgjMd2w9cjz3_-ky` +
+			`NlxAr2v4IKhGNpmM5iIgOS1VZnOZ68m6_pbLBSp3nssTdlqvd0tIiTHU",` +
+			`"qi":"IYd7DHOhrWvxkwPQsRM2tOgrjbcrfvtQJipd-DlcxyVuuM9sQLdgjVk2o` +
+			`y26F0EmpScGLq2MowX7fhd_QJQ3ydy5cY7YIBi87w93IKLEdfnbJtoOPLU` +
+			`W0ITrJReOgo1cq9SbsxYawBgfp_gh6A5603k2-ZQwVK0JKSHuLFkuQ3U"` +
+			`}`
+		key1, err := jwk.ParseKey([]byte(rawKey1))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := msg.Sign(protected1, header1, jwa.RS256.New().NewSigningKey(key1)); err != nil {
+			t.Fatal(err)
+		}
 
-// 		protected := NewHeader()
-// 		protected.SetAlgorithm(jwa.ES256)
-// 		header := NewHeader()
-// 		header.SetKeyID("e9bc097a-ce51-4036-9562-d2ade882db0d")
-// 		rawKey2 := `{"kty":"EC",` +
-// 			`"crv":"P-256",` +
-// 			`"x":"f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvRVEU",` +
-// 			`"y":"x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0",` +
-// 			`"d":"jpsQnnGQmL-YBIffH1136cspYG6-0iY7X1fCE9-E9LI"` +
-// 			`}`
-// 		key2, err := jwk.ParseKey([]byte(rawKey2))
-// 		if err != nil {
-// 			t.Fatal(err)
-// 		}
-// 		if err := msg.Sign(protected, header, jwa.ES256.New().NewSigningKey(key2)); err != nil {
-// 			t.Fatal(err)
-// 		}
+		protected := NewHeader()
+		protected.SetAlgorithm(jwa.ES256)
+		header := NewHeader()
+		header.SetKeyID("e9bc097a-ce51-4036-9562-d2ade882db0d")
+		rawKey2 := `{"kty":"EC",` +
+			`"crv":"P-256",` +
+			`"x":"f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvRVEU",` +
+			`"y":"x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0",` +
+			`"d":"jpsQnnGQmL-YBIffH1136cspYG6-0iY7X1fCE9-E9LI"` +
+			`}`
+		key2, err := jwk.ParseKey([]byte(rawKey2))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := msg.Sign(protected, header, jwa.ES256.New().NewSigningKey(key2)); err != nil {
+			t.Fatal(err)
+		}
 
-// 		data, err := msg.MarshalJSON()
-// 		if err != nil {
-// 			t.Fatal(err)
-// 		}
+		data, err := msg.MarshalJSON()
+		if err != nil {
+			t.Fatal(err)
+		}
 
-// 		var tmp any
-// 		if err := json.Unmarshal(data, &tmp); err != nil {
-// 			t.Fatal(err)
-// 		}
-// 	})
+		var tmp any
+		if err := json.Unmarshal(data, &tmp); err != nil {
+			t.Fatal(err)
+		}
+	})
 
-// 	t.Run("RFC 7515 Appendix A.7. Example JWS Using Flattened JWS JSON Serialization", func(t *testing.T) {
-// 		msg := NewMessage([]byte(`{"iss":"joe",` + "\r\n" +
-// 			` "exp":1300819380,` + "\r\n" +
-// 			` "http://example.com/is_root":true}`))
+	t.Run("RFC 7515 Appendix A.7. Example JWS Using Flattened JWS JSON Serialization", func(t *testing.T) {
+		msg := NewMessage([]byte(`{"iss":"joe",` + "\r\n" +
+			` "exp":1300819380,` + "\r\n" +
+			` "http://example.com/is_root":true}`))
 
-// 		protected2 := NewHeader()
-// 		protected2.SetAlgorithm(jwa.ES256)
-// 		header2 := NewHeader()
-// 		header2.SetKeyID("e9bc097a-ce51-4036-9562-d2ade882db0d")
-// 		rawKey2 := `{"kty":"EC",` +
-// 			`"crv":"P-256",` +
-// 			`"x":"f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvRVEU",` +
-// 			`"y":"x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0",` +
-// 			`"d":"jpsQnnGQmL-YBIffH1136cspYG6-0iY7X1fCE9-E9LI"` +
-// 			`}`
-// 		key2, err := jwk.ParseKey([]byte(rawKey2))
-// 		if err != nil {
-// 			t.Fatal(err)
-// 		}
-// 		if err := msg.Sign(protected2, header2, jwa.ES256.New().NewSigningKey(key2)); err != nil {
-// 			t.Fatal(err)
-// 		}
+		protected2 := NewHeader()
+		protected2.SetAlgorithm(jwa.ES256)
+		header2 := NewHeader()
+		header2.SetKeyID("e9bc097a-ce51-4036-9562-d2ade882db0d")
+		rawKey2 := `{"kty":"EC",` +
+			`"crv":"P-256",` +
+			`"x":"f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvRVEU",` +
+			`"y":"x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0",` +
+			`"d":"jpsQnnGQmL-YBIffH1136cspYG6-0iY7X1fCE9-E9LI"` +
+			`}`
+		key2, err := jwk.ParseKey([]byte(rawKey2))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := msg.Sign(protected2, header2, jwa.ES256.New().NewSigningKey(key2)); err != nil {
+			t.Fatal(err)
+		}
 
-// 		data, err := msg.MarshalJSON()
-// 		if err != nil {
-// 			t.Fatal(err)
-// 		}
+		data, err := msg.MarshalJSON()
+		if err != nil {
+			t.Fatal(err)
+		}
 
-// 		var tmp any
-// 		if err := json.Unmarshal(data, &tmp); err != nil {
-// 			t.Fatal(err)
-// 		}
-// 	})
+		var tmp any
+		if err := json.Unmarshal(data, &tmp); err != nil {
+			t.Fatal(err)
+		}
+	})
 
-// 	// test for b64 header parameter.
-// 	t.Run("RFC 7797 Section 4.2. Example with Header Parameters", func(t *testing.T) {
-// 		msg := NewRawMessage([]byte("$.02"))
-// 		header := NewHeader()
-// 		header.SetAlgorithm(jwa.HS256)
-// 		header.SetBase64(false)
+	// test for b64 header parameter.
+	t.Run("RFC 7797 Section 4.2. Example with Header Parameters", func(t *testing.T) {
+		msg := NewRawMessage([]byte("$.02"))
+		header := NewHeader()
+		header.SetAlgorithm(jwa.HS256)
+		header.SetBase64(false)
 
-// 		rawKey := `{` +
-// 			`"kty":"oct",` +
-// 			`"k":"AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75` +
-// 			`aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow"` +
-// 			`}`
-// 		key, err := jwk.ParseKey([]byte(rawKey))
-// 		if err != nil {
-// 			t.Fatal(err)
-// 		}
+		rawKey := `{` +
+			`"kty":"oct",` +
+			`"k":"AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75` +
+			`aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow"` +
+			`}`
+		key, err := jwk.ParseKey([]byte(rawKey))
+		if err != nil {
+			t.Fatal(err)
+		}
 
-// 		if err := msg.Sign(header, nil, jwa.HS256.New().NewSigningKey(key)); err != nil {
-// 			t.Fatal(err)
-// 		}
+		if err := msg.Sign(header, nil, jwa.HS256.New().NewSigningKey(key)); err != nil {
+			t.Fatal(err)
+		}
 
-// 		got, err := msg.MarshalJSON()
-// 		if err != nil {
-// 			t.Fatal(err)
-// 		}
-// 		want := `{` +
-// 			`"payload":` +
-// 			`"$.02",` +
-// 			`"protected":` +
-// 			`"eyJhbGciOiJIUzI1NiIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19",` +
-// 			`"signature":` +
-// 			`"A5dxf2s96_n5FLueVuW1Z_vh161FwXZC4YLPff6dmDY"` +
-// 			`}`
-// 		if string(got) != want {
-// 			t.Errorf("want %s, got %s", want, got)
-// 		}
-// 	})
-// }
+		got, err := msg.MarshalJSON()
+		if err != nil {
+			t.Fatal(err)
+		}
+		want := `{` +
+			`"payload":` +
+			`"$.02",` +
+			`"protected":` +
+			`"eyJhbGciOiJIUzI1NiIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19",` +
+			`"signature":` +
+			`"A5dxf2s96_n5FLueVuW1Z_vh161FwXZC4YLPff6dmDY"` +
+			`}`
+		if string(got) != want {
+			t.Errorf("want %s, got %s", want, got)
+		}
+	})
+}
 
-// func TestSign(t *testing.T) {
-// 	t.Run("RFC 7515 Appendix A.1 Example JWS Using HMAC SHA-256", func(t *testing.T) {
-// 		rawKey := `{"kty":"oct",` +
-// 			`"k":"AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75` +
-// 			`aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow"` +
-// 			`}`
-// 		key, err := jwk.ParseKey([]byte(rawKey))
-// 		if err != nil {
-// 			t.Fatal(err)
-// 		}
-// 		k := jwa.HS256.New().NewSigningKey(key)
-// 		h := NewHeader()
-// 		h.SetAlgorithm(jwa.HS256)
-// 		h.SetType("JWT")
-// 		payload := []byte(`{"iss":"joe",` + "\r\n" +
-// 			` "exp":1300819380,` + "\r\n" +
-// 			` "http://example.com/is_root":true}`)
-// 		msg := NewMessage(payload)
-// 		if err := msg.Sign(h, nil, k); err != nil {
-// 			t.Fatal(err)
-// 		}
-// 		got, err := msg.Compact()
-// 		if err != nil {
-// 			t.Fatal(err)
-// 		}
+func TestSign(t *testing.T) {
+	t.Run("RFC 7515 Appendix A.1 Example JWS Using HMAC SHA-256", func(t *testing.T) {
+		rawKey := `{"kty":"oct",` +
+			`"k":"AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75` +
+			`aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow"` +
+			`}`
+		key, err := jwk.ParseKey([]byte(rawKey))
+		if err != nil {
+			t.Fatal(err)
+		}
+		k := jwa.HS256.New().NewSigningKey(key)
+		h := NewHeader()
+		h.SetAlgorithm(jwa.HS256)
+		h.SetType("JWT")
+		payload := []byte(`{"iss":"joe",` + "\r\n" +
+			` "exp":1300819380,` + "\r\n" +
+			` "http://example.com/is_root":true}`)
+		msg := NewMessage(payload)
+		if err := msg.Sign(h, nil, k); err != nil {
+			t.Fatal(err)
+		}
+		got, err := msg.Compact()
+		if err != nil {
+			t.Fatal(err)
+		}
 
-// 		// It is not same with Appendix A.1 because JOSE header is compact encoded here.
-// 		want := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9" +
-// 			"." +
-// 			"eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFt" +
-// 			"cGxlLmNvbS9pc19yb290Ijp0cnVlfQ" +
-// 			"." +
-// 			"SfgggA-oZk7ztlq1i8Uz5VhmPmustakoDa9wAf8uHyQ"
-// 		if string(got) != want {
-// 			t.Errorf("want %s, got %s", want, got)
-// 		}
-// 	})
+		// It is not same with Appendix A.1 because JOSE header is compact encoded here.
+		want := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9" +
+			"." +
+			"eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFt" +
+			"cGxlLmNvbS9pc19yb290Ijp0cnVlfQ" +
+			"." +
+			"SfgggA-oZk7ztlq1i8Uz5VhmPmustakoDa9wAf8uHyQ"
+		if string(got) != want {
+			t.Errorf("want %s, got %s", want, got)
+		}
+	})
 
-// 	t.Run("RFC 7515 Appendix A.2. Example JWS Using RSASSA-PKCS1-v1_5 SHA-256", func(t *testing.T) {
-// 		rawKey := `{"kty":"RSA",` +
-// 			`"n":"ofgWCuLjybRlzo0tZWJjNiuSfb4p4fAkd_wWJcyQoTbji9k0l8W26mPddx` +
-// 			`HmfHQp-Vaw-4qPCJrcS2mJPMEzP1Pt0Bm4d4QlL-yRT-SFd2lZS-pCgNMs` +
-// 			`D1W_YpRPEwOWvG6b32690r2jZ47soMZo9wGzjb_7OMg0LOL-bSf63kpaSH` +
-// 			`SXndS5z5rexMdbBYUsLA9e-KXBdQOS-UTo7WTBEMa2R2CapHg665xsmtdV` +
-// 			`MTBQY4uDZlxvb3qCo5ZwKh9kG4LT6_I5IhlJH7aGhyxXFvUK-DWNmoudF8` +
-// 			`NAco9_h9iaGNj8q2ethFkMLs91kzk2PAcDTW9gb54h4FRWyuXpoQ",` +
-// 			`"e":"AQAB",` +
-// 			`"d":"Eq5xpGnNCivDflJsRQBXHx1hdR1k6Ulwe2JZD50LpXyWPEAeP88vLNO97I` +
-// 			`jlA7_GQ5sLKMgvfTeXZx9SE-7YwVol2NXOoAJe46sui395IW_GO-pWJ1O0` +
-// 			`BkTGoVEn2bKVRUCgu-GjBVaYLU6f3l9kJfFNS3E0QbVdxzubSu3Mkqzjkn` +
-// 			`439X0M_V51gfpRLI9JYanrC4D4qAdGcopV_0ZHHzQlBjudU2QvXt4ehNYT` +
-// 			`CBr6XCLQUShb1juUO1ZdiYoFaFQT5Tw8bGUl_x_jTj3ccPDVZFD9pIuhLh` +
-// 			`BOneufuBiB4cS98l2SR_RQyGWSeWjnczT0QU91p1DhOVRuOopznQ",` +
-// 			`"p":"4BzEEOtIpmVdVEZNCqS7baC4crd0pqnRH_5IB3jw3bcxGn6QLvnEtfdUdi` +
-// 			`YrqBdss1l58BQ3KhooKeQTa9AB0Hw_Py5PJdTJNPY8cQn7ouZ2KKDcmnPG` +
-// 			`BY5t7yLc1QlQ5xHdwW1VhvKn-nXqhJTBgIPgtldC-KDV5z-y2XDwGUc",` +
-// 			`"q":"uQPEfgmVtjL0Uyyx88GZFF1fOunH3-7cepKmtH4pxhtCoHqpWmT8YAmZxa` +
-// 			`ewHgHAjLYsp1ZSe7zFYHj7C6ul7TjeLQeZD_YwD66t62wDmpe_HlB-TnBA` +
-// 			`-njbglfIsRLtXlnDzQkv5dTltRJ11BKBBypeeF6689rjcJIDEz9RWdc",` +
-// 			`"dp":"BwKfV3Akq5_MFZDFZCnW-wzl-CCo83WoZvnLQwCTeDv8uzluRSnm71I3Q` +
-// 			`CLdhrqE2e9YkxvuxdBfpT_PI7Yz-FOKnu1R6HsJeDCjn12Sk3vmAktV2zb` +
-// 			`34MCdy7cpdTh_YVr7tss2u6vneTwrA86rZtu5Mbr1C1XsmvkxHQAdYo0",` +
-// 			`"dq":"h_96-mK1R_7glhsum81dZxjTnYynPbZpHziZjeeHcXYsXaaMwkOlODsWa` +
-// 			`7I9xXDoRwbKgB719rrmI2oKr6N3Do9U0ajaHF-NKJnwgjMd2w9cjz3_-ky` +
-// 			`NlxAr2v4IKhGNpmM5iIgOS1VZnOZ68m6_pbLBSp3nssTdlqvd0tIiTHU",` +
-// 			`"qi":"IYd7DHOhrWvxkwPQsRM2tOgrjbcrfvtQJipd-DlcxyVuuM9sQLdgjVk2o` +
-// 			`y26F0EmpScGLq2MowX7fhd_QJQ3ydy5cY7YIBi87w93IKLEdfnbJtoOPLU` +
-// 			`W0ITrJReOgo1cq9SbsxYawBgfp_gh6A5603k2-ZQwVK0JKSHuLFkuQ3U"` +
-// 			`}`
-// 		key, err := jwk.ParseKey([]byte(rawKey))
-// 		if err != nil {
-// 			t.Fatal(err)
-// 		}
-// 		k := jwa.RS256.New().NewSigningKey(key)
-// 		h := NewHeader()
-// 		h.SetAlgorithm(jwa.RS256)
-// 		h.SetType("JWT")
-// 		payload := []byte(`{"iss":"joe",` + "\r\n" +
-// 			` "exp":1300819380,` + "\r\n" +
-// 			` "http://example.com/is_root":true}`)
-// 		msg := NewMessage(payload)
-// 		if err := msg.Sign(h, nil, k); err != nil {
-// 			t.Fatal(err)
-// 		}
-// 		got, err := msg.Compact()
-// 		if err != nil {
-// 			t.Fatal(err)
-// 		}
+	t.Run("RFC 7515 Appendix A.2. Example JWS Using RSASSA-PKCS1-v1_5 SHA-256", func(t *testing.T) {
+		rawKey := `{"kty":"RSA",` +
+			`"n":"ofgWCuLjybRlzo0tZWJjNiuSfb4p4fAkd_wWJcyQoTbji9k0l8W26mPddx` +
+			`HmfHQp-Vaw-4qPCJrcS2mJPMEzP1Pt0Bm4d4QlL-yRT-SFd2lZS-pCgNMs` +
+			`D1W_YpRPEwOWvG6b32690r2jZ47soMZo9wGzjb_7OMg0LOL-bSf63kpaSH` +
+			`SXndS5z5rexMdbBYUsLA9e-KXBdQOS-UTo7WTBEMa2R2CapHg665xsmtdV` +
+			`MTBQY4uDZlxvb3qCo5ZwKh9kG4LT6_I5IhlJH7aGhyxXFvUK-DWNmoudF8` +
+			`NAco9_h9iaGNj8q2ethFkMLs91kzk2PAcDTW9gb54h4FRWyuXpoQ",` +
+			`"e":"AQAB",` +
+			`"d":"Eq5xpGnNCivDflJsRQBXHx1hdR1k6Ulwe2JZD50LpXyWPEAeP88vLNO97I` +
+			`jlA7_GQ5sLKMgvfTeXZx9SE-7YwVol2NXOoAJe46sui395IW_GO-pWJ1O0` +
+			`BkTGoVEn2bKVRUCgu-GjBVaYLU6f3l9kJfFNS3E0QbVdxzubSu3Mkqzjkn` +
+			`439X0M_V51gfpRLI9JYanrC4D4qAdGcopV_0ZHHzQlBjudU2QvXt4ehNYT` +
+			`CBr6XCLQUShb1juUO1ZdiYoFaFQT5Tw8bGUl_x_jTj3ccPDVZFD9pIuhLh` +
+			`BOneufuBiB4cS98l2SR_RQyGWSeWjnczT0QU91p1DhOVRuOopznQ",` +
+			`"p":"4BzEEOtIpmVdVEZNCqS7baC4crd0pqnRH_5IB3jw3bcxGn6QLvnEtfdUdi` +
+			`YrqBdss1l58BQ3KhooKeQTa9AB0Hw_Py5PJdTJNPY8cQn7ouZ2KKDcmnPG` +
+			`BY5t7yLc1QlQ5xHdwW1VhvKn-nXqhJTBgIPgtldC-KDV5z-y2XDwGUc",` +
+			`"q":"uQPEfgmVtjL0Uyyx88GZFF1fOunH3-7cepKmtH4pxhtCoHqpWmT8YAmZxa` +
+			`ewHgHAjLYsp1ZSe7zFYHj7C6ul7TjeLQeZD_YwD66t62wDmpe_HlB-TnBA` +
+			`-njbglfIsRLtXlnDzQkv5dTltRJ11BKBBypeeF6689rjcJIDEz9RWdc",` +
+			`"dp":"BwKfV3Akq5_MFZDFZCnW-wzl-CCo83WoZvnLQwCTeDv8uzluRSnm71I3Q` +
+			`CLdhrqE2e9YkxvuxdBfpT_PI7Yz-FOKnu1R6HsJeDCjn12Sk3vmAktV2zb` +
+			`34MCdy7cpdTh_YVr7tss2u6vneTwrA86rZtu5Mbr1C1XsmvkxHQAdYo0",` +
+			`"dq":"h_96-mK1R_7glhsum81dZxjTnYynPbZpHziZjeeHcXYsXaaMwkOlODsWa` +
+			`7I9xXDoRwbKgB719rrmI2oKr6N3Do9U0ajaHF-NKJnwgjMd2w9cjz3_-ky` +
+			`NlxAr2v4IKhGNpmM5iIgOS1VZnOZ68m6_pbLBSp3nssTdlqvd0tIiTHU",` +
+			`"qi":"IYd7DHOhrWvxkwPQsRM2tOgrjbcrfvtQJipd-DlcxyVuuM9sQLdgjVk2o` +
+			`y26F0EmpScGLq2MowX7fhd_QJQ3ydy5cY7YIBi87w93IKLEdfnbJtoOPLU` +
+			`W0ITrJReOgo1cq9SbsxYawBgfp_gh6A5603k2-ZQwVK0JKSHuLFkuQ3U"` +
+			`}`
+		key, err := jwk.ParseKey([]byte(rawKey))
+		if err != nil {
+			t.Fatal(err)
+		}
+		k := jwa.RS256.New().NewSigningKey(key)
+		h := NewHeader()
+		h.SetAlgorithm(jwa.RS256)
+		h.SetType("JWT")
+		payload := []byte(`{"iss":"joe",` + "\r\n" +
+			` "exp":1300819380,` + "\r\n" +
+			` "http://example.com/is_root":true}`)
+		msg := NewMessage(payload)
+		if err := msg.Sign(h, nil, k); err != nil {
+			t.Fatal(err)
+		}
+		got, err := msg.Compact()
+		if err != nil {
+			t.Fatal(err)
+		}
 
-// 		// It is not same with Appendix A.2 because JOSE header is compact encoded here.
-// 		want := "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9" +
-// 			"." +
-// 			"eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFt" +
-// 			"cGxlLmNvbS9pc19yb290Ijp0cnVlfQ" +
-// 			"." +
-// 			"HVeJTJBURMOJaxWlJmcYE9pnd2Encfn4iYlTS6c9zc0pg5nDpC3vgDkdblOSVu8s" +
-// 			"OYXnCgfpfFxsUn8golAZD9VKZnmd7-Z3RT54aW12zDCLkZUsqKIe3yFSzLzPy-31" +
-// 			"KXolCsqeQgXWnq_HT-gf9I3-FGRvik6ty-YfgjxLvJsgzHwzWWohemAWbfA6lSgZ" +
-// 			"jPEScVMxLQ6z7Uda9BxT8alpUHbJhEbU_3becu_tezD7vsscYp8pPd52LRWMYYIE" +
-// 			"NYApMx4XviHYPG1AIdEPq7TeVFXPBSf_Jops0LeT1B9pCI3IbuCa-Wd4hrhQM1V8" +
-// 			"QaYzD6k11fesYCXZU35kxw"
-// 		if string(got) != want {
-// 			t.Errorf("want %s, got %s", want, got)
-// 		}
-// 	})
+		// It is not same with Appendix A.2 because JOSE header is compact encoded here.
+		want := "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9" +
+			"." +
+			"eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFt" +
+			"cGxlLmNvbS9pc19yb290Ijp0cnVlfQ" +
+			"." +
+			"HVeJTJBURMOJaxWlJmcYE9pnd2Encfn4iYlTS6c9zc0pg5nDpC3vgDkdblOSVu8s" +
+			"OYXnCgfpfFxsUn8golAZD9VKZnmd7-Z3RT54aW12zDCLkZUsqKIe3yFSzLzPy-31" +
+			"KXolCsqeQgXWnq_HT-gf9I3-FGRvik6ty-YfgjxLvJsgzHwzWWohemAWbfA6lSgZ" +
+			"jPEScVMxLQ6z7Uda9BxT8alpUHbJhEbU_3becu_tezD7vsscYp8pPd52LRWMYYIE" +
+			"NYApMx4XviHYPG1AIdEPq7TeVFXPBSf_Jops0LeT1B9pCI3IbuCa-Wd4hrhQM1V8" +
+			"QaYzD6k11fesYCXZU35kxw"
+		if string(got) != want {
+			t.Errorf("want %s, got %s", want, got)
+		}
+	})
 
-// 	t.Run("RFC 7515 Appendix A.5 Example Unsecured JWS", func(t *testing.T) {
-// 		h := NewHeader()
-// 		h.SetAlgorithm(jwa.None)
-// 		h.SetType("JWT")
-// 		payload := []byte(`{"iss":"joe",` + "\r\n" +
-// 			` "exp":1300819380,` + "\r\n" +
-// 			` "http://example.com/is_root":true}`)
-// 		k := jwa.None.New().NewSigningKey(nil)
-// 		msg := NewMessage(payload)
-// 		if err := msg.Sign(h, nil, k); err != nil {
-// 			t.Fatal(err)
-// 		}
-// 		got, err := msg.Compact()
-// 		if err != nil {
-// 			t.Fatal(err)
-// 		}
+	t.Run("RFC 7515 Appendix A.5 Example Unsecured JWS", func(t *testing.T) {
+		h := NewHeader()
+		h.SetAlgorithm(jwa.None)
+		h.SetType("JWT")
+		payload := []byte(`{"iss":"joe",` + "\r\n" +
+			` "exp":1300819380,` + "\r\n" +
+			` "http://example.com/is_root":true}`)
+		k := jwa.None.New().NewSigningKey(nil)
+		msg := NewMessage(payload)
+		if err := msg.Sign(h, nil, k); err != nil {
+			t.Fatal(err)
+		}
+		got, err := msg.Compact()
+		if err != nil {
+			t.Fatal(err)
+		}
 
-// 		// It is not same with Appendix A.5 because JOSE header is compact encoded here.
-// 		want := "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0" +
-// 			"." +
-// 			"eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFt" +
-// 			"cGxlLmNvbS9pc19yb290Ijp0cnVlfQ" +
-// 			"."
-// 		if string(got) != want {
-// 			t.Errorf("want %s, got %s", want, got)
-// 		}
-// 	})
+		// It is not same with Appendix A.5 because JOSE header is compact encoded here.
+		want := "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0" +
+			"." +
+			"eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFt" +
+			"cGxlLmNvbS9pc19yb290Ijp0cnVlfQ" +
+			"."
+		if string(got) != want {
+			t.Errorf("want %s, got %s", want, got)
+		}
+	})
 
-// 	t.Run("RFC 7797 Section 4.2. Example with Header Parameter", func(t *testing.T) {
-// 		rawKey := `{` +
-// 			`"kty":"oct",` +
-// 			`"k":"AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75` +
-// 			`aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow"` +
-// 			`}`
-// 		key, err := jwk.ParseKey([]byte(rawKey))
-// 		if err != nil {
-// 			t.Fatal(err)
-// 		}
-// 		k := jwa.HS256.New().NewSigningKey(key)
-// 		h := NewHeader()
-// 		h.SetAlgorithm(jwa.HS256)
-// 		h.SetType("JWT")
-// 		msg := NewRawMessage([]byte("$.02"))
-// 		if err := msg.Sign(h, nil, k); err != nil {
-// 			t.Fatal(err)
-// 		}
-// 		got, err := msg.Compact()
-// 		if err != nil {
-// 			t.Fatal(err)
-// 		}
-// 		want := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9" +
-// 			"." +
-// 			"." +
-// 			"oa1M-6Wbmk9q4SheILHROv561Ba7U1gVKuIkXZiJcic"
-// 		if string(got) != want {
-// 			t.Errorf("want %s, got %s", want, got)
-// 		}
-// 	})
-// }
+	t.Run("RFC 7797 Section 4.2. Example with Header Parameter", func(t *testing.T) {
+		rawKey := `{` +
+			`"kty":"oct",` +
+			`"k":"AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75` +
+			`aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow"` +
+			`}`
+		key, err := jwk.ParseKey([]byte(rawKey))
+		if err != nil {
+			t.Fatal(err)
+		}
+		k := jwa.HS256.New().NewSigningKey(key)
+		h := NewHeader()
+		h.SetAlgorithm(jwa.HS256)
+		h.SetType("JWT")
+		msg := NewRawMessage([]byte("$.02"))
+		if err := msg.Sign(h, nil, k); err != nil {
+			t.Fatal(err)
+		}
+		got, err := msg.Compact()
+		if err != nil {
+			t.Fatal(err)
+		}
+		want := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9" +
+			"." +
+			"." +
+			"oa1M-6Wbmk9q4SheILHROv561Ba7U1gVKuIkXZiJcic"
+		if string(got) != want {
+			t.Errorf("want %s, got %s", want, got)
+		}
+	})
+}
 
-// func TestKeyTypeMissmatch(t *testing.T) {
-// 	// from RFC 7515 Appendix A.3 Example JWS Using ECDSA P-256 SHA-256
-// 	raw := []byte(
-// 		"eyJhbGciOiJFUzI1NiJ9" + // {"alg":"ES256"}
-// 			"." +
-// 			"eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFt" +
-// 			"cGxlLmNvbS9pc19yb290Ijp0cnVlfQ" +
-// 			"." +
-// 			"DtEhU3ljbEg8L38VWAfUAqOyKAM6-Xx-F4GawxaepmXFCgfTjDxw5djxLa8ISlSA" +
-// 			"pmWQxfKTUJqPP3-Kg6NU1Q",
-// 	)
+func TestKeyTypeMissmatch(t *testing.T) {
+	// from RFC 7515 Appendix A.3 Example JWS Using ECDSA P-256 SHA-256
+	raw := []byte(
+		"eyJhbGciOiJFUzI1NiJ9" + // {"alg":"ES256"}
+			"." +
+			"eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFt" +
+			"cGxlLmNvbS9pc19yb290Ijp0cnVlfQ" +
+			"." +
+			"DtEhU3ljbEg8L38VWAfUAqOyKAM6-Xx-F4GawxaepmXFCgfTjDxw5djxLa8ISlSA" +
+			"pmWQxfKTUJqPP3-Kg6NU1Q",
+	)
 
-// 	// RFC 7517 A.1. Example Public Keys (RSA)
-// 	rawKey := `{"kty":"RSA",` +
-// 		`"n":"0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx` +
-// 		`4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMs` +
-// 		`tn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2` +
-// 		`QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbI` +
-// 		`SD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqb` +
-// 		`w0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw",` +
-// 		`"e":"AQAB",` +
-// 		`"alg":"RS256",` +
-// 		`"kid":"2011-04-29"}`
-// 	key, err := jwk.ParseKey([]byte(rawKey))
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	msg, err := Parse(raw)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	_, _, err = msg.Verify(FindKeyFunc(func(header, _ *Header) (sig.SigningKey, error) {
-// 		alg := header.Algorithm().New()
-// 		return alg.NewSigningKey(key), nil
-// 	}))
-// 	if err == nil {
-// 		t.Error("want error, got nil")
-// 	}
-// }
+	// RFC 7517 A.1. Example Public Keys (RSA)
+	rawKey := `{"kty":"RSA",` +
+		`"n":"0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx` +
+		`4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMs` +
+		`tn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2` +
+		`QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbI` +
+		`SD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqb` +
+		`w0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw",` +
+		`"e":"AQAB",` +
+		`"alg":"RS256",` +
+		`"kid":"2011-04-29"}`
+	key, err := jwk.ParseKey([]byte(rawKey))
+	if err != nil {
+		t.Fatal(err)
+	}
+	v := &Verifier{
+		AlgorithmVerfier: AllowedAlgorithms{jwa.ES256},
+		KeyFinder:        &JWKKeyFinder{JWK: key},
+	}
+	msg, err := Parse(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _, err = v.Verify(context.Background(), msg)
+	if err == nil {
+		t.Error("want error, got nil")
+	}
+}

--- a/jws/jws_test.go
+++ b/jws/jws_test.go
@@ -34,7 +34,8 @@ func TestVerify(t *testing.T) {
 			t.Fatal(err)
 		}
 		v := &Verifier{
-			KeyFinder: &JWKKeyFinder{JWK: key},
+			AlgorithmVerfier: AllowedAlgorithms{jwa.HS256},
+			KeyFinder:        &JWKKeyFinder{JWK: key},
 		}
 
 		msg, err := Parse(raw)
@@ -110,7 +111,8 @@ func TestVerify(t *testing.T) {
 			t.Fatal(err)
 		}
 		v := &Verifier{
-			KeyFinder: &JWKKeyFinder{JWK: key},
+			AlgorithmVerfier: AllowedAlgorithms{jwa.RS256},
+			KeyFinder:        &JWKKeyFinder{JWK: key},
 		}
 
 		msg, err := Parse(raw)
@@ -155,7 +157,8 @@ func TestVerify(t *testing.T) {
 			t.Fatal(err)
 		}
 		v := &Verifier{
-			KeyFinder: &JWKKeyFinder{JWK: key},
+			AlgorithmVerfier: AllowedAlgorithms{jwa.EdDSA},
+			KeyFinder:        &JWKKeyFinder{JWK: key},
 		}
 
 		msg, err := Parse(raw)
@@ -206,7 +209,8 @@ func TestVerify(t *testing.T) {
 			t.Fatal(err)
 		}
 		v := &Verifier{
-			KeyFinder: &JWKKeyFinder{JWK: key},
+			AlgorithmVerfier: AllowedAlgorithms{jwa.EdDSA},
+			KeyFinder:        &JWKKeyFinder{JWK: key},
 		}
 
 		msg, err := Parse(raw)
@@ -241,6 +245,7 @@ func TestVerify(t *testing.T) {
 			t.Fatal(err)
 		}
 		v := &Verifier{
+			AlgorithmVerfier: AllowedAlgorithms{jwa.None},
 			KeyFinder: FindKeyFunc(func(ctx context.Context, header, _ *Header) (sig.SigningKey, error) {
 				return header.Algorithm().New().NewSigningKey(nil), nil
 			}),
@@ -271,7 +276,8 @@ func TestVerify(t *testing.T) {
 			t.Fatal(err)
 		}
 		v := &Verifier{
-			KeyFinder: &JWKKeyFinder{JWK: key},
+			AlgorithmVerfier: AllowedAlgorithms{jwa.EdDSA},
+			KeyFinder:        &JWKKeyFinder{JWK: key},
 		}
 
 		raw := "eyJhbGciOiJFZERTQSJ9" +

--- a/jws/jws_test.go
+++ b/jws/jws_test.go
@@ -159,7 +159,7 @@ func TestVerify(t *testing.T) {
 			t.Fatal(err)
 		}
 		v := &Verifier{
-			AlgorithmVerfier: AllowedAlgorithms{jwa.EdDSA},
+			AlgorithmVerfier: AllowedAlgorithms{jwa.ES256},
 			KeyFinder:        &JWKKeyFinder{JWK: key},
 		}
 
@@ -211,7 +211,7 @@ func TestVerify(t *testing.T) {
 			t.Fatal(err)
 		}
 		v := &Verifier{
-			AlgorithmVerfier: AllowedAlgorithms{jwa.EdDSA},
+			AlgorithmVerfier: AllowedAlgorithms{jwa.ES512},
 			KeyFinder:        &JWKKeyFinder{JWK: key},
 		}
 

--- a/jws/jws_test.go
+++ b/jws/jws_test.go
@@ -2,8 +2,7 @@ package jws
 
 import (
 	"bytes"
-	"encoding/json"
-	"errors"
+	"context"
 	"testing"
 
 	"github.com/shogo82148/goat/jwa"
@@ -34,15 +33,15 @@ func TestVerify(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+		v := &Verifier{
+			KeyFinder: &JWKKeyFinder{JWK: key},
+		}
 
 		msg, err := Parse(raw)
 		if err != nil {
 			t.Fatal(err)
 		}
-		header, payload, err := msg.Verify(FindKeyFunc(func(header, _ *Header) (sig.SigningKey, error) {
-			alg := header.Algorithm().New()
-			return alg.NewSigningKey(key), nil
-		}))
+		header, payload, err := v.Verify(context.Background(), msg)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -110,14 +109,15 @@ func TestVerify(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+		v := &Verifier{
+			KeyFinder: &JWKKeyFinder{JWK: key},
+		}
+
 		msg, err := Parse(raw)
 		if err != nil {
 			t.Fatal(err)
 		}
-		header, payload, err := msg.Verify(FindKeyFunc(func(header, _ *Header) (sig.SigningKey, error) {
-			alg := header.Algorithm().New()
-			return alg.NewSigningKey(key), nil
-		}))
+		header, payload, err := v.Verify(context.Background(), msg)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -154,14 +154,18 @@ func TestVerify(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+		v := &Verifier{
+			KeyFinder: &JWKKeyFinder{JWK: key},
+		}
+
 		msg, err := Parse(raw)
 		if err != nil {
 			t.Fatal(err)
 		}
-		header, payload, err := msg.Verify(FindKeyFunc(func(header, _ *Header) (sig.SigningKey, error) {
-			alg := header.Algorithm().New()
-			return alg.NewSigningKey(key), nil
-		}))
+		header, payload, err := v.Verify(context.Background(), msg)
+		if err != nil {
+			t.Fatal(err)
+		}
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -201,14 +205,15 @@ func TestVerify(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+		v := &Verifier{
+			KeyFinder: &JWKKeyFinder{JWK: key},
+		}
+
 		msg, err := Parse(raw)
 		if err != nil {
 			t.Fatal(err)
 		}
-		header, payload, err := msg.Verify(FindKeyFunc(func(header, _ *Header) (sig.SigningKey, error) {
-			alg := header.Algorithm().New()
-			return alg.NewSigningKey(key), nil
-		}))
+		header, payload, err := v.Verify(context.Background(), msg)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -235,10 +240,13 @@ func TestVerify(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		header, payload, err := msg.Verify(FindKeyFunc(func(header, _ *Header) (sig.SigningKey, error) {
-			alg := header.Algorithm().New()
-			return alg.NewSigningKey(nil), nil
-		}))
+		v := &Verifier{
+			KeyFinder: FindKeyFunc(func(ctx context.Context, header, _ *Header) (sig.SigningKey, error) {
+				return header.Algorithm().New().NewSigningKey(nil), nil
+			}),
+		}
+
+		header, payload, err := v.Verify(context.Background(), msg)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -262,6 +270,10 @@ func TestVerify(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+		v := &Verifier{
+			KeyFinder: &JWKKeyFinder{JWK: key},
+		}
+
 		raw := "eyJhbGciOiJFZERTQSJ9" +
 			"." +
 			"RXhhbXBsZSBvZiBFZDI1NTE5IHNpZ25pbmc" +
@@ -272,10 +284,7 @@ func TestVerify(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		header, payload, err := msg.Verify(FindKeyFunc(func(header, _ *Header) (sig.SigningKey, error) {
-			alg := header.Algorithm().New()
-			return alg.NewSigningKey(key), nil
-		}))
+		header, payload, err := v.Verify(context.Background(), msg)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -291,540 +300,540 @@ func TestVerify(t *testing.T) {
 	})
 }
 
-func TestUnmarshalJSON(t *testing.T) {
-	t.Run("RFC 7515 Appendix A.6. Example JWS Using General JWS JSON Serialization", func(t *testing.T) {
-		raw := `{` +
-			`"payload":` +
-			`"eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGF` +
-			`tcGxlLmNvbS9pc19yb290Ijp0cnVlfQ",` +
-			`"signatures":[` +
-			`{"protected":"eyJhbGciOiJSUzI1NiJ9",` +
-			`"header":` +
-			`{"kid":"2010-12-29"},` +
-			`"signature":` +
-			`"cC4hiUPoj9Eetdgtv3hF80EGrhuB__dzERat0XF9g2VtQgr9PJbu3XOiZj5RZ` +
-			`mh7AAuHIm4Bh-0Qc_lF5YKt_O8W2Fp5jujGbds9uJdbF9CUAr7t1dnZcAcQjb` +
-			`KBYNX4BAynRFdiuB--f_nZLgrnbyTyWzO75vRK5h6xBArLIARNPvkSjtQBMHl` +
-			`b1L07Qe7K0GarZRmB_eSN9383LcOLn6_dO--xi12jzDwusC-eOkHWEsqtFZES` +
-			`c6BfI7noOPqvhJ1phCnvWh6IeYI2w9QOYEUipUTI8np6LbgGY9Fs98rqVt5AX` +
-			`LIhWkWywlVmtVrBp0igcN_IoypGlUPQGe77Rw"},` +
-			`{"protected":"eyJhbGciOiJFUzI1NiJ9",` +
-			`"header":` +
-			`{"kid":"e9bc097a-ce51-4036-9562-d2ade882db0d"},` +
-			`"signature":` +
-			`"DtEhU3ljbEg8L38VWAfUAqOyKAM6-Xx-F4GawxaepmXFCgfTjDxw5djxLa8IS` +
-			`lSApmWQxfKTUJqPP3-Kg6NU1Q"}]` +
-			`}`
-		var msg Message
-		if err := msg.UnmarshalJSON([]byte(raw)); err != nil {
-			t.Fatal(err)
-		}
+// func TestUnmarshalJSON(t *testing.T) {
+// 	t.Run("RFC 7515 Appendix A.6. Example JWS Using General JWS JSON Serialization", func(t *testing.T) {
+// 		raw := `{` +
+// 			`"payload":` +
+// 			`"eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGF` +
+// 			`tcGxlLmNvbS9pc19yb290Ijp0cnVlfQ",` +
+// 			`"signatures":[` +
+// 			`{"protected":"eyJhbGciOiJSUzI1NiJ9",` +
+// 			`"header":` +
+// 			`{"kid":"2010-12-29"},` +
+// 			`"signature":` +
+// 			`"cC4hiUPoj9Eetdgtv3hF80EGrhuB__dzERat0XF9g2VtQgr9PJbu3XOiZj5RZ` +
+// 			`mh7AAuHIm4Bh-0Qc_lF5YKt_O8W2Fp5jujGbds9uJdbF9CUAr7t1dnZcAcQjb` +
+// 			`KBYNX4BAynRFdiuB--f_nZLgrnbyTyWzO75vRK5h6xBArLIARNPvkSjtQBMHl` +
+// 			`b1L07Qe7K0GarZRmB_eSN9383LcOLn6_dO--xi12jzDwusC-eOkHWEsqtFZES` +
+// 			`c6BfI7noOPqvhJ1phCnvWh6IeYI2w9QOYEUipUTI8np6LbgGY9Fs98rqVt5AX` +
+// 			`LIhWkWywlVmtVrBp0igcN_IoypGlUPQGe77Rw"},` +
+// 			`{"protected":"eyJhbGciOiJFUzI1NiJ9",` +
+// 			`"header":` +
+// 			`{"kid":"e9bc097a-ce51-4036-9562-d2ade882db0d"},` +
+// 			`"signature":` +
+// 			`"DtEhU3ljbEg8L38VWAfUAqOyKAM6-Xx-F4GawxaepmXFCgfTjDxw5djxLa8IS` +
+// 			`lSApmWQxfKTUJqPP3-Kg6NU1Q"}]` +
+// 			`}`
+// 		var msg Message
+// 		if err := msg.UnmarshalJSON([]byte(raw)); err != nil {
+// 			t.Fatal(err)
+// 		}
 
-		_, payload, err := msg.Verify(FindKeyFunc(func(protected, header *Header) (sig.SigningKey, error) {
-			if header.KeyID() != "2010-12-29" {
-				return nil, errors.New("unknown key id")
-			}
-			rawKey := `{"kty":"RSA",` +
-				`"n":"ofgWCuLjybRlzo0tZWJjNiuSfb4p4fAkd_wWJcyQoTbji9k0l8W26mPddx` +
-				`HmfHQp-Vaw-4qPCJrcS2mJPMEzP1Pt0Bm4d4QlL-yRT-SFd2lZS-pCgNMs` +
-				`D1W_YpRPEwOWvG6b32690r2jZ47soMZo9wGzjb_7OMg0LOL-bSf63kpaSH` +
-				`SXndS5z5rexMdbBYUsLA9e-KXBdQOS-UTo7WTBEMa2R2CapHg665xsmtdV` +
-				`MTBQY4uDZlxvb3qCo5ZwKh9kG4LT6_I5IhlJH7aGhyxXFvUK-DWNmoudF8` +
-				`NAco9_h9iaGNj8q2ethFkMLs91kzk2PAcDTW9gb54h4FRWyuXpoQ",` +
-				`"e":"AQAB",` +
-				`"d":"Eq5xpGnNCivDflJsRQBXHx1hdR1k6Ulwe2JZD50LpXyWPEAeP88vLNO97I` +
-				`jlA7_GQ5sLKMgvfTeXZx9SE-7YwVol2NXOoAJe46sui395IW_GO-pWJ1O0` +
-				`BkTGoVEn2bKVRUCgu-GjBVaYLU6f3l9kJfFNS3E0QbVdxzubSu3Mkqzjkn` +
-				`439X0M_V51gfpRLI9JYanrC4D4qAdGcopV_0ZHHzQlBjudU2QvXt4ehNYT` +
-				`CBr6XCLQUShb1juUO1ZdiYoFaFQT5Tw8bGUl_x_jTj3ccPDVZFD9pIuhLh` +
-				`BOneufuBiB4cS98l2SR_RQyGWSeWjnczT0QU91p1DhOVRuOopznQ",` +
-				`"p":"4BzEEOtIpmVdVEZNCqS7baC4crd0pqnRH_5IB3jw3bcxGn6QLvnEtfdUdi` +
-				`YrqBdss1l58BQ3KhooKeQTa9AB0Hw_Py5PJdTJNPY8cQn7ouZ2KKDcmnPG` +
-				`BY5t7yLc1QlQ5xHdwW1VhvKn-nXqhJTBgIPgtldC-KDV5z-y2XDwGUc",` +
-				`"q":"uQPEfgmVtjL0Uyyx88GZFF1fOunH3-7cepKmtH4pxhtCoHqpWmT8YAmZxa` +
-				`ewHgHAjLYsp1ZSe7zFYHj7C6ul7TjeLQeZD_YwD66t62wDmpe_HlB-TnBA` +
-				`-njbglfIsRLtXlnDzQkv5dTltRJ11BKBBypeeF6689rjcJIDEz9RWdc",` +
-				`"dp":"BwKfV3Akq5_MFZDFZCnW-wzl-CCo83WoZvnLQwCTeDv8uzluRSnm71I3Q` +
-				`CLdhrqE2e9YkxvuxdBfpT_PI7Yz-FOKnu1R6HsJeDCjn12Sk3vmAktV2zb` +
-				`34MCdy7cpdTh_YVr7tss2u6vneTwrA86rZtu5Mbr1C1XsmvkxHQAdYo0",` +
-				`"dq":"h_96-mK1R_7glhsum81dZxjTnYynPbZpHziZjeeHcXYsXaaMwkOlODsWa` +
-				`7I9xXDoRwbKgB719rrmI2oKr6N3Do9U0ajaHF-NKJnwgjMd2w9cjz3_-ky` +
-				`NlxAr2v4IKhGNpmM5iIgOS1VZnOZ68m6_pbLBSp3nssTdlqvd0tIiTHU",` +
-				`"qi":"IYd7DHOhrWvxkwPQsRM2tOgrjbcrfvtQJipd-DlcxyVuuM9sQLdgjVk2o` +
-				`y26F0EmpScGLq2MowX7fhd_QJQ3ydy5cY7YIBi87w93IKLEdfnbJtoOPLU` +
-				`W0ITrJReOgo1cq9SbsxYawBgfp_gh6A5603k2-ZQwVK0JKSHuLFkuQ3U"` +
-				`}`
-			key, err := jwk.ParseKey([]byte(rawKey))
-			if err != nil {
-				return nil, err
-			}
-			return protected.Algorithm().New().NewSigningKey(key), nil
-		}))
-		if err != nil {
-			t.Fatal(err)
-		}
-		want := []byte(`{"iss":"joe",` + "\r\n" +
-			` "exp":1300819380,` + "\r\n" +
-			` "http://example.com/is_root":true}`)
-		if !bytes.Equal(payload, want) {
-			t.Errorf("unexpected payload: want %q, got %q", string(want), string(payload))
-		}
+// 		_, payload, err := msg.Verify(FindKeyFunc(func(protected, header *Header) (sig.SigningKey, error) {
+// 			if header.KeyID() != "2010-12-29" {
+// 				return nil, errors.New("unknown key id")
+// 			}
+// 			rawKey := `{"kty":"RSA",` +
+// 				`"n":"ofgWCuLjybRlzo0tZWJjNiuSfb4p4fAkd_wWJcyQoTbji9k0l8W26mPddx` +
+// 				`HmfHQp-Vaw-4qPCJrcS2mJPMEzP1Pt0Bm4d4QlL-yRT-SFd2lZS-pCgNMs` +
+// 				`D1W_YpRPEwOWvG6b32690r2jZ47soMZo9wGzjb_7OMg0LOL-bSf63kpaSH` +
+// 				`SXndS5z5rexMdbBYUsLA9e-KXBdQOS-UTo7WTBEMa2R2CapHg665xsmtdV` +
+// 				`MTBQY4uDZlxvb3qCo5ZwKh9kG4LT6_I5IhlJH7aGhyxXFvUK-DWNmoudF8` +
+// 				`NAco9_h9iaGNj8q2ethFkMLs91kzk2PAcDTW9gb54h4FRWyuXpoQ",` +
+// 				`"e":"AQAB",` +
+// 				`"d":"Eq5xpGnNCivDflJsRQBXHx1hdR1k6Ulwe2JZD50LpXyWPEAeP88vLNO97I` +
+// 				`jlA7_GQ5sLKMgvfTeXZx9SE-7YwVol2NXOoAJe46sui395IW_GO-pWJ1O0` +
+// 				`BkTGoVEn2bKVRUCgu-GjBVaYLU6f3l9kJfFNS3E0QbVdxzubSu3Mkqzjkn` +
+// 				`439X0M_V51gfpRLI9JYanrC4D4qAdGcopV_0ZHHzQlBjudU2QvXt4ehNYT` +
+// 				`CBr6XCLQUShb1juUO1ZdiYoFaFQT5Tw8bGUl_x_jTj3ccPDVZFD9pIuhLh` +
+// 				`BOneufuBiB4cS98l2SR_RQyGWSeWjnczT0QU91p1DhOVRuOopznQ",` +
+// 				`"p":"4BzEEOtIpmVdVEZNCqS7baC4crd0pqnRH_5IB3jw3bcxGn6QLvnEtfdUdi` +
+// 				`YrqBdss1l58BQ3KhooKeQTa9AB0Hw_Py5PJdTJNPY8cQn7ouZ2KKDcmnPG` +
+// 				`BY5t7yLc1QlQ5xHdwW1VhvKn-nXqhJTBgIPgtldC-KDV5z-y2XDwGUc",` +
+// 				`"q":"uQPEfgmVtjL0Uyyx88GZFF1fOunH3-7cepKmtH4pxhtCoHqpWmT8YAmZxa` +
+// 				`ewHgHAjLYsp1ZSe7zFYHj7C6ul7TjeLQeZD_YwD66t62wDmpe_HlB-TnBA` +
+// 				`-njbglfIsRLtXlnDzQkv5dTltRJ11BKBBypeeF6689rjcJIDEz9RWdc",` +
+// 				`"dp":"BwKfV3Akq5_MFZDFZCnW-wzl-CCo83WoZvnLQwCTeDv8uzluRSnm71I3Q` +
+// 				`CLdhrqE2e9YkxvuxdBfpT_PI7Yz-FOKnu1R6HsJeDCjn12Sk3vmAktV2zb` +
+// 				`34MCdy7cpdTh_YVr7tss2u6vneTwrA86rZtu5Mbr1C1XsmvkxHQAdYo0",` +
+// 				`"dq":"h_96-mK1R_7glhsum81dZxjTnYynPbZpHziZjeeHcXYsXaaMwkOlODsWa` +
+// 				`7I9xXDoRwbKgB719rrmI2oKr6N3Do9U0ajaHF-NKJnwgjMd2w9cjz3_-ky` +
+// 				`NlxAr2v4IKhGNpmM5iIgOS1VZnOZ68m6_pbLBSp3nssTdlqvd0tIiTHU",` +
+// 				`"qi":"IYd7DHOhrWvxkwPQsRM2tOgrjbcrfvtQJipd-DlcxyVuuM9sQLdgjVk2o` +
+// 				`y26F0EmpScGLq2MowX7fhd_QJQ3ydy5cY7YIBi87w93IKLEdfnbJtoOPLU` +
+// 				`W0ITrJReOgo1cq9SbsxYawBgfp_gh6A5603k2-ZQwVK0JKSHuLFkuQ3U"` +
+// 				`}`
+// 			key, err := jwk.ParseKey([]byte(rawKey))
+// 			if err != nil {
+// 				return nil, err
+// 			}
+// 			return protected.Algorithm().New().NewSigningKey(key), nil
+// 		}))
+// 		if err != nil {
+// 			t.Fatal(err)
+// 		}
+// 		want := []byte(`{"iss":"joe",` + "\r\n" +
+// 			` "exp":1300819380,` + "\r\n" +
+// 			` "http://example.com/is_root":true}`)
+// 		if !bytes.Equal(payload, want) {
+// 			t.Errorf("unexpected payload: want %q, got %q", string(want), string(payload))
+// 		}
 
-		_, payload, err = msg.Verify(FindKeyFunc(func(protected, header *Header) (sig.SigningKey, error) {
-			if header.KeyID() != "e9bc097a-ce51-4036-9562-d2ade882db0d" {
-				return nil, errors.New("unknown key id")
-			}
-			rawKey := `{"kty":"EC",` +
-				`"crv":"P-256",` +
-				`"x":"f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvRVEU",` +
-				`"y":"x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0",` +
-				`"d":"jpsQnnGQmL-YBIffH1136cspYG6-0iY7X1fCE9-E9LI"` +
-				`}`
-			key, err := jwk.ParseKey([]byte(rawKey))
-			if err != nil {
-				return nil, err
-			}
-			return protected.Algorithm().New().NewSigningKey(key), nil
-		}))
-		if err != nil {
-			t.Fatal(err)
-		}
-		if !bytes.Equal(payload, want) {
-			t.Errorf("unexpected payload: want %q, got %q", string(want), string(payload))
-		}
-	})
+// 		_, payload, err = msg.Verify(FindKeyFunc(func(protected, header *Header) (sig.SigningKey, error) {
+// 			if header.KeyID() != "e9bc097a-ce51-4036-9562-d2ade882db0d" {
+// 				return nil, errors.New("unknown key id")
+// 			}
+// 			rawKey := `{"kty":"EC",` +
+// 				`"crv":"P-256",` +
+// 				`"x":"f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvRVEU",` +
+// 				`"y":"x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0",` +
+// 				`"d":"jpsQnnGQmL-YBIffH1136cspYG6-0iY7X1fCE9-E9LI"` +
+// 				`}`
+// 			key, err := jwk.ParseKey([]byte(rawKey))
+// 			if err != nil {
+// 				return nil, err
+// 			}
+// 			return protected.Algorithm().New().NewSigningKey(key), nil
+// 		}))
+// 		if err != nil {
+// 			t.Fatal(err)
+// 		}
+// 		if !bytes.Equal(payload, want) {
+// 			t.Errorf("unexpected payload: want %q, got %q", string(want), string(payload))
+// 		}
+// 	})
 
-	t.Run("RFC 7515 Appendix A.7. Example JWS Using Flattened JWS JSON Serialization", func(t *testing.T) {
-		raw := `{` +
-			`"payload":` +
-			`"eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGF` +
-			`tcGxlLmNvbS9pc19yb290Ijp0cnVlfQ",` +
-			`"protected":"eyJhbGciOiJFUzI1NiJ9",` +
-			`"header":` +
-			`{"kid":"e9bc097a-ce51-4036-9562-d2ade882db0d"},` +
-			`"signature":` +
-			`"DtEhU3ljbEg8L38VWAfUAqOyKAM6-Xx-F4GawxaepmXFCgfTjDxw5djxLa8IS` +
-			`lSApmWQxfKTUJqPP3-Kg6NU1Q"` +
-			`}`
-		var msg Message
-		if err := msg.UnmarshalJSON([]byte(raw)); err != nil {
-			t.Fatal(err)
-		}
-		_, payload, err := msg.Verify(FindKeyFunc(func(protected, header *Header) (sig.SigningKey, error) {
-			if header.KeyID() != "e9bc097a-ce51-4036-9562-d2ade882db0d" {
-				return nil, errors.New("unknown key id")
-			}
-			rawKey := `{"kty":"EC",` +
-				`"crv":"P-256",` +
-				`"x":"f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvRVEU",` +
-				`"y":"x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0",` +
-				`"d":"jpsQnnGQmL-YBIffH1136cspYG6-0iY7X1fCE9-E9LI"` +
-				`}`
-			key, err := jwk.ParseKey([]byte(rawKey))
-			if err != nil {
-				return nil, err
-			}
-			return protected.Algorithm().New().NewSigningKey(key), nil
-		}))
-		if err != nil {
-			t.Fatal(err)
-		}
-		want := []byte(`{"iss":"joe",` + "\r\n" +
-			` "exp":1300819380,` + "\r\n" +
-			` "http://example.com/is_root":true}`)
-		if !bytes.Equal(payload, want) {
-			t.Errorf("unexpected payload: want %q, got %q", string(want), string(payload))
-		}
-	})
+// 	t.Run("RFC 7515 Appendix A.7. Example JWS Using Flattened JWS JSON Serialization", func(t *testing.T) {
+// 		raw := `{` +
+// 			`"payload":` +
+// 			`"eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGF` +
+// 			`tcGxlLmNvbS9pc19yb290Ijp0cnVlfQ",` +
+// 			`"protected":"eyJhbGciOiJFUzI1NiJ9",` +
+// 			`"header":` +
+// 			`{"kid":"e9bc097a-ce51-4036-9562-d2ade882db0d"},` +
+// 			`"signature":` +
+// 			`"DtEhU3ljbEg8L38VWAfUAqOyKAM6-Xx-F4GawxaepmXFCgfTjDxw5djxLa8IS` +
+// 			`lSApmWQxfKTUJqPP3-Kg6NU1Q"` +
+// 			`}`
+// 		var msg Message
+// 		if err := msg.UnmarshalJSON([]byte(raw)); err != nil {
+// 			t.Fatal(err)
+// 		}
+// 		_, payload, err := msg.Verify(FindKeyFunc(func(protected, header *Header) (sig.SigningKey, error) {
+// 			if header.KeyID() != "e9bc097a-ce51-4036-9562-d2ade882db0d" {
+// 				return nil, errors.New("unknown key id")
+// 			}
+// 			rawKey := `{"kty":"EC",` +
+// 				`"crv":"P-256",` +
+// 				`"x":"f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvRVEU",` +
+// 				`"y":"x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0",` +
+// 				`"d":"jpsQnnGQmL-YBIffH1136cspYG6-0iY7X1fCE9-E9LI"` +
+// 				`}`
+// 			key, err := jwk.ParseKey([]byte(rawKey))
+// 			if err != nil {
+// 				return nil, err
+// 			}
+// 			return protected.Algorithm().New().NewSigningKey(key), nil
+// 		}))
+// 		if err != nil {
+// 			t.Fatal(err)
+// 		}
+// 		want := []byte(`{"iss":"joe",` + "\r\n" +
+// 			` "exp":1300819380,` + "\r\n" +
+// 			` "http://example.com/is_root":true}`)
+// 		if !bytes.Equal(payload, want) {
+// 			t.Errorf("unexpected payload: want %q, got %q", string(want), string(payload))
+// 		}
+// 	})
 
-	// test for b64 header parameter.
-	t.Run("RFC 7797 Section 4.2. Example with Header Parameters", func(t *testing.T) {
-		raw := `{` +
-			`"protected":` +
-			`"eyJhbGciOiJIUzI1NiIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19",` +
-			`"payload":` +
-			`"$.02",` +
-			`"signature":` +
-			`"A5dxf2s96_n5FLueVuW1Z_vh161FwXZC4YLPff6dmDY"` +
-			`}`
-		var msg Message
-		if err := msg.UnmarshalJSON([]byte(raw)); err != nil {
-			t.Fatal(err)
-		}
-		_, payload, err := msg.Verify(FindKeyFunc(func(protected, header *Header) (sig.SigningKey, error) {
-			rawKey := `{` +
-				`"kty":"oct",` +
-				`"k":"AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75` +
-				`aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow"` +
-				`}`
-			key, err := jwk.ParseKey([]byte(rawKey))
-			if err != nil {
-				return nil, err
-			}
-			return protected.Algorithm().New().NewSigningKey(key), nil
-		}))
-		if err != nil {
-			t.Fatal(err)
-		}
-		want := []byte(`$.02`)
-		if !bytes.Equal(payload, want) {
-			t.Errorf("unexpected payload: want %q, got %q", string(want), string(payload))
-		}
-	})
-}
+// 	// test for b64 header parameter.
+// 	t.Run("RFC 7797 Section 4.2. Example with Header Parameters", func(t *testing.T) {
+// 		raw := `{` +
+// 			`"protected":` +
+// 			`"eyJhbGciOiJIUzI1NiIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19",` +
+// 			`"payload":` +
+// 			`"$.02",` +
+// 			`"signature":` +
+// 			`"A5dxf2s96_n5FLueVuW1Z_vh161FwXZC4YLPff6dmDY"` +
+// 			`}`
+// 		var msg Message
+// 		if err := msg.UnmarshalJSON([]byte(raw)); err != nil {
+// 			t.Fatal(err)
+// 		}
+// 		_, payload, err := msg.Verify(FindKeyFunc(func(protected, header *Header) (sig.SigningKey, error) {
+// 			rawKey := `{` +
+// 				`"kty":"oct",` +
+// 				`"k":"AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75` +
+// 				`aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow"` +
+// 				`}`
+// 			key, err := jwk.ParseKey([]byte(rawKey))
+// 			if err != nil {
+// 				return nil, err
+// 			}
+// 			return protected.Algorithm().New().NewSigningKey(key), nil
+// 		}))
+// 		if err != nil {
+// 			t.Fatal(err)
+// 		}
+// 		want := []byte(`$.02`)
+// 		if !bytes.Equal(payload, want) {
+// 			t.Errorf("unexpected payload: want %q, got %q", string(want), string(payload))
+// 		}
+// 	})
+// }
 
-func TestMarshalJSON(t *testing.T) {
-	t.Run("RFC 7515 Appendix A.6. Example JWS Using General JWS JSON Serialization", func(t *testing.T) {
-		msg := NewMessage([]byte(`{"iss":"joe",` + "\r\n" +
-			` "exp":1300819380,` + "\r\n" +
-			` "http://example.com/is_root":true}`))
+// func TestMarshalJSON(t *testing.T) {
+// 	t.Run("RFC 7515 Appendix A.6. Example JWS Using General JWS JSON Serialization", func(t *testing.T) {
+// 		msg := NewMessage([]byte(`{"iss":"joe",` + "\r\n" +
+// 			` "exp":1300819380,` + "\r\n" +
+// 			` "http://example.com/is_root":true}`))
 
-		protected1 := NewHeader()
-		protected1.SetAlgorithm(jwa.RS256)
-		header1 := NewHeader()
-		header1.SetKeyID("2010-12-29")
-		rawKey1 := `{"kty":"RSA",` +
-			`"n":"ofgWCuLjybRlzo0tZWJjNiuSfb4p4fAkd_wWJcyQoTbji9k0l8W26mPddx` +
-			`HmfHQp-Vaw-4qPCJrcS2mJPMEzP1Pt0Bm4d4QlL-yRT-SFd2lZS-pCgNMs` +
-			`D1W_YpRPEwOWvG6b32690r2jZ47soMZo9wGzjb_7OMg0LOL-bSf63kpaSH` +
-			`SXndS5z5rexMdbBYUsLA9e-KXBdQOS-UTo7WTBEMa2R2CapHg665xsmtdV` +
-			`MTBQY4uDZlxvb3qCo5ZwKh9kG4LT6_I5IhlJH7aGhyxXFvUK-DWNmoudF8` +
-			`NAco9_h9iaGNj8q2ethFkMLs91kzk2PAcDTW9gb54h4FRWyuXpoQ",` +
-			`"e":"AQAB",` +
-			`"d":"Eq5xpGnNCivDflJsRQBXHx1hdR1k6Ulwe2JZD50LpXyWPEAeP88vLNO97I` +
-			`jlA7_GQ5sLKMgvfTeXZx9SE-7YwVol2NXOoAJe46sui395IW_GO-pWJ1O0` +
-			`BkTGoVEn2bKVRUCgu-GjBVaYLU6f3l9kJfFNS3E0QbVdxzubSu3Mkqzjkn` +
-			`439X0M_V51gfpRLI9JYanrC4D4qAdGcopV_0ZHHzQlBjudU2QvXt4ehNYT` +
-			`CBr6XCLQUShb1juUO1ZdiYoFaFQT5Tw8bGUl_x_jTj3ccPDVZFD9pIuhLh` +
-			`BOneufuBiB4cS98l2SR_RQyGWSeWjnczT0QU91p1DhOVRuOopznQ",` +
-			`"p":"4BzEEOtIpmVdVEZNCqS7baC4crd0pqnRH_5IB3jw3bcxGn6QLvnEtfdUdi` +
-			`YrqBdss1l58BQ3KhooKeQTa9AB0Hw_Py5PJdTJNPY8cQn7ouZ2KKDcmnPG` +
-			`BY5t7yLc1QlQ5xHdwW1VhvKn-nXqhJTBgIPgtldC-KDV5z-y2XDwGUc",` +
-			`"q":"uQPEfgmVtjL0Uyyx88GZFF1fOunH3-7cepKmtH4pxhtCoHqpWmT8YAmZxa` +
-			`ewHgHAjLYsp1ZSe7zFYHj7C6ul7TjeLQeZD_YwD66t62wDmpe_HlB-TnBA` +
-			`-njbglfIsRLtXlnDzQkv5dTltRJ11BKBBypeeF6689rjcJIDEz9RWdc",` +
-			`"dp":"BwKfV3Akq5_MFZDFZCnW-wzl-CCo83WoZvnLQwCTeDv8uzluRSnm71I3Q` +
-			`CLdhrqE2e9YkxvuxdBfpT_PI7Yz-FOKnu1R6HsJeDCjn12Sk3vmAktV2zb` +
-			`34MCdy7cpdTh_YVr7tss2u6vneTwrA86rZtu5Mbr1C1XsmvkxHQAdYo0",` +
-			`"dq":"h_96-mK1R_7glhsum81dZxjTnYynPbZpHziZjeeHcXYsXaaMwkOlODsWa` +
-			`7I9xXDoRwbKgB719rrmI2oKr6N3Do9U0ajaHF-NKJnwgjMd2w9cjz3_-ky` +
-			`NlxAr2v4IKhGNpmM5iIgOS1VZnOZ68m6_pbLBSp3nssTdlqvd0tIiTHU",` +
-			`"qi":"IYd7DHOhrWvxkwPQsRM2tOgrjbcrfvtQJipd-DlcxyVuuM9sQLdgjVk2o` +
-			`y26F0EmpScGLq2MowX7fhd_QJQ3ydy5cY7YIBi87w93IKLEdfnbJtoOPLU` +
-			`W0ITrJReOgo1cq9SbsxYawBgfp_gh6A5603k2-ZQwVK0JKSHuLFkuQ3U"` +
-			`}`
-		key1, err := jwk.ParseKey([]byte(rawKey1))
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := msg.Sign(protected1, header1, jwa.RS256.New().NewSigningKey(key1)); err != nil {
-			t.Fatal(err)
-		}
+// 		protected1 := NewHeader()
+// 		protected1.SetAlgorithm(jwa.RS256)
+// 		header1 := NewHeader()
+// 		header1.SetKeyID("2010-12-29")
+// 		rawKey1 := `{"kty":"RSA",` +
+// 			`"n":"ofgWCuLjybRlzo0tZWJjNiuSfb4p4fAkd_wWJcyQoTbji9k0l8W26mPddx` +
+// 			`HmfHQp-Vaw-4qPCJrcS2mJPMEzP1Pt0Bm4d4QlL-yRT-SFd2lZS-pCgNMs` +
+// 			`D1W_YpRPEwOWvG6b32690r2jZ47soMZo9wGzjb_7OMg0LOL-bSf63kpaSH` +
+// 			`SXndS5z5rexMdbBYUsLA9e-KXBdQOS-UTo7WTBEMa2R2CapHg665xsmtdV` +
+// 			`MTBQY4uDZlxvb3qCo5ZwKh9kG4LT6_I5IhlJH7aGhyxXFvUK-DWNmoudF8` +
+// 			`NAco9_h9iaGNj8q2ethFkMLs91kzk2PAcDTW9gb54h4FRWyuXpoQ",` +
+// 			`"e":"AQAB",` +
+// 			`"d":"Eq5xpGnNCivDflJsRQBXHx1hdR1k6Ulwe2JZD50LpXyWPEAeP88vLNO97I` +
+// 			`jlA7_GQ5sLKMgvfTeXZx9SE-7YwVol2NXOoAJe46sui395IW_GO-pWJ1O0` +
+// 			`BkTGoVEn2bKVRUCgu-GjBVaYLU6f3l9kJfFNS3E0QbVdxzubSu3Mkqzjkn` +
+// 			`439X0M_V51gfpRLI9JYanrC4D4qAdGcopV_0ZHHzQlBjudU2QvXt4ehNYT` +
+// 			`CBr6XCLQUShb1juUO1ZdiYoFaFQT5Tw8bGUl_x_jTj3ccPDVZFD9pIuhLh` +
+// 			`BOneufuBiB4cS98l2SR_RQyGWSeWjnczT0QU91p1DhOVRuOopznQ",` +
+// 			`"p":"4BzEEOtIpmVdVEZNCqS7baC4crd0pqnRH_5IB3jw3bcxGn6QLvnEtfdUdi` +
+// 			`YrqBdss1l58BQ3KhooKeQTa9AB0Hw_Py5PJdTJNPY8cQn7ouZ2KKDcmnPG` +
+// 			`BY5t7yLc1QlQ5xHdwW1VhvKn-nXqhJTBgIPgtldC-KDV5z-y2XDwGUc",` +
+// 			`"q":"uQPEfgmVtjL0Uyyx88GZFF1fOunH3-7cepKmtH4pxhtCoHqpWmT8YAmZxa` +
+// 			`ewHgHAjLYsp1ZSe7zFYHj7C6ul7TjeLQeZD_YwD66t62wDmpe_HlB-TnBA` +
+// 			`-njbglfIsRLtXlnDzQkv5dTltRJ11BKBBypeeF6689rjcJIDEz9RWdc",` +
+// 			`"dp":"BwKfV3Akq5_MFZDFZCnW-wzl-CCo83WoZvnLQwCTeDv8uzluRSnm71I3Q` +
+// 			`CLdhrqE2e9YkxvuxdBfpT_PI7Yz-FOKnu1R6HsJeDCjn12Sk3vmAktV2zb` +
+// 			`34MCdy7cpdTh_YVr7tss2u6vneTwrA86rZtu5Mbr1C1XsmvkxHQAdYo0",` +
+// 			`"dq":"h_96-mK1R_7glhsum81dZxjTnYynPbZpHziZjeeHcXYsXaaMwkOlODsWa` +
+// 			`7I9xXDoRwbKgB719rrmI2oKr6N3Do9U0ajaHF-NKJnwgjMd2w9cjz3_-ky` +
+// 			`NlxAr2v4IKhGNpmM5iIgOS1VZnOZ68m6_pbLBSp3nssTdlqvd0tIiTHU",` +
+// 			`"qi":"IYd7DHOhrWvxkwPQsRM2tOgrjbcrfvtQJipd-DlcxyVuuM9sQLdgjVk2o` +
+// 			`y26F0EmpScGLq2MowX7fhd_QJQ3ydy5cY7YIBi87w93IKLEdfnbJtoOPLU` +
+// 			`W0ITrJReOgo1cq9SbsxYawBgfp_gh6A5603k2-ZQwVK0JKSHuLFkuQ3U"` +
+// 			`}`
+// 		key1, err := jwk.ParseKey([]byte(rawKey1))
+// 		if err != nil {
+// 			t.Fatal(err)
+// 		}
+// 		if err := msg.Sign(protected1, header1, jwa.RS256.New().NewSigningKey(key1)); err != nil {
+// 			t.Fatal(err)
+// 		}
 
-		protected := NewHeader()
-		protected.SetAlgorithm(jwa.ES256)
-		header := NewHeader()
-		header.SetKeyID("e9bc097a-ce51-4036-9562-d2ade882db0d")
-		rawKey2 := `{"kty":"EC",` +
-			`"crv":"P-256",` +
-			`"x":"f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvRVEU",` +
-			`"y":"x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0",` +
-			`"d":"jpsQnnGQmL-YBIffH1136cspYG6-0iY7X1fCE9-E9LI"` +
-			`}`
-		key2, err := jwk.ParseKey([]byte(rawKey2))
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := msg.Sign(protected, header, jwa.ES256.New().NewSigningKey(key2)); err != nil {
-			t.Fatal(err)
-		}
+// 		protected := NewHeader()
+// 		protected.SetAlgorithm(jwa.ES256)
+// 		header := NewHeader()
+// 		header.SetKeyID("e9bc097a-ce51-4036-9562-d2ade882db0d")
+// 		rawKey2 := `{"kty":"EC",` +
+// 			`"crv":"P-256",` +
+// 			`"x":"f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvRVEU",` +
+// 			`"y":"x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0",` +
+// 			`"d":"jpsQnnGQmL-YBIffH1136cspYG6-0iY7X1fCE9-E9LI"` +
+// 			`}`
+// 		key2, err := jwk.ParseKey([]byte(rawKey2))
+// 		if err != nil {
+// 			t.Fatal(err)
+// 		}
+// 		if err := msg.Sign(protected, header, jwa.ES256.New().NewSigningKey(key2)); err != nil {
+// 			t.Fatal(err)
+// 		}
 
-		data, err := msg.MarshalJSON()
-		if err != nil {
-			t.Fatal(err)
-		}
+// 		data, err := msg.MarshalJSON()
+// 		if err != nil {
+// 			t.Fatal(err)
+// 		}
 
-		var tmp any
-		if err := json.Unmarshal(data, &tmp); err != nil {
-			t.Fatal(err)
-		}
-	})
+// 		var tmp any
+// 		if err := json.Unmarshal(data, &tmp); err != nil {
+// 			t.Fatal(err)
+// 		}
+// 	})
 
-	t.Run("RFC 7515 Appendix A.7. Example JWS Using Flattened JWS JSON Serialization", func(t *testing.T) {
-		msg := NewMessage([]byte(`{"iss":"joe",` + "\r\n" +
-			` "exp":1300819380,` + "\r\n" +
-			` "http://example.com/is_root":true}`))
+// 	t.Run("RFC 7515 Appendix A.7. Example JWS Using Flattened JWS JSON Serialization", func(t *testing.T) {
+// 		msg := NewMessage([]byte(`{"iss":"joe",` + "\r\n" +
+// 			` "exp":1300819380,` + "\r\n" +
+// 			` "http://example.com/is_root":true}`))
 
-		protected2 := NewHeader()
-		protected2.SetAlgorithm(jwa.ES256)
-		header2 := NewHeader()
-		header2.SetKeyID("e9bc097a-ce51-4036-9562-d2ade882db0d")
-		rawKey2 := `{"kty":"EC",` +
-			`"crv":"P-256",` +
-			`"x":"f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvRVEU",` +
-			`"y":"x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0",` +
-			`"d":"jpsQnnGQmL-YBIffH1136cspYG6-0iY7X1fCE9-E9LI"` +
-			`}`
-		key2, err := jwk.ParseKey([]byte(rawKey2))
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := msg.Sign(protected2, header2, jwa.ES256.New().NewSigningKey(key2)); err != nil {
-			t.Fatal(err)
-		}
+// 		protected2 := NewHeader()
+// 		protected2.SetAlgorithm(jwa.ES256)
+// 		header2 := NewHeader()
+// 		header2.SetKeyID("e9bc097a-ce51-4036-9562-d2ade882db0d")
+// 		rawKey2 := `{"kty":"EC",` +
+// 			`"crv":"P-256",` +
+// 			`"x":"f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvRVEU",` +
+// 			`"y":"x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0",` +
+// 			`"d":"jpsQnnGQmL-YBIffH1136cspYG6-0iY7X1fCE9-E9LI"` +
+// 			`}`
+// 		key2, err := jwk.ParseKey([]byte(rawKey2))
+// 		if err != nil {
+// 			t.Fatal(err)
+// 		}
+// 		if err := msg.Sign(protected2, header2, jwa.ES256.New().NewSigningKey(key2)); err != nil {
+// 			t.Fatal(err)
+// 		}
 
-		data, err := msg.MarshalJSON()
-		if err != nil {
-			t.Fatal(err)
-		}
+// 		data, err := msg.MarshalJSON()
+// 		if err != nil {
+// 			t.Fatal(err)
+// 		}
 
-		var tmp any
-		if err := json.Unmarshal(data, &tmp); err != nil {
-			t.Fatal(err)
-		}
-	})
+// 		var tmp any
+// 		if err := json.Unmarshal(data, &tmp); err != nil {
+// 			t.Fatal(err)
+// 		}
+// 	})
 
-	// test for b64 header parameter.
-	t.Run("RFC 7797 Section 4.2. Example with Header Parameters", func(t *testing.T) {
-		msg := NewRawMessage([]byte("$.02"))
-		header := NewHeader()
-		header.SetAlgorithm(jwa.HS256)
-		header.SetBase64(false)
+// 	// test for b64 header parameter.
+// 	t.Run("RFC 7797 Section 4.2. Example with Header Parameters", func(t *testing.T) {
+// 		msg := NewRawMessage([]byte("$.02"))
+// 		header := NewHeader()
+// 		header.SetAlgorithm(jwa.HS256)
+// 		header.SetBase64(false)
 
-		rawKey := `{` +
-			`"kty":"oct",` +
-			`"k":"AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75` +
-			`aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow"` +
-			`}`
-		key, err := jwk.ParseKey([]byte(rawKey))
-		if err != nil {
-			t.Fatal(err)
-		}
+// 		rawKey := `{` +
+// 			`"kty":"oct",` +
+// 			`"k":"AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75` +
+// 			`aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow"` +
+// 			`}`
+// 		key, err := jwk.ParseKey([]byte(rawKey))
+// 		if err != nil {
+// 			t.Fatal(err)
+// 		}
 
-		if err := msg.Sign(header, nil, jwa.HS256.New().NewSigningKey(key)); err != nil {
-			t.Fatal(err)
-		}
+// 		if err := msg.Sign(header, nil, jwa.HS256.New().NewSigningKey(key)); err != nil {
+// 			t.Fatal(err)
+// 		}
 
-		got, err := msg.MarshalJSON()
-		if err != nil {
-			t.Fatal(err)
-		}
-		want := `{` +
-			`"payload":` +
-			`"$.02",` +
-			`"protected":` +
-			`"eyJhbGciOiJIUzI1NiIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19",` +
-			`"signature":` +
-			`"A5dxf2s96_n5FLueVuW1Z_vh161FwXZC4YLPff6dmDY"` +
-			`}`
-		if string(got) != want {
-			t.Errorf("want %s, got %s", want, got)
-		}
-	})
-}
+// 		got, err := msg.MarshalJSON()
+// 		if err != nil {
+// 			t.Fatal(err)
+// 		}
+// 		want := `{` +
+// 			`"payload":` +
+// 			`"$.02",` +
+// 			`"protected":` +
+// 			`"eyJhbGciOiJIUzI1NiIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19",` +
+// 			`"signature":` +
+// 			`"A5dxf2s96_n5FLueVuW1Z_vh161FwXZC4YLPff6dmDY"` +
+// 			`}`
+// 		if string(got) != want {
+// 			t.Errorf("want %s, got %s", want, got)
+// 		}
+// 	})
+// }
 
-func TestSign(t *testing.T) {
-	t.Run("RFC 7515 Appendix A.1 Example JWS Using HMAC SHA-256", func(t *testing.T) {
-		rawKey := `{"kty":"oct",` +
-			`"k":"AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75` +
-			`aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow"` +
-			`}`
-		key, err := jwk.ParseKey([]byte(rawKey))
-		if err != nil {
-			t.Fatal(err)
-		}
-		k := jwa.HS256.New().NewSigningKey(key)
-		h := NewHeader()
-		h.SetAlgorithm(jwa.HS256)
-		h.SetType("JWT")
-		payload := []byte(`{"iss":"joe",` + "\r\n" +
-			` "exp":1300819380,` + "\r\n" +
-			` "http://example.com/is_root":true}`)
-		msg := NewMessage(payload)
-		if err := msg.Sign(h, nil, k); err != nil {
-			t.Fatal(err)
-		}
-		got, err := msg.Compact()
-		if err != nil {
-			t.Fatal(err)
-		}
+// func TestSign(t *testing.T) {
+// 	t.Run("RFC 7515 Appendix A.1 Example JWS Using HMAC SHA-256", func(t *testing.T) {
+// 		rawKey := `{"kty":"oct",` +
+// 			`"k":"AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75` +
+// 			`aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow"` +
+// 			`}`
+// 		key, err := jwk.ParseKey([]byte(rawKey))
+// 		if err != nil {
+// 			t.Fatal(err)
+// 		}
+// 		k := jwa.HS256.New().NewSigningKey(key)
+// 		h := NewHeader()
+// 		h.SetAlgorithm(jwa.HS256)
+// 		h.SetType("JWT")
+// 		payload := []byte(`{"iss":"joe",` + "\r\n" +
+// 			` "exp":1300819380,` + "\r\n" +
+// 			` "http://example.com/is_root":true}`)
+// 		msg := NewMessage(payload)
+// 		if err := msg.Sign(h, nil, k); err != nil {
+// 			t.Fatal(err)
+// 		}
+// 		got, err := msg.Compact()
+// 		if err != nil {
+// 			t.Fatal(err)
+// 		}
 
-		// It is not same with Appendix A.1 because JOSE header is compact encoded here.
-		want := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9" +
-			"." +
-			"eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFt" +
-			"cGxlLmNvbS9pc19yb290Ijp0cnVlfQ" +
-			"." +
-			"SfgggA-oZk7ztlq1i8Uz5VhmPmustakoDa9wAf8uHyQ"
-		if string(got) != want {
-			t.Errorf("want %s, got %s", want, got)
-		}
-	})
+// 		// It is not same with Appendix A.1 because JOSE header is compact encoded here.
+// 		want := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9" +
+// 			"." +
+// 			"eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFt" +
+// 			"cGxlLmNvbS9pc19yb290Ijp0cnVlfQ" +
+// 			"." +
+// 			"SfgggA-oZk7ztlq1i8Uz5VhmPmustakoDa9wAf8uHyQ"
+// 		if string(got) != want {
+// 			t.Errorf("want %s, got %s", want, got)
+// 		}
+// 	})
 
-	t.Run("RFC 7515 Appendix A.2. Example JWS Using RSASSA-PKCS1-v1_5 SHA-256", func(t *testing.T) {
-		rawKey := `{"kty":"RSA",` +
-			`"n":"ofgWCuLjybRlzo0tZWJjNiuSfb4p4fAkd_wWJcyQoTbji9k0l8W26mPddx` +
-			`HmfHQp-Vaw-4qPCJrcS2mJPMEzP1Pt0Bm4d4QlL-yRT-SFd2lZS-pCgNMs` +
-			`D1W_YpRPEwOWvG6b32690r2jZ47soMZo9wGzjb_7OMg0LOL-bSf63kpaSH` +
-			`SXndS5z5rexMdbBYUsLA9e-KXBdQOS-UTo7WTBEMa2R2CapHg665xsmtdV` +
-			`MTBQY4uDZlxvb3qCo5ZwKh9kG4LT6_I5IhlJH7aGhyxXFvUK-DWNmoudF8` +
-			`NAco9_h9iaGNj8q2ethFkMLs91kzk2PAcDTW9gb54h4FRWyuXpoQ",` +
-			`"e":"AQAB",` +
-			`"d":"Eq5xpGnNCivDflJsRQBXHx1hdR1k6Ulwe2JZD50LpXyWPEAeP88vLNO97I` +
-			`jlA7_GQ5sLKMgvfTeXZx9SE-7YwVol2NXOoAJe46sui395IW_GO-pWJ1O0` +
-			`BkTGoVEn2bKVRUCgu-GjBVaYLU6f3l9kJfFNS3E0QbVdxzubSu3Mkqzjkn` +
-			`439X0M_V51gfpRLI9JYanrC4D4qAdGcopV_0ZHHzQlBjudU2QvXt4ehNYT` +
-			`CBr6XCLQUShb1juUO1ZdiYoFaFQT5Tw8bGUl_x_jTj3ccPDVZFD9pIuhLh` +
-			`BOneufuBiB4cS98l2SR_RQyGWSeWjnczT0QU91p1DhOVRuOopznQ",` +
-			`"p":"4BzEEOtIpmVdVEZNCqS7baC4crd0pqnRH_5IB3jw3bcxGn6QLvnEtfdUdi` +
-			`YrqBdss1l58BQ3KhooKeQTa9AB0Hw_Py5PJdTJNPY8cQn7ouZ2KKDcmnPG` +
-			`BY5t7yLc1QlQ5xHdwW1VhvKn-nXqhJTBgIPgtldC-KDV5z-y2XDwGUc",` +
-			`"q":"uQPEfgmVtjL0Uyyx88GZFF1fOunH3-7cepKmtH4pxhtCoHqpWmT8YAmZxa` +
-			`ewHgHAjLYsp1ZSe7zFYHj7C6ul7TjeLQeZD_YwD66t62wDmpe_HlB-TnBA` +
-			`-njbglfIsRLtXlnDzQkv5dTltRJ11BKBBypeeF6689rjcJIDEz9RWdc",` +
-			`"dp":"BwKfV3Akq5_MFZDFZCnW-wzl-CCo83WoZvnLQwCTeDv8uzluRSnm71I3Q` +
-			`CLdhrqE2e9YkxvuxdBfpT_PI7Yz-FOKnu1R6HsJeDCjn12Sk3vmAktV2zb` +
-			`34MCdy7cpdTh_YVr7tss2u6vneTwrA86rZtu5Mbr1C1XsmvkxHQAdYo0",` +
-			`"dq":"h_96-mK1R_7glhsum81dZxjTnYynPbZpHziZjeeHcXYsXaaMwkOlODsWa` +
-			`7I9xXDoRwbKgB719rrmI2oKr6N3Do9U0ajaHF-NKJnwgjMd2w9cjz3_-ky` +
-			`NlxAr2v4IKhGNpmM5iIgOS1VZnOZ68m6_pbLBSp3nssTdlqvd0tIiTHU",` +
-			`"qi":"IYd7DHOhrWvxkwPQsRM2tOgrjbcrfvtQJipd-DlcxyVuuM9sQLdgjVk2o` +
-			`y26F0EmpScGLq2MowX7fhd_QJQ3ydy5cY7YIBi87w93IKLEdfnbJtoOPLU` +
-			`W0ITrJReOgo1cq9SbsxYawBgfp_gh6A5603k2-ZQwVK0JKSHuLFkuQ3U"` +
-			`}`
-		key, err := jwk.ParseKey([]byte(rawKey))
-		if err != nil {
-			t.Fatal(err)
-		}
-		k := jwa.RS256.New().NewSigningKey(key)
-		h := NewHeader()
-		h.SetAlgorithm(jwa.RS256)
-		h.SetType("JWT")
-		payload := []byte(`{"iss":"joe",` + "\r\n" +
-			` "exp":1300819380,` + "\r\n" +
-			` "http://example.com/is_root":true}`)
-		msg := NewMessage(payload)
-		if err := msg.Sign(h, nil, k); err != nil {
-			t.Fatal(err)
-		}
-		got, err := msg.Compact()
-		if err != nil {
-			t.Fatal(err)
-		}
+// 	t.Run("RFC 7515 Appendix A.2. Example JWS Using RSASSA-PKCS1-v1_5 SHA-256", func(t *testing.T) {
+// 		rawKey := `{"kty":"RSA",` +
+// 			`"n":"ofgWCuLjybRlzo0tZWJjNiuSfb4p4fAkd_wWJcyQoTbji9k0l8W26mPddx` +
+// 			`HmfHQp-Vaw-4qPCJrcS2mJPMEzP1Pt0Bm4d4QlL-yRT-SFd2lZS-pCgNMs` +
+// 			`D1W_YpRPEwOWvG6b32690r2jZ47soMZo9wGzjb_7OMg0LOL-bSf63kpaSH` +
+// 			`SXndS5z5rexMdbBYUsLA9e-KXBdQOS-UTo7WTBEMa2R2CapHg665xsmtdV` +
+// 			`MTBQY4uDZlxvb3qCo5ZwKh9kG4LT6_I5IhlJH7aGhyxXFvUK-DWNmoudF8` +
+// 			`NAco9_h9iaGNj8q2ethFkMLs91kzk2PAcDTW9gb54h4FRWyuXpoQ",` +
+// 			`"e":"AQAB",` +
+// 			`"d":"Eq5xpGnNCivDflJsRQBXHx1hdR1k6Ulwe2JZD50LpXyWPEAeP88vLNO97I` +
+// 			`jlA7_GQ5sLKMgvfTeXZx9SE-7YwVol2NXOoAJe46sui395IW_GO-pWJ1O0` +
+// 			`BkTGoVEn2bKVRUCgu-GjBVaYLU6f3l9kJfFNS3E0QbVdxzubSu3Mkqzjkn` +
+// 			`439X0M_V51gfpRLI9JYanrC4D4qAdGcopV_0ZHHzQlBjudU2QvXt4ehNYT` +
+// 			`CBr6XCLQUShb1juUO1ZdiYoFaFQT5Tw8bGUl_x_jTj3ccPDVZFD9pIuhLh` +
+// 			`BOneufuBiB4cS98l2SR_RQyGWSeWjnczT0QU91p1DhOVRuOopznQ",` +
+// 			`"p":"4BzEEOtIpmVdVEZNCqS7baC4crd0pqnRH_5IB3jw3bcxGn6QLvnEtfdUdi` +
+// 			`YrqBdss1l58BQ3KhooKeQTa9AB0Hw_Py5PJdTJNPY8cQn7ouZ2KKDcmnPG` +
+// 			`BY5t7yLc1QlQ5xHdwW1VhvKn-nXqhJTBgIPgtldC-KDV5z-y2XDwGUc",` +
+// 			`"q":"uQPEfgmVtjL0Uyyx88GZFF1fOunH3-7cepKmtH4pxhtCoHqpWmT8YAmZxa` +
+// 			`ewHgHAjLYsp1ZSe7zFYHj7C6ul7TjeLQeZD_YwD66t62wDmpe_HlB-TnBA` +
+// 			`-njbglfIsRLtXlnDzQkv5dTltRJ11BKBBypeeF6689rjcJIDEz9RWdc",` +
+// 			`"dp":"BwKfV3Akq5_MFZDFZCnW-wzl-CCo83WoZvnLQwCTeDv8uzluRSnm71I3Q` +
+// 			`CLdhrqE2e9YkxvuxdBfpT_PI7Yz-FOKnu1R6HsJeDCjn12Sk3vmAktV2zb` +
+// 			`34MCdy7cpdTh_YVr7tss2u6vneTwrA86rZtu5Mbr1C1XsmvkxHQAdYo0",` +
+// 			`"dq":"h_96-mK1R_7glhsum81dZxjTnYynPbZpHziZjeeHcXYsXaaMwkOlODsWa` +
+// 			`7I9xXDoRwbKgB719rrmI2oKr6N3Do9U0ajaHF-NKJnwgjMd2w9cjz3_-ky` +
+// 			`NlxAr2v4IKhGNpmM5iIgOS1VZnOZ68m6_pbLBSp3nssTdlqvd0tIiTHU",` +
+// 			`"qi":"IYd7DHOhrWvxkwPQsRM2tOgrjbcrfvtQJipd-DlcxyVuuM9sQLdgjVk2o` +
+// 			`y26F0EmpScGLq2MowX7fhd_QJQ3ydy5cY7YIBi87w93IKLEdfnbJtoOPLU` +
+// 			`W0ITrJReOgo1cq9SbsxYawBgfp_gh6A5603k2-ZQwVK0JKSHuLFkuQ3U"` +
+// 			`}`
+// 		key, err := jwk.ParseKey([]byte(rawKey))
+// 		if err != nil {
+// 			t.Fatal(err)
+// 		}
+// 		k := jwa.RS256.New().NewSigningKey(key)
+// 		h := NewHeader()
+// 		h.SetAlgorithm(jwa.RS256)
+// 		h.SetType("JWT")
+// 		payload := []byte(`{"iss":"joe",` + "\r\n" +
+// 			` "exp":1300819380,` + "\r\n" +
+// 			` "http://example.com/is_root":true}`)
+// 		msg := NewMessage(payload)
+// 		if err := msg.Sign(h, nil, k); err != nil {
+// 			t.Fatal(err)
+// 		}
+// 		got, err := msg.Compact()
+// 		if err != nil {
+// 			t.Fatal(err)
+// 		}
 
-		// It is not same with Appendix A.2 because JOSE header is compact encoded here.
-		want := "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9" +
-			"." +
-			"eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFt" +
-			"cGxlLmNvbS9pc19yb290Ijp0cnVlfQ" +
-			"." +
-			"HVeJTJBURMOJaxWlJmcYE9pnd2Encfn4iYlTS6c9zc0pg5nDpC3vgDkdblOSVu8s" +
-			"OYXnCgfpfFxsUn8golAZD9VKZnmd7-Z3RT54aW12zDCLkZUsqKIe3yFSzLzPy-31" +
-			"KXolCsqeQgXWnq_HT-gf9I3-FGRvik6ty-YfgjxLvJsgzHwzWWohemAWbfA6lSgZ" +
-			"jPEScVMxLQ6z7Uda9BxT8alpUHbJhEbU_3becu_tezD7vsscYp8pPd52LRWMYYIE" +
-			"NYApMx4XviHYPG1AIdEPq7TeVFXPBSf_Jops0LeT1B9pCI3IbuCa-Wd4hrhQM1V8" +
-			"QaYzD6k11fesYCXZU35kxw"
-		if string(got) != want {
-			t.Errorf("want %s, got %s", want, got)
-		}
-	})
+// 		// It is not same with Appendix A.2 because JOSE header is compact encoded here.
+// 		want := "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9" +
+// 			"." +
+// 			"eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFt" +
+// 			"cGxlLmNvbS9pc19yb290Ijp0cnVlfQ" +
+// 			"." +
+// 			"HVeJTJBURMOJaxWlJmcYE9pnd2Encfn4iYlTS6c9zc0pg5nDpC3vgDkdblOSVu8s" +
+// 			"OYXnCgfpfFxsUn8golAZD9VKZnmd7-Z3RT54aW12zDCLkZUsqKIe3yFSzLzPy-31" +
+// 			"KXolCsqeQgXWnq_HT-gf9I3-FGRvik6ty-YfgjxLvJsgzHwzWWohemAWbfA6lSgZ" +
+// 			"jPEScVMxLQ6z7Uda9BxT8alpUHbJhEbU_3becu_tezD7vsscYp8pPd52LRWMYYIE" +
+// 			"NYApMx4XviHYPG1AIdEPq7TeVFXPBSf_Jops0LeT1B9pCI3IbuCa-Wd4hrhQM1V8" +
+// 			"QaYzD6k11fesYCXZU35kxw"
+// 		if string(got) != want {
+// 			t.Errorf("want %s, got %s", want, got)
+// 		}
+// 	})
 
-	t.Run("RFC 7515 Appendix A.5 Example Unsecured JWS", func(t *testing.T) {
-		h := NewHeader()
-		h.SetAlgorithm(jwa.None)
-		h.SetType("JWT")
-		payload := []byte(`{"iss":"joe",` + "\r\n" +
-			` "exp":1300819380,` + "\r\n" +
-			` "http://example.com/is_root":true}`)
-		k := jwa.None.New().NewSigningKey(nil)
-		msg := NewMessage(payload)
-		if err := msg.Sign(h, nil, k); err != nil {
-			t.Fatal(err)
-		}
-		got, err := msg.Compact()
-		if err != nil {
-			t.Fatal(err)
-		}
+// 	t.Run("RFC 7515 Appendix A.5 Example Unsecured JWS", func(t *testing.T) {
+// 		h := NewHeader()
+// 		h.SetAlgorithm(jwa.None)
+// 		h.SetType("JWT")
+// 		payload := []byte(`{"iss":"joe",` + "\r\n" +
+// 			` "exp":1300819380,` + "\r\n" +
+// 			` "http://example.com/is_root":true}`)
+// 		k := jwa.None.New().NewSigningKey(nil)
+// 		msg := NewMessage(payload)
+// 		if err := msg.Sign(h, nil, k); err != nil {
+// 			t.Fatal(err)
+// 		}
+// 		got, err := msg.Compact()
+// 		if err != nil {
+// 			t.Fatal(err)
+// 		}
 
-		// It is not same with Appendix A.5 because JOSE header is compact encoded here.
-		want := "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0" +
-			"." +
-			"eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFt" +
-			"cGxlLmNvbS9pc19yb290Ijp0cnVlfQ" +
-			"."
-		if string(got) != want {
-			t.Errorf("want %s, got %s", want, got)
-		}
-	})
+// 		// It is not same with Appendix A.5 because JOSE header is compact encoded here.
+// 		want := "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0" +
+// 			"." +
+// 			"eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFt" +
+// 			"cGxlLmNvbS9pc19yb290Ijp0cnVlfQ" +
+// 			"."
+// 		if string(got) != want {
+// 			t.Errorf("want %s, got %s", want, got)
+// 		}
+// 	})
 
-	t.Run("RFC 7797 Section 4.2. Example with Header Parameter", func(t *testing.T) {
-		rawKey := `{` +
-			`"kty":"oct",` +
-			`"k":"AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75` +
-			`aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow"` +
-			`}`
-		key, err := jwk.ParseKey([]byte(rawKey))
-		if err != nil {
-			t.Fatal(err)
-		}
-		k := jwa.HS256.New().NewSigningKey(key)
-		h := NewHeader()
-		h.SetAlgorithm(jwa.HS256)
-		h.SetType("JWT")
-		msg := NewRawMessage([]byte("$.02"))
-		if err := msg.Sign(h, nil, k); err != nil {
-			t.Fatal(err)
-		}
-		got, err := msg.Compact()
-		if err != nil {
-			t.Fatal(err)
-		}
-		want := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9" +
-			"." +
-			"." +
-			"oa1M-6Wbmk9q4SheILHROv561Ba7U1gVKuIkXZiJcic"
-		if string(got) != want {
-			t.Errorf("want %s, got %s", want, got)
-		}
-	})
-}
+// 	t.Run("RFC 7797 Section 4.2. Example with Header Parameter", func(t *testing.T) {
+// 		rawKey := `{` +
+// 			`"kty":"oct",` +
+// 			`"k":"AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75` +
+// 			`aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow"` +
+// 			`}`
+// 		key, err := jwk.ParseKey([]byte(rawKey))
+// 		if err != nil {
+// 			t.Fatal(err)
+// 		}
+// 		k := jwa.HS256.New().NewSigningKey(key)
+// 		h := NewHeader()
+// 		h.SetAlgorithm(jwa.HS256)
+// 		h.SetType("JWT")
+// 		msg := NewRawMessage([]byte("$.02"))
+// 		if err := msg.Sign(h, nil, k); err != nil {
+// 			t.Fatal(err)
+// 		}
+// 		got, err := msg.Compact()
+// 		if err != nil {
+// 			t.Fatal(err)
+// 		}
+// 		want := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9" +
+// 			"." +
+// 			"." +
+// 			"oa1M-6Wbmk9q4SheILHROv561Ba7U1gVKuIkXZiJcic"
+// 		if string(got) != want {
+// 			t.Errorf("want %s, got %s", want, got)
+// 		}
+// 	})
+// }
 
-func TestKeyTypeMissmatch(t *testing.T) {
-	// from RFC 7515 Appendix A.3 Example JWS Using ECDSA P-256 SHA-256
-	raw := []byte(
-		"eyJhbGciOiJFUzI1NiJ9" + // {"alg":"ES256"}
-			"." +
-			"eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFt" +
-			"cGxlLmNvbS9pc19yb290Ijp0cnVlfQ" +
-			"." +
-			"DtEhU3ljbEg8L38VWAfUAqOyKAM6-Xx-F4GawxaepmXFCgfTjDxw5djxLa8ISlSA" +
-			"pmWQxfKTUJqPP3-Kg6NU1Q",
-	)
+// func TestKeyTypeMissmatch(t *testing.T) {
+// 	// from RFC 7515 Appendix A.3 Example JWS Using ECDSA P-256 SHA-256
+// 	raw := []byte(
+// 		"eyJhbGciOiJFUzI1NiJ9" + // {"alg":"ES256"}
+// 			"." +
+// 			"eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFt" +
+// 			"cGxlLmNvbS9pc19yb290Ijp0cnVlfQ" +
+// 			"." +
+// 			"DtEhU3ljbEg8L38VWAfUAqOyKAM6-Xx-F4GawxaepmXFCgfTjDxw5djxLa8ISlSA" +
+// 			"pmWQxfKTUJqPP3-Kg6NU1Q",
+// 	)
 
-	// RFC 7517 A.1. Example Public Keys (RSA)
-	rawKey := `{"kty":"RSA",` +
-		`"n":"0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx` +
-		`4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMs` +
-		`tn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2` +
-		`QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbI` +
-		`SD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqb` +
-		`w0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw",` +
-		`"e":"AQAB",` +
-		`"alg":"RS256",` +
-		`"kid":"2011-04-29"}`
-	key, err := jwk.ParseKey([]byte(rawKey))
-	if err != nil {
-		t.Fatal(err)
-	}
-	msg, err := Parse(raw)
-	if err != nil {
-		t.Fatal(err)
-	}
-	_, _, err = msg.Verify(FindKeyFunc(func(header, _ *Header) (sig.SigningKey, error) {
-		alg := header.Algorithm().New()
-		return alg.NewSigningKey(key), nil
-	}))
-	if err == nil {
-		t.Error("want error, got nil")
-	}
-}
+// 	// RFC 7517 A.1. Example Public Keys (RSA)
+// 	rawKey := `{"kty":"RSA",` +
+// 		`"n":"0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx` +
+// 		`4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMs` +
+// 		`tn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2` +
+// 		`QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbI` +
+// 		`SD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqb` +
+// 		`w0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw",` +
+// 		`"e":"AQAB",` +
+// 		`"alg":"RS256",` +
+// 		`"kid":"2011-04-29"}`
+// 	key, err := jwk.ParseKey([]byte(rawKey))
+// 	if err != nil {
+// 		t.Fatal(err)
+// 	}
+// 	msg, err := Parse(raw)
+// 	if err != nil {
+// 		t.Fatal(err)
+// 	}
+// 	_, _, err = msg.Verify(FindKeyFunc(func(header, _ *Header) (sig.SigningKey, error) {
+// 		alg := header.Algorithm().New()
+// 		return alg.NewSigningKey(key), nil
+// 	}))
+// 	if err == nil {
+// 		t.Error("want error, got nil")
+// 	}
+// }

--- a/jws/key_finder.go
+++ b/jws/key_finder.go
@@ -2,6 +2,7 @@ package jws
 
 import (
 	"context"
+	"errors"
 
 	"github.com/shogo82148/goat/jwk"
 	"github.com/shogo82148/goat/sig"
@@ -25,6 +26,9 @@ type JWKKeyFinder struct {
 }
 
 func (f *JWKKeyFinder) FindKey(ctx context.Context, protected, unprotected *Header) (key sig.SigningKey, err error) {
-	alg := protected.Algorithm().New()
-	return alg.NewSigningKey(f.JWK), nil
+	alg := protected.Algorithm()
+	if !alg.Available() {
+		return nil, errors.New("jws: algorithm not available")
+	}
+	return alg.New().NewSigningKey(f.JWK), nil
 }

--- a/jws/key_finder.go
+++ b/jws/key_finder.go
@@ -1,0 +1,30 @@
+package jws
+
+import (
+	"context"
+
+	"github.com/shogo82148/goat/jwk"
+	"github.com/shogo82148/goat/sig"
+)
+
+// KeyFinder finds a signing key for the JWS message.
+type KeyFinder interface {
+	FindKey(ctx context.Context, protected, unprotected *Header) (key sig.SigningKey, err error)
+}
+
+// FindKeyFunc is an adapter to allow the use of ordinary functions as KeyFinder.
+type FindKeyFunc func(ctx context.Context, protected, unprotected *Header) (key sig.SigningKey, err error)
+
+func (f FindKeyFunc) FindKey(ctx context.Context, protected, unprotected *Header) (key sig.SigningKey, err error) {
+	return f(ctx, protected, unprotected)
+}
+
+// JWKKeyFinder returns a specific signing key.
+type JWKKeyFinder struct {
+	JWK *jwk.Key
+}
+
+func (f *JWKKeyFinder) FindKey(ctx context.Context, protected, unprotected *Header) (key sig.SigningKey, err error) {
+	alg := protected.Algorithm().New()
+	return alg.NewSigningKey(f.JWK), nil
+}

--- a/jws/rfc7520_test.go
+++ b/jws/rfc7520_test.go
@@ -1,88 +1,97 @@
 package jws
 
-// import (
-// 	"encoding/json"
-// 	"errors"
-// 	"os"
-// 	"testing"
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"testing"
 
-// 	"github.com/shogo82148/goat/jwa"
-// 	"github.com/shogo82148/goat/jwk"
-// 	"github.com/shogo82148/goat/sig"
-// )
+	"github.com/shogo82148/goat/jwa"
+	"github.com/shogo82148/goat/jwk"
+	"github.com/shogo82148/goat/sig"
+)
 
-// type testVector struct {
-// 	Title        string             `json:"title"`
-// 	Reproducible bool               `json:"reproducible"`
-// 	Input        *testVectorInput   `json:"input"`
-// 	Signing      *testVectorSigning `json:"signing"`
-// 	Output       *testVectorOutput  `json:"output"`
-// }
+type testVector struct {
+	Title        string             `json:"title"`
+	Reproducible bool               `json:"reproducible"`
+	Input        *testVectorInput   `json:"input"`
+	Signing      *testVectorSigning `json:"signing"`
+	Output       *testVectorOutput  `json:"output"`
+}
 
-// type testVectorInput struct {
-// 	Payload   string                 `json:"payload"`
-// 	Key       *jwk.Key               `json:"key"`
-// 	Algorithm jwa.SignatureAlgorithm `json:"alg"`
-// }
+type testVectorInput struct {
+	Payload   string                 `json:"payload"`
+	Key       *jwk.Key               `json:"key"`
+	Algorithm jwa.SignatureAlgorithm `json:"alg"`
+}
 
-// type testVectorSigning struct {
-// 	Protected          *Header `json:"protected"`
-// 	ProtectedBase64URL string  `json:"protected_b64u"`
-// 	SignatureInput     string  `json:"sig-input"`
-// 	Signature          string  `json:"sig"`
-// }
+type testVectorSigning struct {
+	Protected          *Header `json:"protected"`
+	ProtectedBase64URL string  `json:"protected_b64u"`
+	SignatureInput     string  `json:"sig-input"`
+	Signature          string  `json:"sig"`
+}
 
-// type testVectorOutput struct {
-// 	Compact   string   `json:"compact"`
-// 	JSON      *Message `json:"json"`
-// 	Flattened *Message `json:"flattened"`
-// }
+type testVectorOutput struct {
+	Compact   string   `json:"compact"`
+	JSON      *Message `json:"json"`
+	Flattened *Message `json:"flattened"`
+}
 
-// func TestRFC7520(t *testing.T) {
-// 	t.Run("4.1. RSA v1.5 Signature", func(t *testing.T) {
-// 		data, err := os.ReadFile("testdata/rfc7520/4_1.rsa_v15_signature.json")
-// 		if err != nil {
-// 			t.Fatal(err)
-// 		}
-// 		var tv testVector
-// 		if err := json.Unmarshal(data, &tv); err != nil {
-// 			t.Fatal(err)
-// 		}
+func TestRFC7520(t *testing.T) {
+	t.Run("4.1. RSA v1.5 Signature", func(t *testing.T) {
+		data, err := os.ReadFile("testdata/rfc7520/4_1.rsa_v15_signature.json")
+		if err != nil {
+			t.Fatal(err)
+		}
+		var tv testVector
+		if err := json.Unmarshal(data, &tv); err != nil {
+			t.Fatal(err)
+		}
 
-// 		// verify the signature of the compact serialization.
-// 		msg, err := Parse([]byte(tv.Output.Compact))
-// 		if err != nil {
-// 			t.Fatal(err)
-// 		}
-// 		_, body, err := msg.Verify(FindKeyFunc(func(protected, unprotected *Header) (key sig.SigningKey, err error) {
-// 			if protected.KeyID() != tv.Input.Key.KeyID() {
-// 				return nil, errors.New("key not found")
-// 			}
-// 			alg := tv.Input.Algorithm.New()
-// 			return alg.NewSigningKey(tv.Input.Key), nil
-// 		}))
-// 		if err != nil {
-// 			t.Fatal(err)
-// 		}
-// 		if string(body) != tv.Input.Payload {
-// 			t.Errorf("unexpected payload: want %s, got %s", tv.Input.Payload, body)
-// 		}
+		// verify the signature of the compact serialization.
+		msg, err := Parse([]byte(tv.Output.Compact))
+		if err != nil {
+			t.Fatal(err)
+		}
+		v := &Verifier{
+			AlgorithmVerfier: AllowedAlgorithms{tv.Input.Algorithm},
+			KeyFinder: FindKeyFunc(func(_ context.Context, protected, unprotected *Header) (key sig.SigningKey, err error) {
+				if protected.KeyID() != tv.Input.Key.KeyID() {
+					return nil, errors.New("key not found")
+				}
+				alg := tv.Input.Algorithm.New()
+				return alg.NewSigningKey(tv.Input.Key), nil
+			}),
+		}
+		_, body, err := v.Verify(context.Background(), msg)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(body) != tv.Input.Payload {
+			t.Errorf("unexpected payload: want %s, got %s", tv.Input.Payload, body)
+		}
 
-// 		// verify the signature of the JSON serialization.
-// 		_, body, err = tv.Output.JSON.Verify(FindKeyFunc(func(protected, unprotected *Header) (key sig.SigningKey, err error) {
-// 			if protected.KeyID() != tv.Input.Key.KeyID() {
-// 				return nil, errors.New("key not found")
-// 			}
-// 			alg := tv.Input.Algorithm.New()
-// 			return alg.NewSigningKey(tv.Input.Key), nil
-// 		}))
-// 		if err != nil {
-// 			t.Fatal(err)
-// 		}
-// 		if string(body) != tv.Input.Payload {
-// 			t.Errorf("unexpected payload: want %s, got %s", tv.Input.Payload, body)
-// 		}
+		// verify the signature of the JSON serialization.
+		v = &Verifier{
+			AlgorithmVerfier: AllowedAlgorithms{tv.Input.Algorithm},
+			KeyFinder: FindKeyFunc(func(_ context.Context, protected, unprotected *Header) (key sig.SigningKey, err error) {
+				if protected.KeyID() != tv.Input.Key.KeyID() {
+					return nil, errors.New("key not found")
+				}
+				alg := tv.Input.Algorithm.New()
+				return alg.NewSigningKey(tv.Input.Key), nil
+			}),
+		}
+		_, body, err = v.Verify(context.Background(), tv.Output.JSON)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(body) != tv.Input.Payload {
+			t.Errorf("unexpected payload: want %s, got %s", tv.Input.Payload, body)
+		}
 
-// 		// TODO: verify the signature of the flattened serialization.
-// 	})
-// }
+		// TODO: verify the signature of the flattened serialization.
+	})
+}

--- a/jws/rfc7520_test.go
+++ b/jws/rfc7520_test.go
@@ -1,88 +1,88 @@
 package jws
 
-import (
-	"encoding/json"
-	"errors"
-	"os"
-	"testing"
+// import (
+// 	"encoding/json"
+// 	"errors"
+// 	"os"
+// 	"testing"
 
-	"github.com/shogo82148/goat/jwa"
-	"github.com/shogo82148/goat/jwk"
-	"github.com/shogo82148/goat/sig"
-)
+// 	"github.com/shogo82148/goat/jwa"
+// 	"github.com/shogo82148/goat/jwk"
+// 	"github.com/shogo82148/goat/sig"
+// )
 
-type testVector struct {
-	Title        string             `json:"title"`
-	Reproducible bool               `json:"reproducible"`
-	Input        *testVectorInput   `json:"input"`
-	Signing      *testVectorSigning `json:"signing"`
-	Output       *testVectorOutput  `json:"output"`
-}
+// type testVector struct {
+// 	Title        string             `json:"title"`
+// 	Reproducible bool               `json:"reproducible"`
+// 	Input        *testVectorInput   `json:"input"`
+// 	Signing      *testVectorSigning `json:"signing"`
+// 	Output       *testVectorOutput  `json:"output"`
+// }
 
-type testVectorInput struct {
-	Payload   string                 `json:"payload"`
-	Key       *jwk.Key               `json:"key"`
-	Algorithm jwa.SignatureAlgorithm `json:"alg"`
-}
+// type testVectorInput struct {
+// 	Payload   string                 `json:"payload"`
+// 	Key       *jwk.Key               `json:"key"`
+// 	Algorithm jwa.SignatureAlgorithm `json:"alg"`
+// }
 
-type testVectorSigning struct {
-	Protected          *Header `json:"protected"`
-	ProtectedBase64URL string  `json:"protected_b64u"`
-	SignatureInput     string  `json:"sig-input"`
-	Signature          string  `json:"sig"`
-}
+// type testVectorSigning struct {
+// 	Protected          *Header `json:"protected"`
+// 	ProtectedBase64URL string  `json:"protected_b64u"`
+// 	SignatureInput     string  `json:"sig-input"`
+// 	Signature          string  `json:"sig"`
+// }
 
-type testVectorOutput struct {
-	Compact   string   `json:"compact"`
-	JSON      *Message `json:"json"`
-	Flattened *Message `json:"flattened"`
-}
+// type testVectorOutput struct {
+// 	Compact   string   `json:"compact"`
+// 	JSON      *Message `json:"json"`
+// 	Flattened *Message `json:"flattened"`
+// }
 
-func TestRFC7520(t *testing.T) {
-	t.Run("4.1. RSA v1.5 Signature", func(t *testing.T) {
-		data, err := os.ReadFile("testdata/rfc7520/4_1.rsa_v15_signature.json")
-		if err != nil {
-			t.Fatal(err)
-		}
-		var tv testVector
-		if err := json.Unmarshal(data, &tv); err != nil {
-			t.Fatal(err)
-		}
+// func TestRFC7520(t *testing.T) {
+// 	t.Run("4.1. RSA v1.5 Signature", func(t *testing.T) {
+// 		data, err := os.ReadFile("testdata/rfc7520/4_1.rsa_v15_signature.json")
+// 		if err != nil {
+// 			t.Fatal(err)
+// 		}
+// 		var tv testVector
+// 		if err := json.Unmarshal(data, &tv); err != nil {
+// 			t.Fatal(err)
+// 		}
 
-		// verify the signature of the compact serialization.
-		msg, err := Parse([]byte(tv.Output.Compact))
-		if err != nil {
-			t.Fatal(err)
-		}
-		_, body, err := msg.Verify(FindKeyFunc(func(protected, unprotected *Header) (key sig.SigningKey, err error) {
-			if protected.KeyID() != tv.Input.Key.KeyID() {
-				return nil, errors.New("key not found")
-			}
-			alg := tv.Input.Algorithm.New()
-			return alg.NewSigningKey(tv.Input.Key), nil
-		}))
-		if err != nil {
-			t.Fatal(err)
-		}
-		if string(body) != tv.Input.Payload {
-			t.Errorf("unexpected payload: want %s, got %s", tv.Input.Payload, body)
-		}
+// 		// verify the signature of the compact serialization.
+// 		msg, err := Parse([]byte(tv.Output.Compact))
+// 		if err != nil {
+// 			t.Fatal(err)
+// 		}
+// 		_, body, err := msg.Verify(FindKeyFunc(func(protected, unprotected *Header) (key sig.SigningKey, err error) {
+// 			if protected.KeyID() != tv.Input.Key.KeyID() {
+// 				return nil, errors.New("key not found")
+// 			}
+// 			alg := tv.Input.Algorithm.New()
+// 			return alg.NewSigningKey(tv.Input.Key), nil
+// 		}))
+// 		if err != nil {
+// 			t.Fatal(err)
+// 		}
+// 		if string(body) != tv.Input.Payload {
+// 			t.Errorf("unexpected payload: want %s, got %s", tv.Input.Payload, body)
+// 		}
 
-		// verify the signature of the JSON serialization.
-		_, body, err = tv.Output.JSON.Verify(FindKeyFunc(func(protected, unprotected *Header) (key sig.SigningKey, err error) {
-			if protected.KeyID() != tv.Input.Key.KeyID() {
-				return nil, errors.New("key not found")
-			}
-			alg := tv.Input.Algorithm.New()
-			return alg.NewSigningKey(tv.Input.Key), nil
-		}))
-		if err != nil {
-			t.Fatal(err)
-		}
-		if string(body) != tv.Input.Payload {
-			t.Errorf("unexpected payload: want %s, got %s", tv.Input.Payload, body)
-		}
+// 		// verify the signature of the JSON serialization.
+// 		_, body, err = tv.Output.JSON.Verify(FindKeyFunc(func(protected, unprotected *Header) (key sig.SigningKey, err error) {
+// 			if protected.KeyID() != tv.Input.Key.KeyID() {
+// 				return nil, errors.New("key not found")
+// 			}
+// 			alg := tv.Input.Algorithm.New()
+// 			return alg.NewSigningKey(tv.Input.Key), nil
+// 		}))
+// 		if err != nil {
+// 			t.Fatal(err)
+// 		}
+// 		if string(body) != tv.Input.Payload {
+// 			t.Errorf("unexpected payload: want %s, got %s", tv.Input.Payload, body)
+// 		}
 
-		// TODO: verify the signature of the flattened serialization.
-	})
-}
+// 		// TODO: verify the signature of the flattened serialization.
+// 	})
+// }

--- a/jws/verifier.go
+++ b/jws/verifier.go
@@ -25,12 +25,12 @@ func (a AllowedAlgorithms) VerifyAlgorithm(ctx context.Context, alg jwa.Signatur
 	return errors.New("jws: signing algorithm is not allowed")
 }
 
-// UnsafeAnyAlgorithm is an AlgorithmVerfier that accepts any algorithm.
-var UnsafeAnyAlgorithm = unsafeAnyAlgorithmVerifier{}
+// UnsecureAnyAlgorithm is an AlgorithmVerfier that accepts any algorithm.
+var UnsecureAnyAlgorithm = unsecureAnyAlgorithmVerifier{}
 
-type unsafeAnyAlgorithmVerifier struct{}
+type unsecureAnyAlgorithmVerifier struct{}
 
-func (unsafeAnyAlgorithmVerifier) VerifyAlgorithm(ctx context.Context, alg jwa.SignatureAlgorithm) error {
+func (unsecureAnyAlgorithmVerifier) VerifyAlgorithm(ctx context.Context, alg jwa.SignatureAlgorithm) error {
 	return nil
 }
 

--- a/jws/verifier.go
+++ b/jws/verifier.go
@@ -60,6 +60,9 @@ func (v *Verifier) Verify(ctx context.Context, msg *Message) (protected *Header,
 	buf := make([]byte, size)
 
 	for _, sig := range msg.Signatures {
+		if err := v.AlgorithmVerfier.VerifyAlgorithm(ctx, sig.protected.alg); err != nil {
+			continue
+		}
 		key, err := v.KeyFinder.FindKey(ctx, sig.protected, sig.header)
 		if err != nil {
 			continue

--- a/jws/verifier.go
+++ b/jws/verifier.go
@@ -3,17 +3,52 @@ package jws
 import (
 	"context"
 	"errors"
+
+	"github.com/shogo82148/goat/jwa"
 )
 
 var errVerifyFailed = errors.New("jws: failed to verify the message")
 
+// AlgorithmVerfier verifies the algorithm used for signing.
+type AlgorithmVerfier interface {
+	VerifyAlgorithm(ctx context.Context, alg jwa.SignatureAlgorithm) error
+}
+
+type AllowedAlgorithms []jwa.SignatureAlgorithm
+
+func (a AllowedAlgorithms) VerifyAlgorithm(ctx context.Context, alg jwa.SignatureAlgorithm) error {
+	for _, allowed := range a {
+		if alg == allowed {
+			return nil
+		}
+	}
+	return errors.New("jws: signing algorithm is not allowed")
+}
+
+// UnsafeAnyAlgorithm is an AlgorithmVerfier that accepts any algorithm.
+var UnsafeAnyAlgorithm = unsafeAnyAlgorithmVerifier{}
+
+type unsafeAnyAlgorithmVerifier struct{}
+
+func (unsafeAnyAlgorithmVerifier) VerifyAlgorithm(ctx context.Context, alg jwa.SignatureAlgorithm) error {
+	return nil
+}
+
 // Verifier verifies the JWS message.
 type Verifier struct {
-	KeyFinder KeyFinder
+	_NamedFieldsRequired struct{}
+
+	AlgorithmVerfier AlgorithmVerfier
+	KeyFinder        KeyFinder
 }
 
 // Verify verifies the JWS message.
 func (v *Verifier) Verify(ctx context.Context, msg *Message) (protected *Header, payload []byte, err error) {
+	_ = v._NamedFieldsRequired
+	if v.AlgorithmVerfier == nil || v.KeyFinder == nil {
+		return nil, nil, errors.New("jws: verifier is not configured")
+	}
+
 	// pre-allocate buffer
 	size := 0
 	for _, sig := range msg.Signatures {

--- a/jws/verifier.go
+++ b/jws/verifier.go
@@ -1,0 +1,65 @@
+package jws
+
+import (
+	"errors"
+
+	"github.com/shogo82148/goat/sig"
+)
+
+var errVerifyFailed = errors.New("jws: failed to verify the message")
+
+// KeyFinder is a wrapper for the FindKey method.
+type KeyFinder interface {
+	// FindKey finds a signing key for the JWS message.
+	FindKey(protected, unprotected *Header) (key sig.SigningKey, err error)
+}
+
+// FindKeyFunc is an adapter to allow the use of ordinary functions as KeyFinder.
+type FindKeyFunc func(protected, unprotected *Header) (key sig.SigningKey, err error)
+
+func (f FindKeyFunc) FindKey(protected, unprotected *Header) (key sig.SigningKey, err error) {
+	return f(protected, unprotected)
+}
+
+// Verifier verifies the JWS message.
+type Verifier struct {
+	KeyFinder KeyFinder
+}
+
+// Verify verifies the JWS message.
+func (v *Verifier) Verify(msg *Message) (protected *Header, payload []byte, err error) {
+	// pre-allocate buffer
+	size := 0
+	for _, sig := range msg.Signatures {
+		if len(sig.raw) > size {
+			size = len(sig.raw)
+		}
+	}
+	size += len(msg.payload) + 1 // +1 for '.'
+	buf := make([]byte, size)
+
+	for _, sig := range msg.Signatures {
+		key, err := v.KeyFinder.FindKey(sig.protected, sig.header)
+		if err != nil {
+			continue
+		}
+		buf = buf[:0]
+		buf = append(buf, sig.raw...)
+		buf = append(buf, '.')
+		buf = append(buf, msg.payload...)
+		err = key.Verify(buf, sig.signature)
+		if err == nil {
+			var ret []byte
+			if sig.protected.b64 {
+				ret, err = b64Decode(msg.payload)
+				if err != nil {
+					return nil, nil, errVerifyFailed
+				}
+			} else {
+				ret = msg.payload
+			}
+			return sig.protected, ret, nil
+		}
+	}
+	return nil, nil, errVerifyFailed
+}

--- a/jwt/example_test.go
+++ b/jwt/example_test.go
@@ -24,10 +24,13 @@ func ExampleParse() {
 	}
 
 	data := "eyJhbGciOiJFZERTQSJ9." +
-		"eyJpc3MiOiJodHRwczovL2dpdGh1Yi5jb20vc2hvZ284MjE0OC9nb2F0In0." +
-		"40CbHAJKHO_wM6YdpXjrK6b4duHoD14e9fyrUxUvOVGGK_lOCkQCfR0eJWYwLhUwAATHFTI0ppkh1cBidC8DDQ"
+		"eyJhdWQiOiJodHRwczovL2dpdGh1Yi5jb20vc2hvZ284MjE0OCIsImlzcyI6Imh0dHBzOi8vZ2l0aHViLmNvbS9zaG9nbzgyMTQ4L2dvYXQifQ." +
+		"2p0nndDnxqsA9u1unq2bLPJiJpSj0hOfCNXe1b_Dsu7LskZPj1lFxv56rptqalzYVmR8kcrMyEIrRb94gr_KBw"
 	p := &jwt.Parser{
-		KeyFinder: &jwt.JWKKeyFiner{Key: key},
+		AlgorithmVerfier:      jwt.AllowedAlgorithms{jwa.EdDSA},
+		KeyFinder:             &jwt.JWKKeyFiner{Key: key},
+		IssuerSubjectVerifier: jwt.Issuer("https://github.com/shogo82148/goat"),
+		AudienceVerifier:      jwt.Audience("https://github.com/shogo82148"),
 	}
 	token, err := p.Parse(context.Background(), []byte(data))
 	if err != nil {
@@ -54,6 +57,7 @@ func ExampleSign() {
 	header.SetAlgorithm(jwa.EdDSA)
 	claims := new(jwt.Claims)
 	claims.Issuer = "https://github.com/shogo82148/goat"
+	claims.Audience = []string{"https://github.com/shogo82148"}
 
 	// sign
 	token, err := jwt.Sign(header, claims, signingKey)
@@ -63,7 +67,7 @@ func ExampleSign() {
 	fmt.Println(string(token))
 
 	// Output:
-	// eyJhbGciOiJFZERTQSJ9.eyJpc3MiOiJodHRwczovL2dpdGh1Yi5jb20vc2hvZ284MjE0OC9nb2F0In0.40CbHAJKHO_wM6YdpXjrK6b4duHoD14e9fyrUxUvOVGGK_lOCkQCfR0eJWYwLhUwAATHFTI0ppkh1cBidC8DDQ
+	// eyJhbGciOiJFZERTQSJ9.eyJhdWQiOiJodHRwczovL2dpdGh1Yi5jb20vc2hvZ284MjE0OCIsImlzcyI6Imh0dHBzOi8vZ2l0aHViLmNvbS9zaG9nbzgyMTQ4L2dvYXQifQ.2p0nndDnxqsA9u1unq2bLPJiJpSj0hOfCNXe1b_Dsu7LskZPj1lFxv56rptqalzYVmR8kcrMyEIrRb94gr_KBw
 }
 
 func ExampleClaims_DecodeCustom() {

--- a/jwt/example_test.go
+++ b/jwt/example_test.go
@@ -1,6 +1,7 @@
 package jwt_test
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -25,8 +26,10 @@ func ExampleParse() {
 	data := "eyJhbGciOiJFZERTQSJ9." +
 		"eyJpc3MiOiJodHRwczovL2dpdGh1Yi5jb20vc2hvZ284MjE0OC9nb2F0In0." +
 		"40CbHAJKHO_wM6YdpXjrK6b4duHoD14e9fyrUxUvOVGGK_lOCkQCfR0eJWYwLhUwAATHFTI0ppkh1cBidC8DDQ"
-	finder := &jwt.JWKKeyFiner{Key: key}
-	token, err := jwt.Parse([]byte(data), finder)
+	p := &jwt.Parser{
+		KeyFinder: &jwt.JWKKeyFiner{Key: key},
+	}
+	token, err := p.Parse(context.Background(), []byte(data))
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/jwt/fuzz_test.go
+++ b/jwt/fuzz_test.go
@@ -1,131 +1,134 @@
 package jwt
 
-// import (
-// 	"context"
-// 	"errors"
-// 	"reflect"
-// 	"testing"
-// 	"time"
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+	"time"
 
-// 	_ "github.com/shogo82148/goat/jwa/es" // for ECDSA
-// 	_ "github.com/shogo82148/goat/jwa/hs" // for HMAC SHA-256
-// 	_ "github.com/shogo82148/goat/jwa/rs" // for RSASSA-PKCS1-v1_5 SHA-256
-// 	"github.com/shogo82148/goat/jwk"
-// 	"github.com/shogo82148/goat/jws"
-// 	"github.com/shogo82148/goat/sig"
-// )
+	_ "github.com/shogo82148/goat/jwa/es" // for ECDSA
+	_ "github.com/shogo82148/goat/jwa/hs" // for HMAC SHA-256
+	_ "github.com/shogo82148/goat/jwa/rs" // for RSASSA-PKCS1-v1_5 SHA-256
+	"github.com/shogo82148/goat/jwk"
+	"github.com/shogo82148/goat/jws"
+	"github.com/shogo82148/goat/sig"
+)
 
-// func FuzzJWT(f *testing.F) {
-// 	defer mockTime(func() time.Time {
-// 		return time.Unix(1300819379, 0)
-// 	})()
+func FuzzJWT(f *testing.F) {
+	defer mockTime(func() time.Time {
+		return time.Unix(1300819379, 0)
+	})()
 
-// 	f.Add(
-// 		"eyJ0eXAiOiJKV1QiLA0KICJhbGciOiJIUzI1NiJ9"+
-// 			"."+
-// 			"eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFt"+
-// 			"cGxlLmNvbS9pc19yb290Ijp0cnVlfQ"+
-// 			"."+
-// 			"dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk",
-// 		`{"kty":"oct",`+
-// 			`"k":"AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75`+
-// 			`aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow"`+
-// 			`}`,
-// 	)
-// 	f.Add(
-// 		"eyJhbGciOiJSUzI1NiJ9"+
-// 			"."+
-// 			"eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFt"+
-// 			"cGxlLmNvbS9pc19yb290Ijp0cnVlfQ"+
-// 			"."+
-// 			"cC4hiUPoj9Eetdgtv3hF80EGrhuB__dzERat0XF9g2VtQgr9PJbu3XOiZj5RZmh7"+
-// 			"AAuHIm4Bh-0Qc_lF5YKt_O8W2Fp5jujGbds9uJdbF9CUAr7t1dnZcAcQjbKBYNX4"+
-// 			"BAynRFdiuB--f_nZLgrnbyTyWzO75vRK5h6xBArLIARNPvkSjtQBMHlb1L07Qe7K"+
-// 			"0GarZRmB_eSN9383LcOLn6_dO--xi12jzDwusC-eOkHWEsqtFZESc6BfI7noOPqv"+
-// 			"hJ1phCnvWh6IeYI2w9QOYEUipUTI8np6LbgGY9Fs98rqVt5AXLIhWkWywlVmtVrB"+
-// 			"p0igcN_IoypGlUPQGe77Rw",
-// 		`{"kty":"RSA",`+
-// 			`"n":"ofgWCuLjybRlzo0tZWJjNiuSfb4p4fAkd_wWJcyQoTbji9k0l8W26mPddx`+
-// 			`HmfHQp-Vaw-4qPCJrcS2mJPMEzP1Pt0Bm4d4QlL-yRT-SFd2lZS-pCgNMs`+
-// 			`D1W_YpRPEwOWvG6b32690r2jZ47soMZo9wGzjb_7OMg0LOL-bSf63kpaSH`+
-// 			`SXndS5z5rexMdbBYUsLA9e-KXBdQOS-UTo7WTBEMa2R2CapHg665xsmtdV`+
-// 			`MTBQY4uDZlxvb3qCo5ZwKh9kG4LT6_I5IhlJH7aGhyxXFvUK-DWNmoudF8`+
-// 			`NAco9_h9iaGNj8q2ethFkMLs91kzk2PAcDTW9gb54h4FRWyuXpoQ",`+
-// 			`"e":"AQAB",`+
-// 			`"d":"Eq5xpGnNCivDflJsRQBXHx1hdR1k6Ulwe2JZD50LpXyWPEAeP88vLNO97I`+
-// 			`jlA7_GQ5sLKMgvfTeXZx9SE-7YwVol2NXOoAJe46sui395IW_GO-pWJ1O0`+
-// 			`BkTGoVEn2bKVRUCgu-GjBVaYLU6f3l9kJfFNS3E0QbVdxzubSu3Mkqzjkn`+
-// 			`439X0M_V51gfpRLI9JYanrC4D4qAdGcopV_0ZHHzQlBjudU2QvXt4ehNYT`+
-// 			`CBr6XCLQUShb1juUO1ZdiYoFaFQT5Tw8bGUl_x_jTj3ccPDVZFD9pIuhLh`+
-// 			`BOneufuBiB4cS98l2SR_RQyGWSeWjnczT0QU91p1DhOVRuOopznQ",`+
-// 			`"p":"4BzEEOtIpmVdVEZNCqS7baC4crd0pqnRH_5IB3jw3bcxGn6QLvnEtfdUdi`+
-// 			`YrqBdss1l58BQ3KhooKeQTa9AB0Hw_Py5PJdTJNPY8cQn7ouZ2KKDcmnPG`+
-// 			`BY5t7yLc1QlQ5xHdwW1VhvKn-nXqhJTBgIPgtldC-KDV5z-y2XDwGUc",`+
-// 			`"q":"uQPEfgmVtjL0Uyyx88GZFF1fOunH3-7cepKmtH4pxhtCoHqpWmT8YAmZxa`+
-// 			`ewHgHAjLYsp1ZSe7zFYHj7C6ul7TjeLQeZD_YwD66t62wDmpe_HlB-TnBA`+
-// 			`-njbglfIsRLtXlnDzQkv5dTltRJ11BKBBypeeF6689rjcJIDEz9RWdc",`+
-// 			`"dp":"BwKfV3Akq5_MFZDFZCnW-wzl-CCo83WoZvnLQwCTeDv8uzluRSnm71I3Q`+
-// 			`CLdhrqE2e9YkxvuxdBfpT_PI7Yz-FOKnu1R6HsJeDCjn12Sk3vmAktV2zb`+
-// 			`34MCdy7cpdTh_YVr7tss2u6vneTwrA86rZtu5Mbr1C1XsmvkxHQAdYo0",`+
-// 			`"dq":"h_96-mK1R_7glhsum81dZxjTnYynPbZpHziZjeeHcXYsXaaMwkOlODsWa`+
-// 			`7I9xXDoRwbKgB719rrmI2oKr6N3Do9U0ajaHF-NKJnwgjMd2w9cjz3_-ky`+
-// 			`NlxAr2v4IKhGNpmM5iIgOS1VZnOZ68m6_pbLBSp3nssTdlqvd0tIiTHU",`+
-// 			`"qi":"IYd7DHOhrWvxkwPQsRM2tOgrjbcrfvtQJipd-DlcxyVuuM9sQLdgjVk2o`+
-// 			`y26F0EmpScGLq2MowX7fhd_QJQ3ydy5cY7YIBi87w93IKLEdfnbJtoOPLU`+
-// 			`W0ITrJReOgo1cq9SbsxYawBgfp_gh6A5603k2-ZQwVK0JKSHuLFkuQ3U"`+
-// 			`}`,
-// 	)
-// 	f.Add(
-// 		"eyJhbGciOiJFUzI1NiJ9"+
-// 			"."+
-// 			"eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFt"+
-// 			"cGxlLmNvbS9pc19yb290Ijp0cnVlfQ"+
-// 			"."+
-// 			"DtEhU3ljbEg8L38VWAfUAqOyKAM6-Xx-F4GawxaepmXFCgfTjDxw5djxLa8ISlSA"+
-// 			"pmWQxfKTUJqPP3-Kg6NU1Q",
-// 		`{"kty":"EC",`+
-// 			`"crv":"P-256",`+
-// 			`"x":"f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvRVEU",`+
-// 			`"y":"x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0",`+
-// 			`"d":"jpsQnnGQmL-YBIffH1136cspYG6-0iY7X1fCE9-E9LI"`+
-// 			`}`,
-// 	)
-// 	f.Fuzz(func(t *testing.T, data, key string) {
-// 		k, err := jwk.ParseKey([]byte(key))
-// 		if err != nil {
-// 			return
-// 		}
-// 		p := &Parser{
-// 			KeyFinder: FindKeyFunc(func(ctx context.Context, header *jws.Header) (sig.SigningKey, error) {
-// 				alg := header.Algorithm()
-// 				if !alg.Available() {
-// 					return nil, errors.New("unknown algorithm")
-// 				}
-// 				sigKey := alg.New().NewSigningKey(k)
-// 				return sigKey, nil
-// 			}),
-// 		}
-// 		var sigKey sig.SigningKey
-// 		token1, err := p.Parse(context.Background(), []byte(data))
-// 		if err != nil {
-// 			return
-// 		}
-// 		if k.PrivateKey() == nil {
-// 			return // the key doesn't support signing, we skip it.
-// 		}
+	f.Add(
+		"eyJ0eXAiOiJKV1QiLA0KICJhbGciOiJIUzI1NiJ9"+
+			"."+
+			"eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFt"+
+			"cGxlLmNvbS9pc19yb290Ijp0cnVlfQ"+
+			"."+
+			"dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk",
+		`{"kty":"oct",`+
+			`"k":"AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75`+
+			`aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow"`+
+			`}`,
+	)
+	f.Add(
+		"eyJhbGciOiJSUzI1NiJ9"+
+			"."+
+			"eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFt"+
+			"cGxlLmNvbS9pc19yb290Ijp0cnVlfQ"+
+			"."+
+			"cC4hiUPoj9Eetdgtv3hF80EGrhuB__dzERat0XF9g2VtQgr9PJbu3XOiZj5RZmh7"+
+			"AAuHIm4Bh-0Qc_lF5YKt_O8W2Fp5jujGbds9uJdbF9CUAr7t1dnZcAcQjbKBYNX4"+
+			"BAynRFdiuB--f_nZLgrnbyTyWzO75vRK5h6xBArLIARNPvkSjtQBMHlb1L07Qe7K"+
+			"0GarZRmB_eSN9383LcOLn6_dO--xi12jzDwusC-eOkHWEsqtFZESc6BfI7noOPqv"+
+			"hJ1phCnvWh6IeYI2w9QOYEUipUTI8np6LbgGY9Fs98rqVt5AXLIhWkWywlVmtVrB"+
+			"p0igcN_IoypGlUPQGe77Rw",
+		`{"kty":"RSA",`+
+			`"n":"ofgWCuLjybRlzo0tZWJjNiuSfb4p4fAkd_wWJcyQoTbji9k0l8W26mPddx`+
+			`HmfHQp-Vaw-4qPCJrcS2mJPMEzP1Pt0Bm4d4QlL-yRT-SFd2lZS-pCgNMs`+
+			`D1W_YpRPEwOWvG6b32690r2jZ47soMZo9wGzjb_7OMg0LOL-bSf63kpaSH`+
+			`SXndS5z5rexMdbBYUsLA9e-KXBdQOS-UTo7WTBEMa2R2CapHg665xsmtdV`+
+			`MTBQY4uDZlxvb3qCo5ZwKh9kG4LT6_I5IhlJH7aGhyxXFvUK-DWNmoudF8`+
+			`NAco9_h9iaGNj8q2ethFkMLs91kzk2PAcDTW9gb54h4FRWyuXpoQ",`+
+			`"e":"AQAB",`+
+			`"d":"Eq5xpGnNCivDflJsRQBXHx1hdR1k6Ulwe2JZD50LpXyWPEAeP88vLNO97I`+
+			`jlA7_GQ5sLKMgvfTeXZx9SE-7YwVol2NXOoAJe46sui395IW_GO-pWJ1O0`+
+			`BkTGoVEn2bKVRUCgu-GjBVaYLU6f3l9kJfFNS3E0QbVdxzubSu3Mkqzjkn`+
+			`439X0M_V51gfpRLI9JYanrC4D4qAdGcopV_0ZHHzQlBjudU2QvXt4ehNYT`+
+			`CBr6XCLQUShb1juUO1ZdiYoFaFQT5Tw8bGUl_x_jTj3ccPDVZFD9pIuhLh`+
+			`BOneufuBiB4cS98l2SR_RQyGWSeWjnczT0QU91p1DhOVRuOopznQ",`+
+			`"p":"4BzEEOtIpmVdVEZNCqS7baC4crd0pqnRH_5IB3jw3bcxGn6QLvnEtfdUdi`+
+			`YrqBdss1l58BQ3KhooKeQTa9AB0Hw_Py5PJdTJNPY8cQn7ouZ2KKDcmnPG`+
+			`BY5t7yLc1QlQ5xHdwW1VhvKn-nXqhJTBgIPgtldC-KDV5z-y2XDwGUc",`+
+			`"q":"uQPEfgmVtjL0Uyyx88GZFF1fOunH3-7cepKmtH4pxhtCoHqpWmT8YAmZxa`+
+			`ewHgHAjLYsp1ZSe7zFYHj7C6ul7TjeLQeZD_YwD66t62wDmpe_HlB-TnBA`+
+			`-njbglfIsRLtXlnDzQkv5dTltRJ11BKBBypeeF6689rjcJIDEz9RWdc",`+
+			`"dp":"BwKfV3Akq5_MFZDFZCnW-wzl-CCo83WoZvnLQwCTeDv8uzluRSnm71I3Q`+
+			`CLdhrqE2e9YkxvuxdBfpT_PI7Yz-FOKnu1R6HsJeDCjn12Sk3vmAktV2zb`+
+			`34MCdy7cpdTh_YVr7tss2u6vneTwrA86rZtu5Mbr1C1XsmvkxHQAdYo0",`+
+			`"dq":"h_96-mK1R_7glhsum81dZxjTnYynPbZpHziZjeeHcXYsXaaMwkOlODsWa`+
+			`7I9xXDoRwbKgB719rrmI2oKr6N3Do9U0ajaHF-NKJnwgjMd2w9cjz3_-ky`+
+			`NlxAr2v4IKhGNpmM5iIgOS1VZnOZ68m6_pbLBSp3nssTdlqvd0tIiTHU",`+
+			`"qi":"IYd7DHOhrWvxkwPQsRM2tOgrjbcrfvtQJipd-DlcxyVuuM9sQLdgjVk2o`+
+			`y26F0EmpScGLq2MowX7fhd_QJQ3ydy5cY7YIBi87w93IKLEdfnbJtoOPLU`+
+			`W0ITrJReOgo1cq9SbsxYawBgfp_gh6A5603k2-ZQwVK0JKSHuLFkuQ3U"`+
+			`}`,
+	)
+	f.Add(
+		"eyJhbGciOiJFUzI1NiJ9"+
+			"."+
+			"eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFt"+
+			"cGxlLmNvbS9pc19yb290Ijp0cnVlfQ"+
+			"."+
+			"DtEhU3ljbEg8L38VWAfUAqOyKAM6-Xx-F4GawxaepmXFCgfTjDxw5djxLa8ISlSA"+
+			"pmWQxfKTUJqPP3-Kg6NU1Q",
+		`{"kty":"EC",`+
+			`"crv":"P-256",`+
+			`"x":"f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvRVEU",`+
+			`"y":"x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0",`+
+			`"d":"jpsQnnGQmL-YBIffH1136cspYG6-0iY7X1fCE9-E9LI"`+
+			`}`,
+	)
+	f.Fuzz(func(t *testing.T, data, key string) {
+		k, err := jwk.ParseKey([]byte(key))
+		if err != nil {
+			return
+		}
+		var sigKey sig.SigningKey
+		p := &Parser{
+			KeyFinder: FindKeyFunc(func(ctx context.Context, header *jws.Header) (sig.SigningKey, error) {
+				alg := header.Algorithm()
+				if !alg.Available() {
+					return nil, errors.New("unknown algorithm")
+				}
+				sigKey = alg.New().NewSigningKey(k)
+				return sigKey, nil
+			}),
+		}
+		token1, err := p.Parse(context.Background(), []byte(data))
+		if err != nil {
+			return
+		}
+		if k.PrivateKey() == nil {
+			return // the key doesn't support signing, we skip it.
+		}
 
-// 		signed, err := Sign(token1.Header, token1.Claims, sigKey)
-// 		if err != nil {
-// 			t.Fatal(err)
-// 		}
-// 		token2, err := Parse(signed, FindKeyFunc(func(header *jws.Header) (sig.SigningKey, error) {
-// 			return sigKey, nil
-// 		}))
-// 		if err != nil {
-// 			t.Fatal(err)
-// 		}
-// 		if !reflect.DeepEqual(token1.Claims, token2.Claims) {
-// 			t.Error("payload mismatch")
-// 		}
-// 	})
-// }
+		signed, err := Sign(token1.Header, token1.Claims, sigKey)
+		if err != nil {
+			t.Fatal(err)
+		}
+		p = &Parser{
+			KeyFinder: FindKeyFunc(func(ctx context.Context, header *jws.Header) (sig.SigningKey, error) {
+				return sigKey, nil
+			}),
+		}
+		token2, err := p.Parse(context.Background(), signed)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !reflect.DeepEqual(token1.Claims, token2.Claims) {
+			t.Error("payload mismatch")
+		}
+	})
+}

--- a/jwt/fuzz_test.go
+++ b/jwt/fuzz_test.go
@@ -16,9 +16,9 @@ import (
 )
 
 func FuzzJWT(f *testing.F) {
-	defer mockTime(func() time.Time {
+	mockTime(f, func() time.Time {
 		return time.Unix(1300819379, 0)
-	})()
+	})
 
 	f.Add(
 		"eyJ0eXAiOiJKV1QiLA0KICJhbGciOiJIUzI1NiJ9"+

--- a/jwt/fuzz_test.go
+++ b/jwt/fuzz_test.go
@@ -1,127 +1,131 @@
 package jwt
 
-import (
-	"errors"
-	"reflect"
-	"testing"
-	"time"
+// import (
+// 	"context"
+// 	"errors"
+// 	"reflect"
+// 	"testing"
+// 	"time"
 
-	_ "github.com/shogo82148/goat/jwa/es" // for ECDSA
-	_ "github.com/shogo82148/goat/jwa/hs" // for HMAC SHA-256
-	_ "github.com/shogo82148/goat/jwa/rs" // for RSASSA-PKCS1-v1_5 SHA-256
-	"github.com/shogo82148/goat/jwk"
-	"github.com/shogo82148/goat/jws"
-	"github.com/shogo82148/goat/sig"
-)
+// 	_ "github.com/shogo82148/goat/jwa/es" // for ECDSA
+// 	_ "github.com/shogo82148/goat/jwa/hs" // for HMAC SHA-256
+// 	_ "github.com/shogo82148/goat/jwa/rs" // for RSASSA-PKCS1-v1_5 SHA-256
+// 	"github.com/shogo82148/goat/jwk"
+// 	"github.com/shogo82148/goat/jws"
+// 	"github.com/shogo82148/goat/sig"
+// )
 
-func FuzzJWT(f *testing.F) {
-	defer mockTime(func() time.Time {
-		return time.Unix(1300819379, 0)
-	})()
+// func FuzzJWT(f *testing.F) {
+// 	defer mockTime(func() time.Time {
+// 		return time.Unix(1300819379, 0)
+// 	})()
 
-	f.Add(
-		"eyJ0eXAiOiJKV1QiLA0KICJhbGciOiJIUzI1NiJ9"+
-			"."+
-			"eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFt"+
-			"cGxlLmNvbS9pc19yb290Ijp0cnVlfQ"+
-			"."+
-			"dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk",
-		`{"kty":"oct",`+
-			`"k":"AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75`+
-			`aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow"`+
-			`}`,
-	)
-	f.Add(
-		"eyJhbGciOiJSUzI1NiJ9"+
-			"."+
-			"eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFt"+
-			"cGxlLmNvbS9pc19yb290Ijp0cnVlfQ"+
-			"."+
-			"cC4hiUPoj9Eetdgtv3hF80EGrhuB__dzERat0XF9g2VtQgr9PJbu3XOiZj5RZmh7"+
-			"AAuHIm4Bh-0Qc_lF5YKt_O8W2Fp5jujGbds9uJdbF9CUAr7t1dnZcAcQjbKBYNX4"+
-			"BAynRFdiuB--f_nZLgrnbyTyWzO75vRK5h6xBArLIARNPvkSjtQBMHlb1L07Qe7K"+
-			"0GarZRmB_eSN9383LcOLn6_dO--xi12jzDwusC-eOkHWEsqtFZESc6BfI7noOPqv"+
-			"hJ1phCnvWh6IeYI2w9QOYEUipUTI8np6LbgGY9Fs98rqVt5AXLIhWkWywlVmtVrB"+
-			"p0igcN_IoypGlUPQGe77Rw",
-		`{"kty":"RSA",`+
-			`"n":"ofgWCuLjybRlzo0tZWJjNiuSfb4p4fAkd_wWJcyQoTbji9k0l8W26mPddx`+
-			`HmfHQp-Vaw-4qPCJrcS2mJPMEzP1Pt0Bm4d4QlL-yRT-SFd2lZS-pCgNMs`+
-			`D1W_YpRPEwOWvG6b32690r2jZ47soMZo9wGzjb_7OMg0LOL-bSf63kpaSH`+
-			`SXndS5z5rexMdbBYUsLA9e-KXBdQOS-UTo7WTBEMa2R2CapHg665xsmtdV`+
-			`MTBQY4uDZlxvb3qCo5ZwKh9kG4LT6_I5IhlJH7aGhyxXFvUK-DWNmoudF8`+
-			`NAco9_h9iaGNj8q2ethFkMLs91kzk2PAcDTW9gb54h4FRWyuXpoQ",`+
-			`"e":"AQAB",`+
-			`"d":"Eq5xpGnNCivDflJsRQBXHx1hdR1k6Ulwe2JZD50LpXyWPEAeP88vLNO97I`+
-			`jlA7_GQ5sLKMgvfTeXZx9SE-7YwVol2NXOoAJe46sui395IW_GO-pWJ1O0`+
-			`BkTGoVEn2bKVRUCgu-GjBVaYLU6f3l9kJfFNS3E0QbVdxzubSu3Mkqzjkn`+
-			`439X0M_V51gfpRLI9JYanrC4D4qAdGcopV_0ZHHzQlBjudU2QvXt4ehNYT`+
-			`CBr6XCLQUShb1juUO1ZdiYoFaFQT5Tw8bGUl_x_jTj3ccPDVZFD9pIuhLh`+
-			`BOneufuBiB4cS98l2SR_RQyGWSeWjnczT0QU91p1DhOVRuOopznQ",`+
-			`"p":"4BzEEOtIpmVdVEZNCqS7baC4crd0pqnRH_5IB3jw3bcxGn6QLvnEtfdUdi`+
-			`YrqBdss1l58BQ3KhooKeQTa9AB0Hw_Py5PJdTJNPY8cQn7ouZ2KKDcmnPG`+
-			`BY5t7yLc1QlQ5xHdwW1VhvKn-nXqhJTBgIPgtldC-KDV5z-y2XDwGUc",`+
-			`"q":"uQPEfgmVtjL0Uyyx88GZFF1fOunH3-7cepKmtH4pxhtCoHqpWmT8YAmZxa`+
-			`ewHgHAjLYsp1ZSe7zFYHj7C6ul7TjeLQeZD_YwD66t62wDmpe_HlB-TnBA`+
-			`-njbglfIsRLtXlnDzQkv5dTltRJ11BKBBypeeF6689rjcJIDEz9RWdc",`+
-			`"dp":"BwKfV3Akq5_MFZDFZCnW-wzl-CCo83WoZvnLQwCTeDv8uzluRSnm71I3Q`+
-			`CLdhrqE2e9YkxvuxdBfpT_PI7Yz-FOKnu1R6HsJeDCjn12Sk3vmAktV2zb`+
-			`34MCdy7cpdTh_YVr7tss2u6vneTwrA86rZtu5Mbr1C1XsmvkxHQAdYo0",`+
-			`"dq":"h_96-mK1R_7glhsum81dZxjTnYynPbZpHziZjeeHcXYsXaaMwkOlODsWa`+
-			`7I9xXDoRwbKgB719rrmI2oKr6N3Do9U0ajaHF-NKJnwgjMd2w9cjz3_-ky`+
-			`NlxAr2v4IKhGNpmM5iIgOS1VZnOZ68m6_pbLBSp3nssTdlqvd0tIiTHU",`+
-			`"qi":"IYd7DHOhrWvxkwPQsRM2tOgrjbcrfvtQJipd-DlcxyVuuM9sQLdgjVk2o`+
-			`y26F0EmpScGLq2MowX7fhd_QJQ3ydy5cY7YIBi87w93IKLEdfnbJtoOPLU`+
-			`W0ITrJReOgo1cq9SbsxYawBgfp_gh6A5603k2-ZQwVK0JKSHuLFkuQ3U"`+
-			`}`,
-	)
-	f.Add(
-		"eyJhbGciOiJFUzI1NiJ9"+
-			"."+
-			"eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFt"+
-			"cGxlLmNvbS9pc19yb290Ijp0cnVlfQ"+
-			"."+
-			"DtEhU3ljbEg8L38VWAfUAqOyKAM6-Xx-F4GawxaepmXFCgfTjDxw5djxLa8ISlSA"+
-			"pmWQxfKTUJqPP3-Kg6NU1Q",
-		`{"kty":"EC",`+
-			`"crv":"P-256",`+
-			`"x":"f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvRVEU",`+
-			`"y":"x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0",`+
-			`"d":"jpsQnnGQmL-YBIffH1136cspYG6-0iY7X1fCE9-E9LI"`+
-			`}`,
-	)
-	f.Fuzz(func(t *testing.T, data, key string) {
-		k, err := jwk.ParseKey([]byte(key))
-		if err != nil {
-			return
-		}
-		var sigKey sig.SigningKey
-		token1, err := Parse([]byte(data), FindKeyFunc(func(header *jws.Header) (sig.SigningKey, error) {
-			alg := header.Algorithm()
-			if !alg.Available() {
-				return nil, errors.New("unknown algorithm")
-			}
-			sigKey = alg.New().NewSigningKey(k)
-			return sigKey, nil
-		}))
-		if err != nil {
-			return
-		}
-		if k.PrivateKey() == nil {
-			return // the key doesn't support signing, we skip it.
-		}
+// 	f.Add(
+// 		"eyJ0eXAiOiJKV1QiLA0KICJhbGciOiJIUzI1NiJ9"+
+// 			"."+
+// 			"eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFt"+
+// 			"cGxlLmNvbS9pc19yb290Ijp0cnVlfQ"+
+// 			"."+
+// 			"dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk",
+// 		`{"kty":"oct",`+
+// 			`"k":"AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75`+
+// 			`aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow"`+
+// 			`}`,
+// 	)
+// 	f.Add(
+// 		"eyJhbGciOiJSUzI1NiJ9"+
+// 			"."+
+// 			"eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFt"+
+// 			"cGxlLmNvbS9pc19yb290Ijp0cnVlfQ"+
+// 			"."+
+// 			"cC4hiUPoj9Eetdgtv3hF80EGrhuB__dzERat0XF9g2VtQgr9PJbu3XOiZj5RZmh7"+
+// 			"AAuHIm4Bh-0Qc_lF5YKt_O8W2Fp5jujGbds9uJdbF9CUAr7t1dnZcAcQjbKBYNX4"+
+// 			"BAynRFdiuB--f_nZLgrnbyTyWzO75vRK5h6xBArLIARNPvkSjtQBMHlb1L07Qe7K"+
+// 			"0GarZRmB_eSN9383LcOLn6_dO--xi12jzDwusC-eOkHWEsqtFZESc6BfI7noOPqv"+
+// 			"hJ1phCnvWh6IeYI2w9QOYEUipUTI8np6LbgGY9Fs98rqVt5AXLIhWkWywlVmtVrB"+
+// 			"p0igcN_IoypGlUPQGe77Rw",
+// 		`{"kty":"RSA",`+
+// 			`"n":"ofgWCuLjybRlzo0tZWJjNiuSfb4p4fAkd_wWJcyQoTbji9k0l8W26mPddx`+
+// 			`HmfHQp-Vaw-4qPCJrcS2mJPMEzP1Pt0Bm4d4QlL-yRT-SFd2lZS-pCgNMs`+
+// 			`D1W_YpRPEwOWvG6b32690r2jZ47soMZo9wGzjb_7OMg0LOL-bSf63kpaSH`+
+// 			`SXndS5z5rexMdbBYUsLA9e-KXBdQOS-UTo7WTBEMa2R2CapHg665xsmtdV`+
+// 			`MTBQY4uDZlxvb3qCo5ZwKh9kG4LT6_I5IhlJH7aGhyxXFvUK-DWNmoudF8`+
+// 			`NAco9_h9iaGNj8q2ethFkMLs91kzk2PAcDTW9gb54h4FRWyuXpoQ",`+
+// 			`"e":"AQAB",`+
+// 			`"d":"Eq5xpGnNCivDflJsRQBXHx1hdR1k6Ulwe2JZD50LpXyWPEAeP88vLNO97I`+
+// 			`jlA7_GQ5sLKMgvfTeXZx9SE-7YwVol2NXOoAJe46sui395IW_GO-pWJ1O0`+
+// 			`BkTGoVEn2bKVRUCgu-GjBVaYLU6f3l9kJfFNS3E0QbVdxzubSu3Mkqzjkn`+
+// 			`439X0M_V51gfpRLI9JYanrC4D4qAdGcopV_0ZHHzQlBjudU2QvXt4ehNYT`+
+// 			`CBr6XCLQUShb1juUO1ZdiYoFaFQT5Tw8bGUl_x_jTj3ccPDVZFD9pIuhLh`+
+// 			`BOneufuBiB4cS98l2SR_RQyGWSeWjnczT0QU91p1DhOVRuOopznQ",`+
+// 			`"p":"4BzEEOtIpmVdVEZNCqS7baC4crd0pqnRH_5IB3jw3bcxGn6QLvnEtfdUdi`+
+// 			`YrqBdss1l58BQ3KhooKeQTa9AB0Hw_Py5PJdTJNPY8cQn7ouZ2KKDcmnPG`+
+// 			`BY5t7yLc1QlQ5xHdwW1VhvKn-nXqhJTBgIPgtldC-KDV5z-y2XDwGUc",`+
+// 			`"q":"uQPEfgmVtjL0Uyyx88GZFF1fOunH3-7cepKmtH4pxhtCoHqpWmT8YAmZxa`+
+// 			`ewHgHAjLYsp1ZSe7zFYHj7C6ul7TjeLQeZD_YwD66t62wDmpe_HlB-TnBA`+
+// 			`-njbglfIsRLtXlnDzQkv5dTltRJ11BKBBypeeF6689rjcJIDEz9RWdc",`+
+// 			`"dp":"BwKfV3Akq5_MFZDFZCnW-wzl-CCo83WoZvnLQwCTeDv8uzluRSnm71I3Q`+
+// 			`CLdhrqE2e9YkxvuxdBfpT_PI7Yz-FOKnu1R6HsJeDCjn12Sk3vmAktV2zb`+
+// 			`34MCdy7cpdTh_YVr7tss2u6vneTwrA86rZtu5Mbr1C1XsmvkxHQAdYo0",`+
+// 			`"dq":"h_96-mK1R_7glhsum81dZxjTnYynPbZpHziZjeeHcXYsXaaMwkOlODsWa`+
+// 			`7I9xXDoRwbKgB719rrmI2oKr6N3Do9U0ajaHF-NKJnwgjMd2w9cjz3_-ky`+
+// 			`NlxAr2v4IKhGNpmM5iIgOS1VZnOZ68m6_pbLBSp3nssTdlqvd0tIiTHU",`+
+// 			`"qi":"IYd7DHOhrWvxkwPQsRM2tOgrjbcrfvtQJipd-DlcxyVuuM9sQLdgjVk2o`+
+// 			`y26F0EmpScGLq2MowX7fhd_QJQ3ydy5cY7YIBi87w93IKLEdfnbJtoOPLU`+
+// 			`W0ITrJReOgo1cq9SbsxYawBgfp_gh6A5603k2-ZQwVK0JKSHuLFkuQ3U"`+
+// 			`}`,
+// 	)
+// 	f.Add(
+// 		"eyJhbGciOiJFUzI1NiJ9"+
+// 			"."+
+// 			"eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFt"+
+// 			"cGxlLmNvbS9pc19yb290Ijp0cnVlfQ"+
+// 			"."+
+// 			"DtEhU3ljbEg8L38VWAfUAqOyKAM6-Xx-F4GawxaepmXFCgfTjDxw5djxLa8ISlSA"+
+// 			"pmWQxfKTUJqPP3-Kg6NU1Q",
+// 		`{"kty":"EC",`+
+// 			`"crv":"P-256",`+
+// 			`"x":"f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvRVEU",`+
+// 			`"y":"x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0",`+
+// 			`"d":"jpsQnnGQmL-YBIffH1136cspYG6-0iY7X1fCE9-E9LI"`+
+// 			`}`,
+// 	)
+// 	f.Fuzz(func(t *testing.T, data, key string) {
+// 		k, err := jwk.ParseKey([]byte(key))
+// 		if err != nil {
+// 			return
+// 		}
+// 		p := &Parser{
+// 			KeyFinder: FindKeyFunc(func(ctx context.Context, header *jws.Header) (sig.SigningKey, error) {
+// 				alg := header.Algorithm()
+// 				if !alg.Available() {
+// 					return nil, errors.New("unknown algorithm")
+// 				}
+// 				sigKey := alg.New().NewSigningKey(k)
+// 				return sigKey, nil
+// 			}),
+// 		}
+// 		var sigKey sig.SigningKey
+// 		token1, err := p.Parse(context.Background(), []byte(data))
+// 		if err != nil {
+// 			return
+// 		}
+// 		if k.PrivateKey() == nil {
+// 			return // the key doesn't support signing, we skip it.
+// 		}
 
-		signed, err := Sign(token1.Header, token1.Claims, sigKey)
-		if err != nil {
-			t.Fatal(err)
-		}
-		token2, err := Parse(signed, FindKeyFunc(func(header *jws.Header) (sig.SigningKey, error) {
-			return sigKey, nil
-		}))
-		if err != nil {
-			t.Fatal(err)
-		}
-		if !reflect.DeepEqual(token1.Claims, token2.Claims) {
-			t.Error("payload mismatch")
-		}
-	})
-}
+// 		signed, err := Sign(token1.Header, token1.Claims, sigKey)
+// 		if err != nil {
+// 			t.Fatal(err)
+// 		}
+// 		token2, err := Parse(signed, FindKeyFunc(func(header *jws.Header) (sig.SigningKey, error) {
+// 			return sigKey, nil
+// 		}))
+// 		if err != nil {
+// 			t.Fatal(err)
+// 		}
+// 		if !reflect.DeepEqual(token1.Claims, token2.Claims) {
+// 			t.Error("payload mismatch")
+// 		}
+// 	})
+// }

--- a/jwt/fuzz_test.go
+++ b/jwt/fuzz_test.go
@@ -105,6 +105,9 @@ func FuzzJWT(f *testing.F) {
 				sigKey = alg.New().NewSigningKey(k)
 				return sigKey, nil
 			}),
+			AlgorithmVerfier:      UnsecureAnyAlgorithm,
+			IssuerSubjectVerifier: UnsecureAnyIssuerSubject,
+			AudienceVerifier:      UnsecureAnyAudience,
 		}
 		token1, err := p.Parse(context.Background(), []byte(data))
 		if err != nil {
@@ -122,6 +125,9 @@ func FuzzJWT(f *testing.F) {
 			KeyFinder: FindKeyFunc(func(ctx context.Context, header *jws.Header) (sig.SigningKey, error) {
 				return sigKey, nil
 			}),
+			AlgorithmVerfier:      UnsecureAnyAlgorithm,
+			IssuerSubjectVerifier: UnsecureAnyIssuerSubject,
+			AudienceVerifier:      UnsecureAnyAudience,
 		}
 		token2, err := p.Parse(context.Background(), signed)
 		if err != nil {

--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -1,4 +1,4 @@
-// Package jws handles JSON Web Token defined in RFC 7519.
+// Package jwt handles JSON Web Token defined in RFC 7519.
 package jwt
 
 import (

--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -43,6 +43,12 @@ type Claims struct {
 	Raw map[string]any
 }
 
+// Token is a decoded JWT token.
+type Token struct {
+	Header *jws.Header
+	Claims *Claims
+}
+
 func Sign(header *jws.Header, claims *Claims, key sig.SigningKey) ([]byte, error) {
 	payload, err := encodeClaims(claims)
 	if err != nil {

--- a/jwt/jwt_test.go
+++ b/jwt/jwt_test.go
@@ -157,76 +157,76 @@ func TestParse_Claims(t *testing.T) {
 	}
 }
 
-// func TestSign(t *testing.T) {
+func TestSign(t *testing.T) {
 
-// 	t.Run("RFC 7519 Section 3.1. Example JWT", func(t *testing.T) {
-// 		rawKey := `{"kty":"oct",` +
-// 			`"k":"AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75` +
-// 			`aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow"` +
-// 			`}`
-// 		key, err := jwk.ParseKey([]byte(rawKey))
-// 		if err != nil {
-// 			t.Fatal(err)
-// 		}
-// 		sigKey := jwa.HS256.New().NewSigningKey(key)
+	t.Run("RFC 7519 Section 3.1. Example JWT", func(t *testing.T) {
+		rawKey := `{"kty":"oct",` +
+			`"k":"AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75` +
+			`aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow"` +
+			`}`
+		key, err := jwk.ParseKey([]byte(rawKey))
+		if err != nil {
+			t.Fatal(err)
+		}
+		sigKey := jwa.HS256.New().NewSigningKey(key)
 
-// 		header := jws.NewHeader()
-// 		header.SetAlgorithm(jwa.HS256)
-// 		header.SetType("JWT")
-// 		claims := &Claims{
-// 			Issuer:         "joe",
-// 			ExpirationTime: time.Unix(1300819380, 0),
-// 			Raw: map[string]any{
-// 				"http://example.com/is_root": true,
-// 			},
-// 		}
+		header := jws.NewHeader()
+		header.SetAlgorithm(jwa.HS256)
+		header.SetType("JWT")
+		claims := &Claims{
+			Issuer:         "joe",
+			ExpirationTime: time.Unix(1300819380, 0),
+			Raw: map[string]any{
+				"http://example.com/is_root": true,
+			},
+		}
 
-// 		got, err := Sign(header, claims, sigKey)
-// 		if err != nil {
-// 			t.Fatal(err)
-// 		}
+		got, err := Sign(header, claims, sigKey)
+		if err != nil {
+			t.Fatal(err)
+		}
 
-// 		want := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9" +
-// 			"." +
-// 			"eyJleHAiOjEzMDA4MTkzODAsImh0dHA6Ly9leGFtcGxlLmNvbS9pc19yb290Ijp0" +
-// 			"cnVlLCJpc3MiOiJqb2UifQ" +
-// 			"." +
-// 			"tu77b1J0ZCHMDd3tWZm36iolxZtBRaArSrtayOBDO34"
+		want := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9" +
+			"." +
+			"eyJleHAiOjEzMDA4MTkzODAsImh0dHA6Ly9leGFtcGxlLmNvbS9pc19yb290Ijp0" +
+			"cnVlLCJpc3MiOiJqb2UifQ" +
+			"." +
+			"tu77b1J0ZCHMDd3tWZm36iolxZtBRaArSrtayOBDO34"
 
-// 		if string(got) != want {
-// 			t.Errorf("unexpected payload: want %s, got %s", want, got)
-// 		}
-// 	})
+		if string(got) != want {
+			t.Errorf("unexpected payload: want %s, got %s", want, got)
+		}
+	})
 
-// 	t.Run("RFC 7519 Section 6.1. Example Unsecured JWT", func(t *testing.T) {
-// 		sigKey := jwa.None.New().NewSigningKey(nil)
-// 		header := jws.NewHeader()
-// 		header.SetAlgorithm(jwa.None)
-// 		header.SetType("JWT")
-// 		claims := &Claims{
-// 			Issuer:         "joe",
-// 			ExpirationTime: time.Unix(1300819380, 0),
-// 			Raw: map[string]any{
-// 				"http://example.com/is_root": true,
-// 			},
-// 		}
+	t.Run("RFC 7519 Section 6.1. Example Unsecured JWT", func(t *testing.T) {
+		sigKey := jwa.None.New().NewSigningKey(nil)
+		header := jws.NewHeader()
+		header.SetAlgorithm(jwa.None)
+		header.SetType("JWT")
+		claims := &Claims{
+			Issuer:         "joe",
+			ExpirationTime: time.Unix(1300819380, 0),
+			Raw: map[string]any{
+				"http://example.com/is_root": true,
+			},
+		}
 
-// 		got, err := Sign(header, claims, sigKey)
-// 		if err != nil {
-// 			t.Fatal(err)
-// 		}
+		got, err := Sign(header, claims, sigKey)
+		if err != nil {
+			t.Fatal(err)
+		}
 
-// 		want := "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0" +
-// 			"." +
-// 			"eyJleHAiOjEzMDA4MTkzODAsImh0dHA6Ly9leGFtcGxlLmNvbS9pc19yb290Ijp0" +
-// 			"cnVlLCJpc3MiOiJqb2UifQ" +
-// 			"."
+		want := "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0" +
+			"." +
+			"eyJleHAiOjEzMDA4MTkzODAsImh0dHA6Ly9leGFtcGxlLmNvbS9pc19yb290Ijp0" +
+			"cnVlLCJpc3MiOiJqb2UifQ" +
+			"."
 
-// 		if string(got) != want {
-// 			t.Errorf("unexpected payload: want %s, got %s", want, got)
-// 		}
-// 	})
-// }
+		if string(got) != want {
+			t.Errorf("unexpected payload: want %s, got %s", want, got)
+		}
+	})
+}
 
 func BenchmarkParse(b *testing.B) {
 	mockTime(b, func() time.Time {

--- a/jwt/jwt_test.go
+++ b/jwt/jwt_test.go
@@ -5,9 +5,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/shogo82148/goat/jwa"
 	_ "github.com/shogo82148/goat/jwa/hs"   // for HMAC SHA-256
 	_ "github.com/shogo82148/goat/jwa/none" // for none
 	"github.com/shogo82148/goat/jwk"
+	"github.com/shogo82148/goat/jws"
+	"github.com/shogo82148/goat/sig"
 )
 
 func mockTime(f func() time.Time) func() {
@@ -41,7 +44,10 @@ func TestParse(t *testing.T) {
 			t.Fatal(err)
 		}
 		p := &Parser{
-			KeyFinder: &JWKKeyFiner{Key: key},
+			KeyFinder:             &JWKKeyFiner{Key: key},
+			AlgorithmVerfier:      AllowedAlgorithms{jwa.HS256},
+			IssuerSubjectVerifier: Issuer("joe"),
+			AudienceVerifier:      UnsecureAnyAudience,
 		}
 		token, err := p.Parse(context.Background(), raw)
 		if err != nil {
@@ -60,33 +66,39 @@ func TestParse(t *testing.T) {
 		}
 	})
 
-	// t.Run("RFC 7519 Section 6.1. Example Unsecured JWT", func(t *testing.T) {
-	// 	raw := []byte(
-	// 		"eyJhbGciOiJub25lIn0" +
-	// 			"." +
-	// 			"eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFt" +
-	// 			"cGxlLmNvbS9pc19yb290Ijp0cnVlfQ" +
-	// 			".",
-	// 	)
-	// 	token, err := Parse(raw, FindKeyFunc(func(header *jws.Header) (sig.SigningKey, error) {
-	// 		alg := header.Algorithm().New()
-	// 		return alg.NewSigningKey(nil), nil
-	// 	}))
-	// 	if err != nil {
-	// 		t.Fatal(err)
-	// 	}
+	t.Run("RFC 7519 Section 6.1. Example Unsecured JWT", func(t *testing.T) {
+		raw := []byte(
+			"eyJhbGciOiJub25lIn0" +
+				"." +
+				"eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFt" +
+				"cGxlLmNvbS9pc19yb290Ijp0cnVlfQ" +
+				".",
+		)
+		p := &Parser{
+			KeyFinder: FindKeyFunc(func(ctx context.Context, header *jws.Header) (key sig.SigningKey, err error) {
+				alg := header.Algorithm().New()
+				return alg.NewSigningKey(nil), nil
+			}),
+			AlgorithmVerfier:      AllowedAlgorithms{jwa.None},
+			IssuerSubjectVerifier: Issuer("joe"),
+			AudienceVerifier:      UnsecureAnyAudience,
+		}
+		token, err := p.Parse(context.Background(), raw)
+		if err != nil {
+			t.Fatal(err)
+		}
 
-	// 	c := token.Claims
-	// 	if want, got := "joe", c.Issuer; want != got {
-	// 		t.Errorf("invalid issuer: want %q, got %q", want, got)
-	// 	}
-	// 	if want, got := time.Unix(1300819380, 0), token.Claims.ExpirationTime; !want.Equal(got) {
-	// 		t.Errorf("invalid exp claim: want %s, got %s", want, got)
-	// 	}
-	// 	if v, ok := c.Raw["http://example.com/is_root"].(bool); !ok || !v {
-	// 		t.Error("unexpected claim")
-	// 	}
-	// })
+		c := token.Claims
+		if want, got := "joe", c.Issuer; want != got {
+			t.Errorf("invalid issuer: want %q, got %q", want, got)
+		}
+		if want, got := time.Unix(1300819380, 0), token.Claims.ExpirationTime; !want.Equal(got) {
+			t.Errorf("invalid exp claim: want %s, got %s", want, got)
+		}
+		if v, ok := c.Raw["http://example.com/is_root"].(bool); !ok || !v {
+			t.Error("unexpected claim")
+		}
+	})
 }
 
 // func TestParse_Claims(t *testing.T) {

--- a/jwt/jwt_test.go
+++ b/jwt/jwt_test.go
@@ -228,34 +228,39 @@ func TestParse_Claims(t *testing.T) {
 // 	})
 // }
 
-// func BenchmarkParse(b *testing.B) {
-// 	defer mockTime(func() time.Time {
-// 		return time.Unix(1300819379, 0)
-// 	})()
+func BenchmarkParse(b *testing.B) {
+	mockTime(b, func() time.Time {
+		return time.Unix(1300819379, 0)
+	})
 
-// 	raw := []byte(
-// 		"eyJ0eXAiOiJKV1QiLA0KICJhbGciOiJIUzI1NiJ9" +
-// 			"." +
-// 			"eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFt" +
-// 			"cGxlLmNvbS9pc19yb290Ijp0cnVlfQ" +
-// 			"." +
-// 			"dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk",
-// 	)
-// 	rawKey := `{"kty":"oct",` +
-// 		`"k":"AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75` +
-// 		`aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow"` +
-// 		`}`
-// 	key, err := jwk.ParseKey([]byte(rawKey))
-// 	if err != nil {
-// 		b.Fatal(err)
-// 	}
-// 	finder := &JWKKeyFiner{Key: key}
+	raw := []byte(
+		"eyJ0eXAiOiJKV1QiLA0KICJhbGciOiJIUzI1NiJ9" +
+			"." +
+			"eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFt" +
+			"cGxlLmNvbS9pc19yb290Ijp0cnVlfQ" +
+			"." +
+			"dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk",
+	)
+	rawKey := `{"kty":"oct",` +
+		`"k":"AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75` +
+		`aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow"` +
+		`}`
+	key, err := jwk.ParseKey([]byte(rawKey))
+	if err != nil {
+		b.Fatal(err)
+	}
+	p := &Parser{
+		KeyFinder:             &JWKKeyFiner{Key: key},
+		AlgorithmVerfier:      AllowedAlgorithms{jwa.HS256},
+		IssuerSubjectVerifier: Issuer("joe"),
+		AudienceVerifier:      UnsecureAnyAudience,
+	}
 
-// 	b.ResetTimer()
-// 	for i := 0; i < b.N; i++ {
-// 		_, err := Parse(raw, finder)
-// 		if err != nil {
-// 			b.Fatal(err)
-// 		}
-// 	}
-// }
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := p.Parse(context.Background(), raw)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/jwt/jwt_test.go
+++ b/jwt/jwt_test.go
@@ -1,16 +1,13 @@
 package jwt
 
 import (
-	"encoding/base64"
+	"context"
 	"testing"
 	"time"
 
-	"github.com/shogo82148/goat/jwa"
 	_ "github.com/shogo82148/goat/jwa/hs"   // for HMAC SHA-256
 	_ "github.com/shogo82148/goat/jwa/none" // for none
 	"github.com/shogo82148/goat/jwk"
-	"github.com/shogo82148/goat/jws"
-	"github.com/shogo82148/goat/sig"
 )
 
 func mockTime(f func() time.Time) func() {
@@ -43,8 +40,10 @@ func TestParse(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		finder := &JWKKeyFiner{Key: key}
-		token, err := Parse(raw, finder)
+		p := &Parser{
+			KeyFinder: &JWKKeyFiner{Key: key},
+		}
+		token, err := p.Parse(context.Background(), raw)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -61,183 +60,183 @@ func TestParse(t *testing.T) {
 		}
 	})
 
-	t.Run("RFC 7519 Section 6.1. Example Unsecured JWT", func(t *testing.T) {
-		raw := []byte(
-			"eyJhbGciOiJub25lIn0" +
-				"." +
-				"eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFt" +
-				"cGxlLmNvbS9pc19yb290Ijp0cnVlfQ" +
-				".",
-		)
-		token, err := Parse(raw, FindKeyFunc(func(header *jws.Header) (sig.SigningKey, error) {
-			alg := header.Algorithm().New()
-			return alg.NewSigningKey(nil), nil
-		}))
-		if err != nil {
-			t.Fatal(err)
-		}
+	// t.Run("RFC 7519 Section 6.1. Example Unsecured JWT", func(t *testing.T) {
+	// 	raw := []byte(
+	// 		"eyJhbGciOiJub25lIn0" +
+	// 			"." +
+	// 			"eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFt" +
+	// 			"cGxlLmNvbS9pc19yb290Ijp0cnVlfQ" +
+	// 			".",
+	// 	)
+	// 	token, err := Parse(raw, FindKeyFunc(func(header *jws.Header) (sig.SigningKey, error) {
+	// 		alg := header.Algorithm().New()
+	// 		return alg.NewSigningKey(nil), nil
+	// 	}))
+	// 	if err != nil {
+	// 		t.Fatal(err)
+	// 	}
 
-		c := token.Claims
-		if want, got := "joe", c.Issuer; want != got {
-			t.Errorf("invalid issuer: want %q, got %q", want, got)
-		}
-		if want, got := time.Unix(1300819380, 0), token.Claims.ExpirationTime; !want.Equal(got) {
-			t.Errorf("invalid exp claim: want %s, got %s", want, got)
-		}
-		if v, ok := c.Raw["http://example.com/is_root"].(bool); !ok || !v {
-			t.Error("unexpected claim")
-		}
-	})
+	// 	c := token.Claims
+	// 	if want, got := "joe", c.Issuer; want != got {
+	// 		t.Errorf("invalid issuer: want %q, got %q", want, got)
+	// 	}
+	// 	if want, got := time.Unix(1300819380, 0), token.Claims.ExpirationTime; !want.Equal(got) {
+	// 		t.Errorf("invalid exp claim: want %s, got %s", want, got)
+	// 	}
+	// 	if v, ok := c.Raw["http://example.com/is_root"].(bool); !ok || !v {
+	// 		t.Error("unexpected claim")
+	// 	}
+	// })
 }
 
-func TestParse_Claims(t *testing.T) {
-	var now time.Time
-	defer mockTime(func() time.Time {
-		return now
-	})()
+// func TestParse_Claims(t *testing.T) {
+// 	var now time.Time
+// 	defer mockTime(func() time.Time {
+// 		return now
+// 	})()
 
-	algNone := FindKeyFunc(func(header *jws.Header) (sig.SigningKey, error) {
-		alg := jwa.None.New()
-		return alg.NewSigningKey(nil), nil
-	})
+// 	algNone := FindKeyFunc(func(header *jws.Header) (sig.SigningKey, error) {
+// 		alg := jwa.None.New()
+// 		return alg.NewSigningKey(nil), nil
+// 	})
 
-	var err error
-	var token, data []byte
+// 	var err error
+// 	var token, data []byte
 
-	token = []byte(`{"exp":1300819380}`)
-	data = []byte(
-		"eyJhbGciOiJub25lIn0." + // {"alg":"none"}
-			base64.RawURLEncoding.EncodeToString(token) + ".")
+// 	token = []byte(`{"exp":1300819380}`)
+// 	data = []byte(
+// 		"eyJhbGciOiJub25lIn0." + // {"alg":"none"}
+// 			base64.RawURLEncoding.EncodeToString(token) + ".")
 
-	now = time.Unix(1300819380, -1) // 1ns before expiration time
-	_, err = Parse(data, algNone)
-	if err != nil {
-		t.Error(err)
-	}
+// 	now = time.Unix(1300819380, -1) // 1ns before expiration time
+// 	_, err = Parse(data, algNone)
+// 	if err != nil {
+// 		t.Error(err)
+// 	}
 
-	now = time.Unix(1300819380, 0) // just expiration time
-	_, err = Parse(data, algNone)
-	if err == nil {
-		t.Error("want some error, but not")
-	}
+// 	now = time.Unix(1300819380, 0) // just expiration time
+// 	_, err = Parse(data, algNone)
+// 	if err == nil {
+// 		t.Error("want some error, but not")
+// 	}
 
-	token = []byte(`{"nbf":1300819380}`)
-	data = []byte(
-		"eyJhbGciOiJub25lIn0." + // {"alg":"none"}
-			base64.RawURLEncoding.EncodeToString(token) + ".")
+// 	token = []byte(`{"nbf":1300819380}`)
+// 	data = []byte(
+// 		"eyJhbGciOiJub25lIn0." + // {"alg":"none"}
+// 			base64.RawURLEncoding.EncodeToString(token) + ".")
 
-	now = time.Unix(1300819380, -1) // 1ns before the token is valid
-	_, err = Parse(data, algNone)
-	if err == nil {
-		t.Error("want some error, but not")
-	}
+// 	now = time.Unix(1300819380, -1) // 1ns before the token is valid
+// 	_, err = Parse(data, algNone)
+// 	if err == nil {
+// 		t.Error("want some error, but not")
+// 	}
 
-	now = time.Unix(1300819380, 0) // just activated
-	_, err = Parse(data, algNone)
-	if err != nil {
-		t.Error(err)
-	}
-}
+// 	now = time.Unix(1300819380, 0) // just activated
+// 	_, err = Parse(data, algNone)
+// 	if err != nil {
+// 		t.Error(err)
+// 	}
+// }
 
-func TestSign(t *testing.T) {
+// func TestSign(t *testing.T) {
 
-	t.Run("RFC 7519 Section 3.1. Example JWT", func(t *testing.T) {
-		rawKey := `{"kty":"oct",` +
-			`"k":"AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75` +
-			`aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow"` +
-			`}`
-		key, err := jwk.ParseKey([]byte(rawKey))
-		if err != nil {
-			t.Fatal(err)
-		}
-		sigKey := jwa.HS256.New().NewSigningKey(key)
+// 	t.Run("RFC 7519 Section 3.1. Example JWT", func(t *testing.T) {
+// 		rawKey := `{"kty":"oct",` +
+// 			`"k":"AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75` +
+// 			`aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow"` +
+// 			`}`
+// 		key, err := jwk.ParseKey([]byte(rawKey))
+// 		if err != nil {
+// 			t.Fatal(err)
+// 		}
+// 		sigKey := jwa.HS256.New().NewSigningKey(key)
 
-		header := jws.NewHeader()
-		header.SetAlgorithm(jwa.HS256)
-		header.SetType("JWT")
-		claims := &Claims{
-			Issuer:         "joe",
-			ExpirationTime: time.Unix(1300819380, 0),
-			Raw: map[string]any{
-				"http://example.com/is_root": true,
-			},
-		}
+// 		header := jws.NewHeader()
+// 		header.SetAlgorithm(jwa.HS256)
+// 		header.SetType("JWT")
+// 		claims := &Claims{
+// 			Issuer:         "joe",
+// 			ExpirationTime: time.Unix(1300819380, 0),
+// 			Raw: map[string]any{
+// 				"http://example.com/is_root": true,
+// 			},
+// 		}
 
-		got, err := Sign(header, claims, sigKey)
-		if err != nil {
-			t.Fatal(err)
-		}
+// 		got, err := Sign(header, claims, sigKey)
+// 		if err != nil {
+// 			t.Fatal(err)
+// 		}
 
-		want := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9" +
-			"." +
-			"eyJleHAiOjEzMDA4MTkzODAsImh0dHA6Ly9leGFtcGxlLmNvbS9pc19yb290Ijp0" +
-			"cnVlLCJpc3MiOiJqb2UifQ" +
-			"." +
-			"tu77b1J0ZCHMDd3tWZm36iolxZtBRaArSrtayOBDO34"
+// 		want := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9" +
+// 			"." +
+// 			"eyJleHAiOjEzMDA4MTkzODAsImh0dHA6Ly9leGFtcGxlLmNvbS9pc19yb290Ijp0" +
+// 			"cnVlLCJpc3MiOiJqb2UifQ" +
+// 			"." +
+// 			"tu77b1J0ZCHMDd3tWZm36iolxZtBRaArSrtayOBDO34"
 
-		if string(got) != want {
-			t.Errorf("unexpected payload: want %s, got %s", want, got)
-		}
-	})
+// 		if string(got) != want {
+// 			t.Errorf("unexpected payload: want %s, got %s", want, got)
+// 		}
+// 	})
 
-	t.Run("RFC 7519 Section 6.1. Example Unsecured JWT", func(t *testing.T) {
-		sigKey := jwa.None.New().NewSigningKey(nil)
-		header := jws.NewHeader()
-		header.SetAlgorithm(jwa.None)
-		header.SetType("JWT")
-		claims := &Claims{
-			Issuer:         "joe",
-			ExpirationTime: time.Unix(1300819380, 0),
-			Raw: map[string]any{
-				"http://example.com/is_root": true,
-			},
-		}
+// 	t.Run("RFC 7519 Section 6.1. Example Unsecured JWT", func(t *testing.T) {
+// 		sigKey := jwa.None.New().NewSigningKey(nil)
+// 		header := jws.NewHeader()
+// 		header.SetAlgorithm(jwa.None)
+// 		header.SetType("JWT")
+// 		claims := &Claims{
+// 			Issuer:         "joe",
+// 			ExpirationTime: time.Unix(1300819380, 0),
+// 			Raw: map[string]any{
+// 				"http://example.com/is_root": true,
+// 			},
+// 		}
 
-		got, err := Sign(header, claims, sigKey)
-		if err != nil {
-			t.Fatal(err)
-		}
+// 		got, err := Sign(header, claims, sigKey)
+// 		if err != nil {
+// 			t.Fatal(err)
+// 		}
 
-		want := "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0" +
-			"." +
-			"eyJleHAiOjEzMDA4MTkzODAsImh0dHA6Ly9leGFtcGxlLmNvbS9pc19yb290Ijp0" +
-			"cnVlLCJpc3MiOiJqb2UifQ" +
-			"."
+// 		want := "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0" +
+// 			"." +
+// 			"eyJleHAiOjEzMDA4MTkzODAsImh0dHA6Ly9leGFtcGxlLmNvbS9pc19yb290Ijp0" +
+// 			"cnVlLCJpc3MiOiJqb2UifQ" +
+// 			"."
 
-		if string(got) != want {
-			t.Errorf("unexpected payload: want %s, got %s", want, got)
-		}
-	})
-}
+// 		if string(got) != want {
+// 			t.Errorf("unexpected payload: want %s, got %s", want, got)
+// 		}
+// 	})
+// }
 
-func BenchmarkParse(b *testing.B) {
-	defer mockTime(func() time.Time {
-		return time.Unix(1300819379, 0)
-	})()
+// func BenchmarkParse(b *testing.B) {
+// 	defer mockTime(func() time.Time {
+// 		return time.Unix(1300819379, 0)
+// 	})()
 
-	raw := []byte(
-		"eyJ0eXAiOiJKV1QiLA0KICJhbGciOiJIUzI1NiJ9" +
-			"." +
-			"eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFt" +
-			"cGxlLmNvbS9pc19yb290Ijp0cnVlfQ" +
-			"." +
-			"dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk",
-	)
-	rawKey := `{"kty":"oct",` +
-		`"k":"AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75` +
-		`aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow"` +
-		`}`
-	key, err := jwk.ParseKey([]byte(rawKey))
-	if err != nil {
-		b.Fatal(err)
-	}
-	finder := &JWKKeyFiner{Key: key}
+// 	raw := []byte(
+// 		"eyJ0eXAiOiJKV1QiLA0KICJhbGciOiJIUzI1NiJ9" +
+// 			"." +
+// 			"eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFt" +
+// 			"cGxlLmNvbS9pc19yb290Ijp0cnVlfQ" +
+// 			"." +
+// 			"dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk",
+// 	)
+// 	rawKey := `{"kty":"oct",` +
+// 		`"k":"AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75` +
+// 		`aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow"` +
+// 		`}`
+// 	key, err := jwk.ParseKey([]byte(rawKey))
+// 	if err != nil {
+// 		b.Fatal(err)
+// 	}
+// 	finder := &JWKKeyFiner{Key: key}
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		_, err := Parse(raw, finder)
-		if err != nil {
-			b.Fatal(err)
-		}
-	}
-}
+// 	b.ResetTimer()
+// 	for i := 0; i < b.N; i++ {
+// 		_, err := Parse(raw, finder)
+// 		if err != nil {
+// 			b.Fatal(err)
+// 		}
+// 	}
+// }

--- a/jwt/key_finder.go
+++ b/jwt/key_finder.go
@@ -1,6 +1,7 @@
 package jwt
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
@@ -9,22 +10,6 @@ import (
 	"github.com/shogo82148/goat/jws"
 	"github.com/shogo82148/goat/sig"
 )
-
-// KeyFinder is a wrapper for the FindKey method.
-type KeyFinder interface {
-	// FindKey finds the key used for signing.
-	// e.g, you can return a key corresponding to the KID.
-	FindKey(header *jws.Header) (key sig.SigningKey, err error)
-}
-
-// FindKeyFunc is an adapter to allow the use of ordinary functions as KeyFinder interfaces.
-// If f is a function with the appropriate signature, FindKeyFunc(f) is a KeyFinder that calls f.
-type FindKeyFunc func(header *jws.Header) (key sig.SigningKey, err error)
-
-// FindKey calls f(header).
-func (f FindKeyFunc) FindKey(header *jws.Header) (sig.SigningKey, error) {
-	return f(header)
-}
 
 // Token is a decoded JWT token.
 type Token struct {
@@ -56,7 +41,7 @@ type JWKKeyFiner struct {
 	Key *jwk.Key
 }
 
-func (f *JWKKeyFiner) FindKey(header *jws.Header) (sig.SigningKey, error) {
+func (f *JWKKeyFiner) FindKey(ctx context.Context, header *jws.Header) (sig.SigningKey, error) {
 	alg, err := guessAlg(f.Key, header)
 	if err != nil {
 		return nil, err

--- a/jwt/key_finder.go
+++ b/jwt/key_finder.go
@@ -11,12 +11,6 @@ import (
 	"github.com/shogo82148/goat/sig"
 )
 
-// Token is a decoded JWT token.
-type Token struct {
-	Header *jws.Header
-	Claims *Claims
-}
-
 type JWKSKeyFinder struct {
 	JWKS *jwk.Set
 }

--- a/jwt/parser.go
+++ b/jwt/parser.go
@@ -154,6 +154,9 @@ func (p *Parser) Parse(ctx context.Context, data []byte) (*Token, error) {
 	if header.UnmarshalJSON(buf[:n]) != nil {
 		return nil, fmt.Errorf("jwt: failed to parse header: %w", err)
 	}
+	if err := p.AlgorithmVerfier.VerifyAlgorithm(ctx, header.Algorithm()); err != nil {
+		return nil, fmt.Errorf("jwt: failed to verify algorithm: %w", err)
+	}
 
 	// verify signature
 	key, err := p.KeyFinder.FindKey(ctx, &header)

--- a/jwt/parser.go
+++ b/jwt/parser.go
@@ -92,6 +92,17 @@ func (unsecureAnyAudienceVerifier) VerifyAudience(ctx context.Context, aud []str
 	return nil
 }
 
+type Audience string
+
+func (a Audience) VerifyAudience(ctx context.Context, aud []string) error {
+	for _, v := range aud {
+		if v == string(a) {
+			return nil
+		}
+	}
+	return fmt.Errorf("jwt: invalid audience: %s", aud)
+}
+
 // Parser is a JWT parser.
 type Parser struct {
 	_NamedFieldsRequired struct{}

--- a/jwt/parser.go
+++ b/jwt/parser.go
@@ -33,12 +33,12 @@ type AlgorithmVerfier interface {
 	VerifyAlgorithm(ctx context.Context, alg jwa.SignatureAlgorithm) error
 }
 
-// UnsafeAnyAlgorithm is an AlgorithmVerfier that accepts any algorithm.
-var UnsafeAnyAlgorithm = unsafeAnyAlgorithmVerifier{}
+// UnsecureAnyAlgorithm is an AlgorithmVerfier that accepts any algorithm.
+var UnsecureAnyAlgorithm = unsecureAnyAlgorithmVerifier{}
 
-type unsafeAnyAlgorithmVerifier struct{}
+type unsecureAnyAlgorithmVerifier struct{}
 
-func (unsafeAnyAlgorithmVerifier) VerifyAlgorithm(ctx context.Context, alg jwa.SignatureAlgorithm) error {
+func (unsecureAnyAlgorithmVerifier) VerifyAlgorithm(ctx context.Context, alg jwa.SignatureAlgorithm) error {
 	return nil
 }
 

--- a/jwt/parser.go
+++ b/jwt/parser.go
@@ -1,0 +1,193 @@
+package jwt
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/shogo82148/goat/internal/jsonutils"
+	"github.com/shogo82148/goat/jwa"
+	"github.com/shogo82148/goat/jws"
+	"github.com/shogo82148/goat/sig"
+)
+
+// KeyFinder finds the key used for signing.
+// e.g, you can return a key corresponding to the KID.
+type KeyFinder interface {
+	FindKey(ctx context.Context, header *jws.Header) (key sig.SigningKey, err error)
+}
+
+// FindKeyFunc is an adapter to allow the use of ordinary functions as KeyFinder interfaces.
+// If f is a function with the appropriate signature, FindKeyFunc(f) is a KeyFinder that calls f.
+type FindKeyFunc func(ctx context.Context, header *jws.Header) (key sig.SigningKey, err error)
+
+// FindKey calls f(header).
+func (f FindKeyFunc) FindKey(ctx context.Context, header *jws.Header) (sig.SigningKey, error) {
+	return f(ctx, header)
+}
+
+// AlgorithmVerfier verifies the algorithm used for signing.
+type AlgorithmVerfier interface {
+	VerifyAlgorithm(ctx context.Context, alg jwa.SignatureAlgorithm) error
+}
+
+// UnsafeAnyAlgorithm is an AlgorithmVerfier that accepts any algorithm.
+var UnsafeAnyAlgorithm = unsafeAnyAlgorithmVerifier{}
+
+type unsafeAnyAlgorithmVerifier struct{}
+
+func (unsafeAnyAlgorithmVerifier) VerifyAlgorithm(ctx context.Context, alg jwa.SignatureAlgorithm) error {
+	return nil
+}
+
+// IssuerSubjectVerifier verifies the issuer and the subject.
+type IssuerSubjectVerifier interface {
+	VerifyIssuer(ctx context.Context, iss, sub string) error
+}
+
+// AudienceVerifier verifies the audience.
+type AudienceVerifier interface {
+	VerifyAudience(ctx context.Context, aud []string) error
+}
+
+// Parser is a JWT parser.
+type Parser struct {
+	_NamedFieldsRequired struct{}
+
+	KeyFinder             KeyFinder
+	AlgorithmVerfier      AlgorithmVerfier
+	IssuerSubjectVerifier IssuerSubjectVerifier
+	AudienceVerifier      AudienceVerifier
+}
+
+func (p *Parser) Parse(ctx context.Context, data []byte) (*Token, error) {
+	// verify the parser options
+	_ = p._NamedFieldsRequired
+	// if p.KeyFinder == nil || p.AlgorithmVerfier == nil || p.IssuerSubjectVerifier == nil || p.AudienceVerifier == nil {
+	// 	return nil, errors.New("jwt: parser is not configured")
+	// }
+
+	// split to segments
+	idx1 := bytes.IndexByte(data, '.')
+	if idx1 < 0 {
+		return nil, errors.New("jwt: failed to parse: invalid format")
+	}
+	idx2 := bytes.IndexByte(data[idx1+1:], '.')
+	if idx2 < 0 {
+		return nil, errors.New("jwt: failed to parse: invalid format")
+	}
+	idx2 += idx1 + 1
+	b64header := data[:idx1]
+	b64payload := data[idx1+1 : idx2]
+	b64signature := data[idx2+1:]
+
+	// pre-allocate buffer
+	size := len(b64header)
+	if len(b64payload) > size {
+		size = len(b64payload)
+	}
+	if len(b64signature) > size {
+		size = len(b64signature)
+	}
+	buf := make([]byte, b64.DecodedLen(size))
+
+	// parse header
+	n, err := b64.Decode(buf[:cap(buf)], b64header)
+	if err != nil {
+		return nil, fmt.Errorf("jwt: failed to parse header: %w", err)
+	}
+	buf = buf[:n]
+	var header jws.Header
+	if header.UnmarshalJSON(buf[:n]) != nil {
+		return nil, fmt.Errorf("jwt: failed to parse header: %w", err)
+	}
+
+	// verify signature
+	key, err := p.KeyFinder.FindKey(ctx, &header)
+	if err != nil {
+		return nil, fmt.Errorf("jwt: failed to find key: %w", err)
+	}
+	n, err = b64.Decode(buf[:cap(buf)], b64signature)
+	if err != nil {
+		return nil, fmt.Errorf("jwt: failed to parse signature: %w", err)
+	}
+	buf = buf[:n]
+	if err := key.Verify(data[:idx2], buf[:n]); err != nil {
+		return nil, fmt.Errorf("jwt: failed to verify signature: %w", err)
+	}
+
+	// parse payload
+	n, err = b64.Decode(buf[:cap(buf)], b64payload)
+	if err != nil {
+		return nil, fmt.Errorf("jwt: failed to parse signature: %w", err)
+	}
+	buf = buf[:n]
+
+	c, err := p.parseClaims(buf)
+	if err != nil {
+		return nil, err
+	}
+	token := &Token{
+		Header: &header,
+		Claims: c,
+	}
+	return token, nil
+}
+
+func (p *Parser) parseClaims(data []byte) (*Claims, error) {
+	now := nowFunc()
+
+	var raw map[string]any
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.UseNumber()
+	if err := dec.Decode(&raw); err != nil {
+		return nil, fmt.Errorf("jwt: failed to parse claims: %w", err)
+	}
+	c := &Claims{
+		Raw: raw,
+	}
+	d := jsonutils.NewDecoder("jwt", raw)
+
+	c.Issuer, _ = d.GetString("iss")
+	c.Subject, _ = d.GetString("sub")
+
+	// In RFC 7519, the "aud" claim is defined as a string or an array of strings.
+	if aud, ok := raw["aud"]; ok {
+		switch aud := aud.(type) {
+		case []any:
+			for _, v := range aud {
+				s, ok := v.(string)
+				if !ok {
+					d.SaveError(fmt.Errorf("jwt: invalid type of aud claim: %T", v))
+				}
+				c.Audience = append(c.Audience, s)
+			}
+		case string:
+			c.Audience = []string{aud}
+		}
+	}
+
+	if t, ok := d.GetTime("exp"); ok {
+		c.ExpirationTime = t
+		if !now.Before(t) {
+			d.SaveError(fmt.Errorf("jwt: token is expired"))
+		}
+	}
+
+	if t, ok := d.GetTime("nbf"); ok {
+		c.NotBefore = t
+		if now.Before(t) {
+			d.SaveError(fmt.Errorf("jwt: token is not valid yet"))
+		}
+	}
+
+	c.IssuedAt, _ = d.GetTime("iat")
+	c.JWTID, _ = d.GetString("jti")
+
+	if err := d.Err(); err != nil {
+		return nil, err
+	}
+	return c, nil
+}


### PR DESCRIPTION
The current Parse function does not verify the alg, iss, and sub claims. By introducing a new Parser structure, it makes it easier to verify these claims.