### PR TITLE
drop support of Go 1.23

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,6 @@ jobs:
         go:
           - "stable"
           - "1.24"
-          - "1.23"
         goarch:
           - amd64
         include:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Removed Go 1.23 from continuous integration test matrix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->