### PR TITLE
drop support of Go 1.24

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,6 @@ jobs:
           - "stable"
           - "1.26"
           - "1.25"
-          - "1.24"
         goarch:
           - amd64
         include:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/shogo82148/goat
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/jwt/parser.go
+++ b/jwt/parser.go
@@ -132,10 +132,7 @@ func (p *Parser) Parse(ctx context.Context, data []byte) (*Token, error) {
 	b64signature := data[idx2+1:]
 
 	// pre-allocate buffer
-	size := max(len(b64payload), len(b64header))
-	if len(b64signature) > size {
-		size = len(b64signature)
-	}
+	size := max(len(b64signature), len(b64payload), len(b64header))
 	buf := make([]byte, b64.DecodedLen(size))
 
 	// parse header


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded Go toolchain to 1.25.0
  * Updated CI to remove Go 1.24 from the test matrix
* **Improvements**
  * Improved JWT parsing robustness to reduce decoding errors and allocation issues
<!-- end of auto-generated comment: release notes by coderabbit.ai -->