### PR TITLE
add Go 1.22 to the build matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,20 +14,14 @@ jobs:
       fail-fast: false
       matrix:
         go:
+          - "stable"
+          - "1.22"
           - "1.21"
-        goexperiment: [""]
         goarch:
           - amd64
         include:
-          # test with GOEXPERIMENT=loopvar
-          # https://github.com/golang/go/wiki/LoopvarExperiment
-          - go: "1.21"
-            goexperiment: "loopvar"
-            goarch: amd64
-
           # test on 32-bit platforms
-          - go: "1.21"
-            goexperiment: "loopvar"
+          - go: "stable"
             goarch: "386"
 
     steps:
@@ -41,7 +35,6 @@ jobs:
         run: |
           go test -v -coverprofile=profile.cov ./...
         env:
-          GOEXPERIMENT: ${{ matrix.goexperiment }}
           GOARCH: ${{ matrix.goarch }}
 
       - uses: shogo82148/actions-goveralls@v1


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the CI workflow to adjust Go versions tested and refine the testing matrix. Removed an experimental Go version and added a new Go version for 32-bit platform testing. Removed the `GOEXPERIMENT` environment variable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->