### PR TITLE
add Go 1.26 and 1.25 to the test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,8 @@ jobs:
       matrix:
         go:
           - "stable"
+          - "1.26"
+          - "1.25"
           - "1.24"
         goarch:
           - amd64

--- a/internal/curve256k1/field/fe.go
+++ b/internal/curve256k1/field/fe.go
@@ -597,12 +597,12 @@ func (v *Element) Inv(z *Element) *Element {
 	}
 	x.Mul(&x, &z64) // = 2^192 - 1
 
-	for i := 0; i < 16; i++ {
+	for range 16 {
 		x.Square(&x)
 	}
 	x.Mul(&x, &z16) // = 2^208 - 1
 
-	for i := 0; i < 8; i++ {
+	for range 8 {
 		x.Square(&x)
 	}
 	x.Mul(&x, &z8) // = 2^216 - 1
@@ -622,7 +622,7 @@ func (v *Element) Inv(z *Element) *Element {
 	x.Square(&x)
 	x.Mul(&x, z) // = 2^223 - 1
 
-	for i := 0; i < 17; i++ {
+	for range 17 {
 		x.Square(&x)
 	}
 	x.Mul(&x, &z16) // = 2^240 - 2^16 - 1

--- a/internal/curve256k1/scalarmult.go
+++ b/internal/curve256k1/scalarmult.go
@@ -52,7 +52,7 @@ func initBaseTable() {
 		var gen Point
 		var base PointJacobian
 		base.FromAffine(gen.NewGenerator())
-		for i := 0; i < 64; i++ {
+		for i := range 64 {
 			baseTable[i].Init(&base)
 			base.Double(&base)
 			base.Double(&base)

--- a/internal/curve256k1/table_test.go
+++ b/internal/curve256k1/table_test.go
@@ -95,7 +95,7 @@ func TestTable(t *testing.T) {
 	var table lookupTable
 	table.Init(&q)
 
-	for i := 0; i < 16; i++ {
+	for i := range 16 {
 		var want, got PointJacobian
 		table.SelectInto(&got, uint8(i))
 		want.x.SetBytes(decodeHex(myTable[i].x))

--- a/internal/edwards448/field/fe.go
+++ b/internal/edwards448/field/fe.go
@@ -1009,7 +1009,7 @@ func (v *Element) Power446(z *Element) *Element {
 		z111.Square(&z111)
 	}
 	z111.Mul(&z111, &z37)
-	for i := 0; i < 37; i++ {
+	for range 37 {
 		z111.Square(&z111)
 	}
 	z111.Mul(&z111, &z37) // 2^111 - 1

--- a/internal/edwards448/scalar.go
+++ b/internal/edwards448/scalar.go
@@ -1735,13 +1735,13 @@ func (s *Scalar) signedRadix16() [112]int8 {
 	var digits [112]int8
 
 	// Compute unsigned radix-16 digits:
-	for i := 0; i < 56; i++ {
+	for i := range 56 {
 		digits[2*i] = int8(s.s[i] & 0xF)
 		digits[2*i+1] = int8((s.s[i] >> 4) & 0xF)
 	}
 
 	// Recenter coefficients:
-	for i := 0; i < 112-1; i++ {
+	for i := range 112 - 1 {
 		carry := (digits[i] + 8) >> 4
 		digits[i] -= carry << 4
 		digits[i+1] += carry
@@ -1769,7 +1769,7 @@ func (s *Scalar) nonAdjacentForm(w uint) [448]int8 {
 	var naf [448]int8 // non adjacent form of s
 	var digits [8]uint64
 
-	for i := 0; i < 7; i++ {
+	for i := range 7 {
 		digits[i] = binary.LittleEndian.Uint64(s.s[i*8:])
 	}
 

--- a/internal/edwards448/scalar_test.go
+++ b/internal/edwards448/scalar_test.go
@@ -1084,7 +1084,7 @@ func TestMulAdd_Check(t *testing.T) {
 func (s *Scalar) toBig(v *big.Int) *big.Int {
 	var buf [56]byte
 	copy(buf[:], s.s[:])
-	for i := 0; i < len(buf)/2; i++ {
+	for i := range len(buf) / 2 {
 		buf[i], buf[len(buf)-i-1] = buf[len(buf)-i-1], buf[i]
 	}
 	return v.SetBytes(buf[:])
@@ -1126,7 +1126,7 @@ func TestScalarNonAdjacentForm(t *testing.T) {
 
 	sNAF := s.nonAdjacentForm(5)
 
-	for i := 0; i < len(expectedNAF); i++ {
+	for i := range len(expectedNAF) {
 		if expectedNAF[i] != sNAF[i] {
 			t.Errorf("Wrong digit at position %d, got %d, expected %d", i, sNAF[i], expectedNAF[i])
 		}

--- a/internal/edwards448/table.go
+++ b/internal/edwards448/table.go
@@ -17,9 +17,9 @@ var varBasepointTable [56]lookupTable
 func basepointTable() *[56]lookupTable {
 	initBasepointOnce.Do(func() {
 		p := NewGeneratorPoint()
-		for i := 0; i < 56; i++ {
+		for i := range 56 {
 			varBasepointTable[i].Init(p)
-			for j := 0; j < 8; j++ {
+			for range 8 {
 				p.Add(p, p)
 			}
 		}

--- a/internal/jsonutils/decode.go
+++ b/internal/jsonutils/decode.go
@@ -16,7 +16,7 @@ import (
 )
 
 // Unmarshal is same as [json.Unmarshal], but it uses [json.Number] for numbers.
-func Unmarshal(data []byte, v interface{}) error {
+func Unmarshal(data []byte, v any) error {
 	dec := json.NewDecoder(bytes.NewReader(data))
 	dec.UseNumber()
 	if err := dec.Decode(v); err != nil {

--- a/jwa/acbc/acbc.go
+++ b/jwa/acbc/acbc.go
@@ -163,11 +163,9 @@ func extractPadding(payload []byte) (toRemove int, good byte) {
 	good = byte(int32(^t) >> 31)
 
 	// The maximum possible padding length plus the actual length field
-	toCheck := 256
-	// The length of the padded data is public, so we can use an if here
-	if toCheck > len(payload) {
-		toCheck = len(payload)
-	}
+	toCheck := min(
+		// The length of the padded data is public, so we can use an if here
+		256, len(payload))
 
 	for i := 1; i <= toCheck; i++ {
 		t := uint(paddingLen) - uint(i)

--- a/jwa/ecdhes/ecdhes.go
+++ b/jwa/ecdhes/ecdhes.go
@@ -253,10 +253,7 @@ type kdf struct {
 
 func newKDF(hash crypto.Hash, z, alg, apu, apv, pub, priv []byte) *kdf {
 	h := hash.New()
-	size := h.Size()
-	if size < 4 {
-		size = 4
-	}
+	size := max(h.Size(), 4)
 	return &kdf{
 		z:    z,
 		hash: h,

--- a/jwe/jwe.go
+++ b/jwe/jwe.go
@@ -12,6 +12,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 	"math"
 	"net/url"
 
@@ -60,9 +61,7 @@ func (h *Header) Clone() *Header {
 	}
 	clone := *h
 	raw := make(map[string]any, len(h.Raw))
-	for k, v := range h.Raw {
-		raw[k] = v
-	}
+	maps.Copy(raw, h.Raw)
 	clone.Raw = raw
 	return &clone
 }
@@ -1103,9 +1102,7 @@ func b64Encode(src []byte) []byte {
 
 func encodeHeader(h *Header) (map[string]any, error) {
 	raw := make(map[string]any, len(h.Raw))
-	for k, v := range h.Raw {
-		raw[k] = v
-	}
+	maps.Copy(raw, h.Raw)
 	e := jsonutils.NewEncoder(raw)
 	if v := h.alg; v != "" {
 		e.Set(jwa.AlgorithmKey, string(v))

--- a/jwk/jwk.go
+++ b/jwk/jwk.go
@@ -17,6 +17,7 @@ import (
 	"errors"
 	"fmt"
 	"hash"
+	"maps"
 	"net/url"
 	"reflect"
 
@@ -263,9 +264,7 @@ var _ json.Marshaler = (*Key)(nil)
 // MarshalJSON implements [encoding/json.Marshaler]
 func (key *Key) MarshalJSON() ([]byte, error) {
 	raw := make(map[string]any, len(key.Raw))
-	for k, v := range key.Raw {
-		raw[k] = v
-	}
+	maps.Copy(raw, key.Raw)
 	e := jsonutils.NewEncoder(raw)
 	encodeCommonParameters(e, key)
 	if err := e.Err(); err != nil {

--- a/jwk/jwktypes/jwktypes.go
+++ b/jwk/jwktypes/jwktypes.go
@@ -1,6 +1,8 @@
 // Package jwktypes contains types used by the package jwk.
 package jwktypes
 
+import "slices"
+
 // KeyUse is type of "use" JWK parameter
 // defined in RFC 7517 Section 4.2.
 type KeyUse string
@@ -74,13 +76,7 @@ func checkKeyOps(key any, op KeyOp) bool {
 		return true
 	}
 
-	for _, v := range ops {
-		if v == op {
-			return true
-		}
-	}
-
-	return false
+	return slices.Contains(ops, op)
 }
 
 func checkKeyUse(key any, op KeyOp) bool {

--- a/jws/jws.go
+++ b/jws/jws.go
@@ -11,7 +11,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 	"net/url"
+	"slices"
 	"sort"
 
 	"github.com/shogo82148/goat/internal/jsonutils"
@@ -194,10 +196,8 @@ func (h *Header) Base64() bool {
 func (h *Header) SetBase64(b64 bool) {
 	h.nb64 = !b64
 	if !b64 {
-		for _, param := range h.crit {
-			if param == "b64" {
-				return // "b64" is already contained.
-			}
+		if slices.Contains(h.crit, "b64") {
+			return // "b64" is already contained.
 		}
 		h.crit = append(h.crit, "b64")
 	}
@@ -558,9 +558,7 @@ func encodeHeader(h *Header) (map[string]any, error) {
 		return nil, nil
 	}
 	raw := make(map[string]any, len(h.Raw))
-	for k, v := range h.Raw {
-		raw[k] = v
-	}
+	maps.Copy(raw, h.Raw)
 	e := jsonutils.NewEncoder(raw)
 	if v := h.alg; v != "" {
 		e.Set(jwa.AlgorithmKey, string(v))

--- a/jws/verifier.go
+++ b/jws/verifier.go
@@ -3,6 +3,7 @@ package jws
 import (
 	"context"
 	"errors"
+	"slices"
 
 	"github.com/shogo82148/goat/jwa"
 )
@@ -17,10 +18,8 @@ type AlgorithmVerifier interface {
 type AllowedAlgorithms []jwa.SignatureAlgorithm
 
 func (a AllowedAlgorithms) VerifyAlgorithm(ctx context.Context, alg jwa.SignatureAlgorithm) error {
-	for _, allowed := range a {
-		if alg == allowed {
-			return nil
-		}
+	if slices.Contains(a, alg) {
+		return nil
 	}
 	return errors.New("jws: signing algorithm is not allowed")
 }

--- a/jwt/cuctom_decode.go
+++ b/jwt/cuctom_decode.go
@@ -14,15 +14,15 @@ import (
 	"github.com/shogo82148/goat/internal/jsonutils"
 )
 
-var timeType = reflect.TypeOf(time.Time{})
-var urlType = reflect.TypeOf(url.URL{})
-var bigIntType = reflect.TypeOf(big.Int{})
+var timeType = reflect.TypeFor[time.Time]()
+var urlType = reflect.TypeFor[url.URL]()
+var bigIntType = reflect.TypeFor[big.Int]()
 
 // DecodeCustom decodes custom claims into v.
 // v must be a pointer.
 func (c *Claims) DecodeCustom(v any) error {
 	rv := reflect.ValueOf(v)
-	if rv.Kind() != reflect.Ptr || rv.IsNil() {
+	if rv.Kind() != reflect.Pointer || rv.IsNil() {
 		return fmt.Errorf("jwt: invalid decode type: %s", reflect.TypeOf(v))
 	}
 	return decode(c.Raw, rv)
@@ -30,7 +30,7 @@ func (c *Claims) DecodeCustom(v any) error {
 
 func indirect(v reflect.Value) reflect.Value {
 	for {
-		if v.Kind() != reflect.Ptr {
+		if v.Kind() != reflect.Pointer {
 			break
 		}
 		if v.IsNil() {
@@ -160,7 +160,7 @@ func decode(in any, out reflect.Value) error {
 		}
 	case nil:
 		switch out.Kind() {
-		case reflect.Interface, reflect.Ptr, reflect.Map, reflect.Slice:
+		case reflect.Interface, reflect.Pointer, reflect.Map, reflect.Slice:
 			out.Set(reflect.Zero(out.Type()))
 			// otherwise, ignore null for primitives
 		}
@@ -192,7 +192,7 @@ func decode(in any, out reflect.Value) error {
 				if f != nil {
 					subv := out
 					for _, i := range f.index {
-						if subv.Kind() == reflect.Ptr {
+						if subv.Kind() == reflect.Pointer {
 							if subv.IsNil() {
 								if !subv.CanSet() {
 									return fmt.Errorf("jwt: cannot set pointer to unexported struct: %v", subv.Type().Elem())
@@ -301,7 +301,7 @@ func typeFields(t reflect.Type) []field {
 				isUnexported := sf.PkgPath != ""
 				if sf.Anonymous {
 					t := sf.Type
-					if t.Kind() == reflect.Ptr {
+					if t.Kind() == reflect.Pointer {
 						t = t.Elem()
 					}
 					if isUnexported && t.Kind() != reflect.Struct {
@@ -322,7 +322,7 @@ func typeFields(t reflect.Type) []field {
 				index[len(f.index)] = i
 
 				ft := sf.Type
-				if ft.Name() == "" && ft.Kind() == reflect.Ptr {
+				if ft.Name() == "" && ft.Kind() == reflect.Pointer {
 					// Follow pointer.
 					ft = ft.Elem()
 				}

--- a/jwt/cuctom_decode.go
+++ b/jwt/cuctom_decode.go
@@ -29,10 +29,7 @@ func (c *Claims) DecodeCustom(v any) error {
 }
 
 func indirect(v reflect.Value) reflect.Value {
-	for {
-		if v.Kind() != reflect.Pointer {
-			break
-		}
+	for v.Kind() == reflect.Pointer {
 		if v.IsNil() {
 			v.Set(reflect.New(v.Type().Elem()))
 		}

--- a/jwt/custom_encode.go
+++ b/jwt/custom_encode.go
@@ -3,6 +3,7 @@ package jwt
 import (
 	"encoding/json"
 	"fmt"
+	"maps"
 	"math/big"
 	"net/url"
 	"reflect"
@@ -44,9 +45,7 @@ func (c *Claims) EncodeCustom(v any) error {
 	if c.Raw == nil {
 		c.Raw = raw
 	} else {
-		for k, v := range raw {
-			c.Raw[k] = v
-		}
+		maps.Copy(c.Raw, raw)
 	}
 
 	return nil
@@ -93,7 +92,7 @@ func encode(in reflect.Value) (any, error) {
 		for _, f := range fields {
 			subv := in
 			for _, i := range f.index {
-				if subv.Kind() == reflect.Ptr {
+				if subv.Kind() == reflect.Pointer {
 					if subv.IsNil() {
 						if !subv.CanSet() {
 							return nil, fmt.Errorf("jwt: cannot set pointer to unexported struct: %v", subv.Type().Elem())

--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"time"
 
 	"github.com/shogo82148/goat/internal/jsonutils"
@@ -89,9 +90,7 @@ func Sign(header *jws.Header, claims *Claims, key sig.SigningKey) ([]byte, error
 
 func encodeClaims(c *Claims) ([]byte, error) {
 	raw := make(map[string]any, len(c.Raw))
-	for k, v := range c.Raw {
-		raw[k] = v
-	}
+	maps.Copy(raw, c.Raw)
 	e := jsonutils.NewEncoder(raw)
 
 	if iss := c.Issuer; iss != "" {

--- a/jwt/parser.go
+++ b/jwt/parser.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"slices"
 
 	"github.com/shogo82148/goat/internal/jsonutils"
 	"github.com/shogo82148/goat/jwa"
@@ -46,10 +47,8 @@ func (unsecureAnyAlgorithmVerifier) VerifyAlgorithm(ctx context.Context, alg jwa
 type AllowedAlgorithms []jwa.SignatureAlgorithm
 
 func (a AllowedAlgorithms) VerifyAlgorithm(ctx context.Context, alg jwa.SignatureAlgorithm) error {
-	for _, allowed := range a {
-		if alg == allowed {
-			return nil
-		}
+	if slices.Contains(a, alg) {
+		return nil
 	}
 	return errors.New("jwt: signing algorithm is not allowed")
 }
@@ -95,10 +94,8 @@ func (unsecureAnyAudienceVerifier) VerifyAudience(ctx context.Context, aud []str
 type Audience string
 
 func (a Audience) VerifyAudience(ctx context.Context, aud []string) error {
-	for _, v := range aud {
-		if v == string(a) {
-			return nil
-		}
+	if slices.Contains(aud, string(a)) {
+		return nil
 	}
 	return fmt.Errorf("jwt: invalid audience: %s", aud)
 }
@@ -135,10 +132,7 @@ func (p *Parser) Parse(ctx context.Context, data []byte) (*Token, error) {
 	b64signature := data[idx2+1:]
 
 	// pre-allocate buffer
-	size := len(b64header)
-	if len(b64payload) > size {
-		size = len(b64payload)
-	}
+	size := max(len(b64payload), len(b64header))
 	if len(b64signature) > size {
 		size = len(b64signature)
 	}

--- a/secp256k1/openssl_test.go
+++ b/secp256k1/openssl_test.go
@@ -46,7 +46,7 @@ func TestVerify_OpenSSL(t *testing.T) {
 	// generate signature using OpenSSL, and verify it using goat.
 	checkSecp256k1Support(t)
 
-	for i := 0; i < 1024; i++ {
+	for i := range 1024 {
 		t.Run(strconv.Itoa(i), testVerifyOpenSSL)
 	}
 }
@@ -56,7 +56,7 @@ func TestSign_OpenSSL(t *testing.T) {
 	// generate signature using goat, and verify it using OpenSSL.
 	checkSecp256k1Support(t)
 
-	for i := 0; i < 1024; i++ {
+	for i := range 1024 {
 		t.Run(strconv.Itoa(i), testSignOpenSSL)
 	}
 }
@@ -165,8 +165,8 @@ func checkSecp256k1Support(t *testing.T) bool {
 		t.Skip(err)
 		return false
 	}
-	idx := bytes.Index(out, []byte("secp256k1"))
-	if idx < 0 {
+	found := bytes.Contains(out, []byte("secp256k1"))
+	if !found {
 		t.Skip("OpenSSL doesn't support secp256k1")
 		return false
 	}

--- a/secp256k1/secp256k1_test.go
+++ b/secp256k1/secp256k1_test.go
@@ -52,7 +52,7 @@ func TestSign(t *testing.T) {
 	message := []byte("hello secp256k1")
 	sum := sha256.Sum256(message)
 
-	for i := 0; i < 1024; i++ {
+	for range 1024 {
 		r, s, err := ecdsa.Sign(rand.Reader, priv, sum[:])
 		if err != nil {
 			t.Fatal(err)

--- a/x25519/x25519_test.go
+++ b/x25519/x25519_test.go
@@ -104,7 +104,7 @@ func TestX25519(t *testing.T) {
 		t.Run("After 1,000 iteration", func(t *testing.T) {
 			k := decodeHex("0900000000000000000000000000000000000000000000000000000000000000")
 			u := decodeHex("0900000000000000000000000000000000000000000000000000000000000000")
-			for i := 0; i < 1_000; i++ {
+			for range 1_000 {
 				v, err := X25519(k, u)
 				if err != nil {
 					t.Fatal(err)

--- a/x448/x448_test.go
+++ b/x448/x448_test.go
@@ -136,7 +136,7 @@ func TestLoop1(t *testing.T) {
 			"00000000000000000000000000000000000000000000000000000000",
 	)
 
-	for i := 0; i < 1; i++ {
+	for range 1 {
 		tmp, err := X448(k, u)
 		if err != nil {
 			t.Fatal(err)
@@ -164,7 +164,7 @@ func TestLoop1000(t *testing.T) {
 			"00000000000000000000000000000000000000000000000000000000",
 	)
 
-	for i := 0; i < 1000; i++ {
+	for range 1000 {
 		tmp, err := X448(k, u)
 		if err != nil {
 			t.Fatal(err)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI test matrix expanded to run additional Go versions for broader compatibility.

* **Refactor**
  * Many loops and internal utilities modernized to more idiomatic constructs without behavior changes.
  * Map and slice handling simplified using standard library helpers (copy/contains) where applicable.
  * Tests updated to use the same idiomatic loop forms.

* **API**
  * JSON unmarshal signature updated to accept the newer generic-style input type (backwards-compatible).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->