### PR TITLE
add Go 1.23 to the build matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,7 @@ jobs:
       matrix:
         go:
           - "stable"
+          - "1.23"
           - "1.22"
           - "1.21"
         goarch:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Enhanced testing coverage by adding Go version "1.23" to the continuous integration workflow. This ensures the codebase remains compatible with the latest Go version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->