### PR TITLE
Rename jwa algorithms

### DIFF
--- a/jwa/acbc/acbc.go
+++ b/jwa/acbc/acbc.go
@@ -52,9 +52,9 @@ func New256HS512() enc.Algorithm {
 }
 
 func init() {
-	jwa.RegisterEncryptionAlgorithm(jwa.A128CBC_HS256, New128HS256)
-	jwa.RegisterEncryptionAlgorithm(jwa.A192CBC_HS384, New192HS384)
-	jwa.RegisterEncryptionAlgorithm(jwa.A256CBC_HS512, New256HS512)
+	jwa.RegisterEncryptionAlgorithm(jwa.EncryptionAlgorithmA128CBC_HS256, New128HS256)
+	jwa.RegisterEncryptionAlgorithm(jwa.EncryptionAlgorithmA192CBC_HS384, New192HS384)
+	jwa.RegisterEncryptionAlgorithm(jwa.EncryptionAlgorithmA256CBC_HS512, New256HS512)
 }
 
 var _ enc.Algorithm = (*algorithm)(nil)

--- a/jwa/acbc/acbc_test.go
+++ b/jwa/acbc/acbc_test.go
@@ -96,9 +96,9 @@ func TestEncrypt(t *testing.T) {
 
 func TestCEKSize_and_IVSize(t *testing.T) {
 	tests := []jwa.EncryptionAlgorithm{
-		jwa.A128CBC_HS256,
-		jwa.A192CBC_HS384,
-		jwa.A256CBC_HS512,
+		jwa.EncryptionAlgorithmA128CBC_HS256,
+		jwa.EncryptionAlgorithmA192CBC_HS384,
+		jwa.EncryptionAlgorithmA256CBC_HS512,
 	}
 	for _, enc := range tests {
 		enc1 := enc.New()

--- a/jwa/agcm/agcm.go
+++ b/jwa/agcm/agcm.go
@@ -36,9 +36,9 @@ func New256() enc.Algorithm {
 }
 
 func init() {
-	jwa.RegisterEncryptionAlgorithm(jwa.A128GCM, New128)
-	jwa.RegisterEncryptionAlgorithm(jwa.A192GCM, New192)
-	jwa.RegisterEncryptionAlgorithm(jwa.A256GCM, New256)
+	jwa.RegisterEncryptionAlgorithm(jwa.EncryptionAlgorithmA128GCM, New128)
+	jwa.RegisterEncryptionAlgorithm(jwa.EncryptionAlgorithmA192GCM, New192)
+	jwa.RegisterEncryptionAlgorithm(jwa.EncryptionAlgorithmA256GCM, New256)
 }
 
 var _ enc.Algorithm = (*algorithm)(nil)

--- a/jwa/agcm/agcm_test.go
+++ b/jwa/agcm/agcm_test.go
@@ -102,9 +102,9 @@ func TestEncrypt(t *testing.T) {
 
 func TestCEKSize_and_IVSize(t *testing.T) {
 	tests := []jwa.EncryptionAlgorithm{
-		jwa.A128GCM,
-		jwa.A192GCM,
-		jwa.A256GCM,
+		jwa.EncryptionAlgorithmA128GCM,
+		jwa.EncryptionAlgorithmA192GCM,
+		jwa.EncryptionAlgorithmA256GCM,
 	}
 	for _, enc := range tests {
 		enc1 := enc.New()

--- a/jwa/agcmkw/agcmkw.go
+++ b/jwa/agcmkw/agcmkw.go
@@ -41,9 +41,9 @@ func New256() keymanage.Algorithm {
 }
 
 func init() {
-	jwa.RegisterKeyManagementAlgorithm(jwa.A128GCMKW, New128)
-	jwa.RegisterKeyManagementAlgorithm(jwa.A192GCMKW, New192)
-	jwa.RegisterKeyManagementAlgorithm(jwa.A256GCMKW, New256)
+	jwa.RegisterKeyManagementAlgorithm(jwa.KeyManagementAlgorithmA128GCMKW, New128)
+	jwa.RegisterKeyManagementAlgorithm(jwa.KeyManagementAlgorithmA192GCMKW, New192)
+	jwa.RegisterKeyManagementAlgorithm(jwa.KeyManagementAlgorithmA256GCMKW, New256)
 }
 
 var _ keymanage.Algorithm = (*algorithm)(nil)

--- a/jwa/akw/akw.go
+++ b/jwa/akw/akw.go
@@ -40,9 +40,9 @@ func New256() keymanage.Algorithm {
 }
 
 func init() {
-	jwa.RegisterKeyManagementAlgorithm(jwa.A128KW, New128)
-	jwa.RegisterKeyManagementAlgorithm(jwa.A192KW, New192)
-	jwa.RegisterKeyManagementAlgorithm(jwa.A256KW, New256)
+	jwa.RegisterKeyManagementAlgorithm(jwa.KeyManagementAlgorithmA128KW, New128)
+	jwa.RegisterKeyManagementAlgorithm(jwa.KeyManagementAlgorithmA192KW, New192)
+	jwa.RegisterKeyManagementAlgorithm(jwa.KeyManagementAlgorithmA256KW, New256)
 }
 
 func NewKeyWrapper(privateKey []byte) keymanage.KeyWrapper {

--- a/jwa/dir/dir.go
+++ b/jwa/dir/dir.go
@@ -15,7 +15,7 @@ func New() keymanage.Algorithm {
 }
 
 func init() {
-	jwa.RegisterKeyManagementAlgorithm(jwa.Direct, New)
+	jwa.RegisterKeyManagementAlgorithm(jwa.KeyManagementAlgorithmDirect, New)
 }
 
 var _ keymanage.Algorithm = (*Algorithm)(nil)

--- a/jwa/ecdhes/ecdhes.go
+++ b/jwa/ecdhes/ecdhes.go
@@ -59,10 +59,10 @@ func NewA256KW() keymanage.Algorithm {
 }
 
 func init() {
-	jwa.RegisterKeyManagementAlgorithm(jwa.ECDH_ES, New)
-	jwa.RegisterKeyManagementAlgorithm(jwa.ECDH_ES_A128KW, NewA128KW)
-	jwa.RegisterKeyManagementAlgorithm(jwa.ECDH_ES_A192KW, NewA192KW)
-	jwa.RegisterKeyManagementAlgorithm(jwa.ECDH_ES_A256KW, NewA256KW)
+	jwa.RegisterKeyManagementAlgorithm(jwa.KeyManagementAlgorithmECDH_ES, New)
+	jwa.RegisterKeyManagementAlgorithm(jwa.KeyManagementAlgorithmECDH_ES_A128KW, NewA128KW)
+	jwa.RegisterKeyManagementAlgorithm(jwa.KeyManagementAlgorithmECDH_ES_A192KW, NewA192KW)
+	jwa.RegisterKeyManagementAlgorithm(jwa.KeyManagementAlgorithmECDH_ES_A256KW, NewA256KW)
 }
 
 var _ keymanage.Algorithm = (*Algorithm)(nil)

--- a/jwa/ecdhes/ecdhes_test.go
+++ b/jwa/ecdhes/ecdhes_test.go
@@ -62,7 +62,7 @@ func TestUnwrap(t *testing.T) {
 	alg := New()
 	key := alg.NewKeyWrapper(aliceKey)
 	opts := &options{
-		enc: jwa.A128GCM,
+		enc: jwa.EncryptionAlgorithmA128GCM,
 		epk: bobKey,
 		apu: []byte("Alice"),
 		apv: []byte("Bob"),

--- a/jwa/eddsa/eddsa.go
+++ b/jwa/eddsa/eddsa.go
@@ -16,7 +16,7 @@ func New() sig.Algorithm {
 }
 
 func init() {
-	jwa.RegisterSignatureAlgorithm(jwa.EdDSA, New)
+	jwa.RegisterSignatureAlgorithm(jwa.SignatureAlgorithmEdDSA, New)
 }
 
 type algorithm struct{}

--- a/jwa/eddsa/eddsa.go
+++ b/jwa/eddsa/eddsa.go
@@ -1,4 +1,6 @@
 // Package eddsa provides the Edwards-Curve Digital Signature Algorithm defined in RFC 8032.
+//
+// Deprecated: use ed25519 or ed448 package instead of eddsa.
 package eddsa
 
 import (
@@ -11,6 +13,8 @@ import (
 )
 
 // New returns Edwards-Curve Digital Signature Algorithm.
+//
+// Deprecated: use ed25519 or ed448 package instead of eddsa.
 func New() sig.Algorithm {
 	return &algorithm{}
 }

--- a/jwa/es/es.go
+++ b/jwa/es/es.go
@@ -16,7 +16,7 @@ import (
 )
 
 var es256 = &algorithm{
-	alg:  jwa.ES256,
+	alg:  jwa.SignatureAlgorithmES256,
 	hash: crypto.SHA256,
 	crv:  elliptic.P256(),
 }
@@ -27,7 +27,7 @@ func New256() sig.Algorithm {
 }
 
 var es256k = &algorithm{
-	alg:  jwa.ES256K,
+	alg:  jwa.SignatureAlgorithmES256K,
 	hash: crypto.SHA256,
 	crv:  secp256k1.Curve(),
 }
@@ -38,7 +38,7 @@ func New256K() sig.Algorithm {
 }
 
 var es384 = &algorithm{
-	alg:  jwa.ES384,
+	alg:  jwa.SignatureAlgorithmES384,
 	hash: crypto.SHA384,
 	crv:  elliptic.P384(),
 }
@@ -49,7 +49,7 @@ func New384() sig.Algorithm {
 }
 
 var es512 = &algorithm{
-	alg:  jwa.ES512,
+	alg:  jwa.SignatureAlgorithmES512,
 	hash: crypto.SHA512,
 	crv:  elliptic.P521(),
 }
@@ -60,10 +60,10 @@ func New512() sig.Algorithm {
 }
 
 func init() {
-	jwa.RegisterSignatureAlgorithm(jwa.ES256, New256)
-	jwa.RegisterSignatureAlgorithm(jwa.ES384, New384)
-	jwa.RegisterSignatureAlgorithm(jwa.ES512, New512)
-	jwa.RegisterSignatureAlgorithm(jwa.ES256K, New256K)
+	jwa.RegisterSignatureAlgorithm(jwa.SignatureAlgorithmES256, New256)
+	jwa.RegisterSignatureAlgorithm(jwa.SignatureAlgorithmES384, New384)
+	jwa.RegisterSignatureAlgorithm(jwa.SignatureAlgorithmES512, New512)
+	jwa.RegisterSignatureAlgorithm(jwa.SignatureAlgorithmES256K, New256K)
 }
 
 var _ sig.Algorithm = (*algorithm)(nil)

--- a/jwa/hs/hs.go
+++ b/jwa/hs/hs.go
@@ -12,7 +12,7 @@ import (
 )
 
 var hs256 = &algorithm{
-	alg:  jwa.HS256,
+	alg:  jwa.SignatureAlgorithmHS256,
 	hash: crypto.SHA256,
 }
 
@@ -25,7 +25,7 @@ func New256() sig.Algorithm {
 }
 
 var hs384 = &algorithm{
-	alg:  jwa.HS384,
+	alg:  jwa.SignatureAlgorithmHS384,
 	hash: crypto.SHA384,
 }
 
@@ -38,7 +38,7 @@ func New384() sig.Algorithm {
 }
 
 var hs512 = &algorithm{
-	alg:  jwa.HS256,
+	alg:  jwa.SignatureAlgorithmHS256,
 	hash: crypto.SHA512,
 }
 
@@ -51,7 +51,7 @@ func New512() sig.Algorithm {
 }
 
 var hs256w = &algorithm{
-	alg:  jwa.HS256,
+	alg:  jwa.SignatureAlgorithmHS256,
 	hash: crypto.SHA256,
 	weak: true,
 }
@@ -64,7 +64,7 @@ func New256Weak() sig.Algorithm {
 }
 
 var hs384w = &algorithm{
-	alg:  jwa.HS384,
+	alg:  jwa.SignatureAlgorithmHS384,
 	hash: crypto.SHA384,
 	weak: true,
 }
@@ -77,7 +77,7 @@ func New384Weak() sig.Algorithm {
 }
 
 var hs512w = &algorithm{
-	alg:  jwa.HS256,
+	alg:  jwa.SignatureAlgorithmHS256,
 	hash: crypto.SHA512,
 	weak: true,
 }
@@ -90,9 +90,9 @@ func New512Weak() sig.Algorithm {
 }
 
 func init() {
-	jwa.RegisterSignatureAlgorithm(jwa.HS256, New256)
-	jwa.RegisterSignatureAlgorithm(jwa.HS384, New384)
-	jwa.RegisterSignatureAlgorithm(jwa.HS512, New512)
+	jwa.RegisterSignatureAlgorithm(jwa.SignatureAlgorithmHS256, New256)
+	jwa.RegisterSignatureAlgorithm(jwa.SignatureAlgorithmHS384, New384)
+	jwa.RegisterSignatureAlgorithm(jwa.SignatureAlgorithmHS512, New512)
 }
 
 var _ sig.Algorithm = (*algorithm)(nil)

--- a/jwa/jwa.go
+++ b/jwa/jwa.go
@@ -644,20 +644,47 @@ func (enc EncryptionAlgorithm) IVSize() int {
 type KeyType string
 
 const (
-	KeyTypeUnknown KeyType = ""
-
 	// EC is Elliptic Curve.
-	EC KeyType = "EC"
+	//
+	// Deprecated: use [KeyTypeEC] instead of EC.
+	//go:fix inline
+	EC = KeyTypeEC
 
 	// RSA is RSA.
-	RSA KeyType = "RSA"
+	//
+	// Deprecated: use [KeyTypeRSA] instead of RSA.
+	//go:fix inline
+	RSA = KeyTypeRSA
 
 	// OKP is Octet string key pairs
 	// defined in RFC 8037 Section 2. Key Type "OKP".
-	OKP KeyType = "OKP"
+	//
+	// Deprecated: use [KeyTypeOKP] instead of OKP.
+	//go:fix inline
+	OKP = KeyTypeOKP
 
 	// Oct is Octet sequence (used to represent symmetric keys).
-	Oct KeyType = "oct"
+	//
+	// Deprecated: use [KeyTypeOct] instead of Oct.
+	//go:fix inline
+	Oct = KeyTypeOct
+)
+
+const (
+	KeyTypeUnknown KeyType = ""
+
+	// KeyTypeEC is Elliptic Curve.
+	KeyTypeEC KeyType = "EC"
+
+	// KeyTypeRSA is RSA.
+	KeyTypeRSA KeyType = "RSA"
+
+	// KeyTypeOKP is Octet string key pairs
+	// defined in RFC 8037 Section 2. Key Type "OKP".
+	KeyTypeOKP KeyType = "OKP"
+
+	// KeyTypeOct is Octet sequence (used to represent symmetric keys).
+	KeyTypeOct KeyType = "oct"
 )
 
 func (kyt KeyType) String() string {

--- a/jwa/jwa.go
+++ b/jwa/jwa.go
@@ -12,72 +12,161 @@ import (
 type SignatureAlgorithm string
 
 const (
-	SignatureAlgorithmUnknown SignatureAlgorithm = ""
-
 	// HS256 is HMAC using SHA-256.
 	// import github.com/shogo82148/goat/jwa/hs
-	HS256 SignatureAlgorithm = "HS256"
+	//
+	// Deprecated: use [SignatureAlgorithmHS256] instead of HS256.
+	//go:fix inline
+	HS256 = SignatureAlgorithmHS256
 
 	// HS384 is HMAC using SHA-384.
 	// import github.com/shogo82148/goat/jwa/hs
-	HS384 SignatureAlgorithm = "HS384"
+	//
+	// Deprecated: use [SignatureAlgorithmHS384] instead of HS384.
+	//go:fix inline
+	HS384 = SignatureAlgorithmHS384
 
 	// HS512 is HMAC using SHA-512.
 	// import github.com/shogo82148/goat/jwa/hs
-	HS512 SignatureAlgorithm = "HS512"
+	//
+	// Deprecated: use [SignatureAlgorithmHS512] instead of HS512.
+	//go:fix inline
+	HS512 = SignatureAlgorithmHS512
 
 	// RS256 is RSASSA-PKCS1-v1_5 using SHA-256.
 	// import github.com/shogo82148/goat/jwa/rs
-	RS256 SignatureAlgorithm = "RS256"
+	//
+	// Deprecated: use [SignatureAlgorithmRS256] instead of RS256.
+	//go:fix inline
+	RS256 = SignatureAlgorithmRS256
 
 	// RS384 is RSASSA-PKCS1-v1_5 using SHA-384.
 	// import github.com/shogo82148/goat/jwa/rs
-	RS384 SignatureAlgorithm = "RS384"
+	//
+	// Deprecated: use [SignatureAlgorithmRS384] instead of RS384.
+	//go:fix inline
+	RS384 = SignatureAlgorithmRS384
 
 	// RS512 is RSASSA-PKCS1-v1_5 using SHA-512.
 	// import github.com/shogo82148/goat/jwa/rs
-	RS512 SignatureAlgorithm = "RS512"
+	//
+	// Deprecated: use [SignatureAlgorithmRS512] instead of RS512.
+	//go:fix inline
+	RS512 = SignatureAlgorithmRS512
 
 	// ES256 is ECDSA using P-256 and SHA-256.
 	// import github.com/shogo82148/goat/jwa/es
-	ES256 SignatureAlgorithm = "ES256"
+	//
+	// Deprecated: use [SignatureAlgorithmES256] instead of ES256.
+	//go:fix inline
+	ES256 = SignatureAlgorithmES256
 
 	// ES384 is ECDSA using P-384 and SHA-384.
 	// import github.com/shogo82148/goat/jwa/es
-	ES384 SignatureAlgorithm = "ES384"
+	//
+	// Deprecated: use [SignatureAlgorithmES384] instead of ES384.
+	//go:fix inline
+	ES384 = SignatureAlgorithmES384
 
 	// ES512 is ECDSA using P-521 and SHA-512.
 	// import github.com/shogo82148/goat/jwa/es
-	ES512 SignatureAlgorithm = "ES512"
+	//
+	// Deprecated: use [SignatureAlgorithmES512] instead of ES512.
+	//go:fix inline
+	ES512 = SignatureAlgorithmES512
 
 	// PS256 is RSASSA-PSS using SHA-256 and MGF1 with SHA-256.
 	// import github.com/shogo82148/goat/jwa/ps
-	PS256 SignatureAlgorithm = "PS256"
 
 	// PS384 is RSASSA-PSS using SHA-384 and MGF1 with SHA-384.
 	// import github.com/shogo82148/goat/jwa/ps
-	PS384 SignatureAlgorithm = "PS384"
+	PS384 = SignatureAlgorithmPS384
 
 	// PS512 is RSASSA-PSS using SHA-512 and MGF1 with SHA-512.
 	// import github.com/shogo82148/goat/jwa/ps
-	PS512 SignatureAlgorithm = "PS512"
+	PS512 = SignatureAlgorithmPS512
 
 	// None is no digital signature or MAC performed.
 	// import github.com/shogo82148/goat/jwa/none
-	None SignatureAlgorithm = "none"
+	None = SignatureAlgorithmNone
 
 	// EdDSA is Edwards-Curve Digital Signature Algorithm.
 	// import github.com/shogo82148/goat/jwa/eddsa
 	//
 	// Deprecated: use [SignatureAlgorithmEd25519] or [SignatureAlgorithmEd448] instead of EdDSA.
-	EdDSA SignatureAlgorithm = "EdDSA"
+	//go:fix inline
+	EdDSA = SignatureAlgorithmEdDSA
 
 	// ES256K is ECDSA using secp256k1 curve and SHA-256.
 	// import github.com/shogo82148/goat/jwa/es
-	ES256K SignatureAlgorithm = "ES256K"
+	//
+	// Deprecated: use [SignatureAlgorithmES256K] instead of ES256K.
+	//go:fix inline
+	ES256K = SignatureAlgorithmES256K
 )
 
 const (
+	// SignatureAlgorithmUnknown is an unknown signature algorithm.
+	SignatureAlgorithmUnknown SignatureAlgorithm = ""
+
+	// SignatureAlgorithmHS256 is HMAC using SHA-256.
+	// import github.com/shogo82148/goat/jwa/hs
+	SignatureAlgorithmHS256 SignatureAlgorithm = "HS256"
+
+	// SignatureAlgorithmHS384 is HMAC using SHA-384.
+	// import github.com/shogo82148/goat/jwa/hs
+	SignatureAlgorithmHS384 SignatureAlgorithm = "HS384"
+
+	// SignatureAlgorithmHS512 is HMAC using SHA-512.
+	// import github.com/shogo82148/goat/jwa/hs
+	SignatureAlgorithmHS512 SignatureAlgorithm = "HS512"
+
+	// SignatureAlgorithmRS256 is RSASSA-PKCS1-v1_5 using SHA-256.
+	// import github.com/shogo82148/goat/jwa/rs
+	SignatureAlgorithmRS256 SignatureAlgorithm = "RS256"
+
+	// SignatureAlgorithmRS384 is RSASSA-PKCS1-v1_5 using SHA-384.
+	// import github.com/shogo82148/goat/jwa/rs
+	SignatureAlgorithmRS384 SignatureAlgorithm = "RS384"
+
+	// SignatureAlgorithmRS512 is RSASSA-PKCS1-v1_5 using SHA-512.
+	// import github.com/shogo82148/goat/jwa/rs
+	SignatureAlgorithmRS512 SignatureAlgorithm = "RS512"
+
+	// SignatureAlgorithmES256 is ECDSA using P-256 and SHA-256.
+	// import github.com/shogo82148/goat/jwa/es
+	SignatureAlgorithmES256 SignatureAlgorithm = "ES256"
+
+	// SignatureAlgorithmES384 is ECDSA using P-384 and SHA-384.
+	// import github.com/shogo82148/goat/jwa/es
+	SignatureAlgorithmES384 SignatureAlgorithm = "ES384"
+
+	// SignatureAlgorithmES512 is ECDSA using P-521 and SHA-512.
+	// import github.com/shogo82148/goat/jwa/es
+	SignatureAlgorithmES512 SignatureAlgorithm = "ES512"
+
+	// SignatureAlgorithmPS256 is RSASSA-PSS using SHA-256 and MGF1 with SHA-256.
+	// import github.com/shogo82148/goat/jwa/ps
+	SignatureAlgorithmPS256 SignatureAlgorithm = "PS256"
+
+	// SignatureAlgorithmPS384 is RSASSA-PSS using SHA-384 and MGF1 with SHA-384.
+	// import github.com/shogo82148/goat/jwa/ps
+	SignatureAlgorithmPS384 SignatureAlgorithm = "PS384"
+
+	// SignatureAlgorithmPS512 is RSASSA-PSS using SHA-512 and MGF1 with SHA-512.
+	// import github.com/shogo82148/goat/jwa/ps
+	SignatureAlgorithmPS512 SignatureAlgorithm = "PS512"
+
+	// SignatureAlgorithmNone is no digital signature or MAC performed.
+	// import github.com/shogo82148/goat/jwa/none
+	SignatureAlgorithmNone SignatureAlgorithm = "none"
+
+	// SignatureAlgorithmEdDSA is Edwards-Curve Digital Signature Algorithm.
+	// import github.com/shogo82148/goat/jwa/eddsa
+	//
+	// Deprecated: use [SignatureAlgorithmEd25519] or [SignatureAlgorithmEd448] instead of EdDSA.
+	SignatureAlgorithmEdDSA SignatureAlgorithm = "EdDSA"
+
 	// SignatureAlgorithmEd25519 is Ed25519 signature algorithm.
 	// import github.com/shogo82148/goat/jwa/ed25519
 	SignatureAlgorithmEd25519 SignatureAlgorithm = "Ed25519"
@@ -85,6 +174,10 @@ const (
 	// SignatureAlgorithmEd448 is Ed448 signature algorithm.
 	// import github.com/shogo82148/goat/jwa/ed448
 	SignatureAlgorithmEd448 SignatureAlgorithm = "Ed448"
+
+	// SignatureAlgorithmES256K is ECDSA using secp256k1 curve and SHA-256.
+	// import github.com/shogo82148/goat/jwa/es
+	SignatureAlgorithmES256K SignatureAlgorithm = "ES256K"
 )
 
 func (alg SignatureAlgorithm) String() string {
@@ -109,23 +202,23 @@ func (alg SignatureAlgorithm) Available() bool {
 }
 
 var signatureAlgorithms = map[SignatureAlgorithm]func() sig.Algorithm{
-	HS256:                     nil,
-	HS384:                     nil,
-	HS512:                     nil,
-	RS256:                     nil,
-	RS384:                     nil,
-	RS512:                     nil,
-	ES256:                     nil,
-	ES384:                     nil,
-	ES512:                     nil,
-	PS256:                     nil,
-	PS384:                     nil,
-	PS512:                     nil,
-	None:                      nil,
-	EdDSA:                     nil,
-	ES256K:                    nil,
+	SignatureAlgorithmHS256:   nil,
+	SignatureAlgorithmHS384:   nil,
+	SignatureAlgorithmHS512:   nil,
+	SignatureAlgorithmRS256:   nil,
+	SignatureAlgorithmRS384:   nil,
+	SignatureAlgorithmRS512:   nil,
+	SignatureAlgorithmES256:   nil,
+	SignatureAlgorithmES384:   nil,
+	SignatureAlgorithmES512:   nil,
+	SignatureAlgorithmPS256:   nil,
+	SignatureAlgorithmPS384:   nil,
+	SignatureAlgorithmPS512:   nil,
+	SignatureAlgorithmNone:    nil,
+	SignatureAlgorithmEdDSA:   nil,
 	SignatureAlgorithmEd25519: nil,
 	SignatureAlgorithmEd448:   nil,
+	SignatureAlgorithmES256K:  nil,
 }
 
 func RegisterSignatureAlgorithm(alg SignatureAlgorithm, f func() sig.Algorithm) {

--- a/jwa/jwa.go
+++ b/jwa/jwa.go
@@ -237,75 +237,196 @@ func RegisterSignatureAlgorithm(alg SignatureAlgorithm, f func() sig.Algorithm) 
 type KeyManagementAlgorithm string
 
 const (
-	KeyManagementAlgorithmUnknown KeyManagementAlgorithm = ""
-
 	// RSA1_5 is RSAES-PKCS1-v1_5.
 	// import github.com/shogo82148/goat/jwa/rsapkcs1v15
-	RSA1_5 KeyManagementAlgorithm = "RSA1_5"
+	//
+	// Deprecated: use [KeyManagementAlgorithmRSA1_5] instead of RSA1_5.
+	//go:fix inline
+	RSA1_5 = KeyManagementAlgorithmRSA1_5
 
 	// RSA_OAEP is RSAES OAEP.
 	// import github.com/shogo82148/goat/jwa/rsapoaep
-	RSA_OAEP KeyManagementAlgorithm = "RSA-OAEP"
+	//
+	// Deprecated: use [KeyManagementAlgorithmRSA_OAEP] instead of RSA_OAEP.
+	//go:fix inline
+	RSA_OAEP = KeyManagementAlgorithmRSA_OAEP
 
 	// RSA_OAEP_256 is RSAES OAEP using SHA-256 and MGF1 with SHA-256.
 	// import github.com/shogo82148/goat/jwa/rsapoaep
-	RSA_OAEP_256 KeyManagementAlgorithm = "RSA-OAEP-256"
+	//
+	// Deprecated: use [KeyManagementAlgorithmRSA_OAEP_256] instead of RSA_OAEP_256.
+	//go:fix inline
+	RSA_OAEP_256 = KeyManagementAlgorithmRSA_OAEP_256
 
 	// A128KW is AES Key Wrap with default initial value using 128-bit key.
 	// import github.com/shogo82148/goat/jwa/akw
-	A128KW KeyManagementAlgorithm = "A128KW"
+	//
+	// Deprecated: use [KeyManagementAlgorithmA128KW] instead of A128KW.
+	//go:fix inline
+	A128KW = KeyManagementAlgorithmA128KW
 
 	// A192KW is AES Key Wrap with default initial value using 192-bit key.
 	// import github.com/shogo82148/goat/jwa/akw
-	A192KW KeyManagementAlgorithm = "A192KW"
+	//
+	// Deprecated: use [KeyManagementAlgorithmA192KW] instead of A192KW.
+	//go:fix inline
+	A192KW = KeyManagementAlgorithmA192KW
 
 	// A256KW is AES Key Wrap with default initial value using 256-bit key.
 	// import github.com/shogo82148/goat/jwa/akw
-	A256KW KeyManagementAlgorithm = "A256KW"
+	//
+	// Deprecated: use [KeyManagementAlgorithmA256KW] instead of A256KW.
+	//go:fix inline
+	A256KW = KeyManagementAlgorithmA256KW
 
 	// Direct is direct use of a shared symmetric key as the CEK.
 	// import github.com/shogo82148/goat/jwa/dir
-	Direct KeyManagementAlgorithm = "dir"
+	//
+	// Deprecated: use [KeyManagementAlgorithmDirect] instead of Direct.
+	//go:fix inline
+	Direct = KeyManagementAlgorithmDirect
 
 	// ECDH_ES is Elliptic Curve Diffie-Hellman Ephemeral Static key agreement using Concat KDF.
 	// import github.com/shogo82148/goat/jwa/ecdhes
-	ECDH_ES KeyManagementAlgorithm = "ECDH-ES"
+	//
+	// Deprecated: use [KeyManagementAlgorithmECDH_ES] instead of ECDH_ES.
+	//go:fix inline
+	ECDH_ES = KeyManagementAlgorithmECDH_ES
 
 	// ECDH_ES_A128KW is ECDH-ES using Concat KDF and CEK wrapped with "A128KW".
 	// import github.com/shogo82148/goat/jwa/ecdhes
-	ECDH_ES_A128KW KeyManagementAlgorithm = "ECDH-ES+A128KW"
+	//
+	// Deprecated: use [KeyManagementAlgorithmECDH_ES_A128KW] instead of ECDH_ES_A128KW.
+	//go:fix inline
+	ECDH_ES_A128KW = KeyManagementAlgorithmECDH_ES_A128KW
 
 	// ECDH_ES_A192KW is ECDH-ES using Concat KDF and CEK wrapped with "A192KW".
 	// import github.com/shogo82148/goat/jwa/ecdhes
-	ECDH_ES_A192KW KeyManagementAlgorithm = "ECDH-ES+A192KW"
+	//
+	// Deprecated: use [KeyManagementAlgorithmECDH_ES_A192KW] instead of ECDH_ES_A192KW.
+	//go:fix inline
+	ECDH_ES_A192KW = KeyManagementAlgorithmECDH_ES_A192KW
 
 	// ECDH_ES_A256KW is ECDH-ES using Concat KDF and CEK wrapped with "A256KW".
 	// import github.com/shogo82148/goat/jwa/ecdhes
-	ECDH_ES_A256KW KeyManagementAlgorithm = "ECDH-ES+A256KW"
+	//
+	// Deprecated: use [KeyManagementAlgorithmECDH_ES_A256KW] instead of ECDH_ES_A256KW.
+	//go:fix inline
+	ECDH_ES_A256KW = KeyManagementAlgorithmECDH_ES_A256KW
 
 	// A128GCMKW is Key wrapping with AES GCM using 128-bit key.
 	// import github.com/shogo82148/goat/jwa/agcmkw
-	A128GCMKW KeyManagementAlgorithm = "A128GCMKW"
+	//
+	// Deprecated: use [KeyManagementAlgorithmA128GCMKW] instead of A128GCMKW.
+	//go:fix inline
+	A128GCMKW = KeyManagementAlgorithmA128GCMKW
 
-	// A196GCMKW is Key wrapping with AES GCM using 196-bit key.
+	// A192GCMKW is Key wrapping with AES GCM using 192-bit key.
 	// import github.com/shogo82148/goat/jwa/agcmkw
-	A192GCMKW KeyManagementAlgorithm = "A192GCMKW"
+	//
+	// Deprecated: use [KeyManagementAlgorithmA192GCMKW] instead of A192GCMKW.
+	//go:fix inline
+	A192GCMKW = KeyManagementAlgorithmA192GCMKW
 
 	// A256GCMKW is Key wrapping with AES GCM using 256-bit key.
 	// import github.com/shogo82148/goat/jwa/agcmkw
-	A256GCMKW KeyManagementAlgorithm = "A256GCMKW"
+	//
+	// Deprecated: use [KeyManagementAlgorithmA256GCMKW] instead of A256GCMKW.
+	//go:fix inline
+	A256GCMKW = KeyManagementAlgorithmA256GCMKW
 
 	// PBES2_HS256_A128KW is PBES2 with HMAC SHA-256 and "A128KW" wrapping.
 	// import github.com/shogo82148/goat/jwa/pbes2
-	PBES2_HS256_A128KW KeyManagementAlgorithm = "PBES2-HS256+A128KW"
+	//
+	// Deprecated: use [KeyManagementAlgorithmPBES2_HS256_A128KW] instead of PBES2_HS256_A128KW.
+	//go:fix inline
+	PBES2_HS256_A128KW = KeyManagementAlgorithmPBES2_HS256_A128KW
 
 	// PBES2_HS384_A192KW is PBES2 with HMAC SHA-384 and "A192KW" wrapping.
 	// import github.com/shogo82148/goat/jwa/pbes2
-	PBES2_HS384_A192KW KeyManagementAlgorithm = "PBES2-HS384+A192KW"
+	//
+	// Deprecated: use [KeyManagementAlgorithmPBES2_HS384_A192KW] instead of PBES2_HS384_A192KW.
+	//go:fix inline
+	PBES2_HS384_A192KW = KeyManagementAlgorithmPBES2_HS384_A192KW
 
 	// PBES2_HS512_A256KW is PBES2 with HMAC SHA-512 and "A256KW" wrapping.
 	// import github.com/shogo82148/goat/jwa/pbes2
-	PBES2_HS512_A256KW KeyManagementAlgorithm = "PBES2-HS512+A256KW"
+	//
+	// Deprecated: use [KeyManagementAlgorithmPBES2_HS512_A256KW] instead of PBES2_HS512_A256KW.
+	//go:fix inline
+	PBES2_HS512_A256KW = KeyManagementAlgorithmPBES2_HS512_A256KW
+)
+
+const (
+	KeyManagementAlgorithmUnknown KeyManagementAlgorithm = ""
+
+	// KeyManagementAlgorithmRSA1_5 is RSAES-PKCS1-v1_5.
+	// import github.com/shogo82148/goat/jwa/rsapkcs1v15
+	KeyManagementAlgorithmRSA1_5 KeyManagementAlgorithm = "RSA1_5"
+
+	// KeyManagementAlgorithmRSA_OAEP is RSAES OAEP.
+	// import github.com/shogo82148/goat/jwa/rsapoaep
+	KeyManagementAlgorithmRSA_OAEP KeyManagementAlgorithm = "RSA-OAEP"
+
+	// KeyManagementAlgorithmRSA_OAEP_256 is RSAES OAEP using SHA-256 and MGF1 with SHA-256.
+	// import github.com/shogo82148/goat/jwa/rsapoaep
+	KeyManagementAlgorithmRSA_OAEP_256 KeyManagementAlgorithm = "RSA-OAEP-256"
+
+	// KeyManagementAlgorithmA128KW is AES Key Wrap with default initial value using 128-bit key.
+	// import github.com/shogo82148/goat/jwa/akw
+	KeyManagementAlgorithmA128KW KeyManagementAlgorithm = "A128KW"
+
+	// KeyManagementAlgorithmA192KW is AES Key Wrap with default initial value using 192-bit key.
+	// import github.com/shogo82148/goat/jwa/akw
+	KeyManagementAlgorithmA192KW KeyManagementAlgorithm = "A192KW"
+
+	// KeyManagementAlgorithmA256KW is AES Key Wrap with default initial value using 256-bit key.
+	// import github.com/shogo82148/goat/jwa/akw
+	KeyManagementAlgorithmA256KW KeyManagementAlgorithm = "A256KW"
+
+	// KeyManagementAlgorithmDirect is direct use of a shared symmetric key as the CEK.
+	// import github.com/shogo82148/goat/jwa/dir
+	KeyManagementAlgorithmDirect KeyManagementAlgorithm = "dir"
+
+	// KeyManagementAlgorithmECDH_ES is Elliptic Curve Diffie-Hellman Ephemeral Static key agreement using Concat KDF.
+	// import github.com/shogo82148/goat/jwa/ecdhes
+	KeyManagementAlgorithmECDH_ES KeyManagementAlgorithm = "ECDH-ES"
+
+	// KeyManagementAlgorithmECDH_ES_A128KW is ECDH-ES using Concat KDF and CEK wrapped with "A128KW".
+	// import github.com/shogo82148/goat/jwa/ecdhes
+	KeyManagementAlgorithmECDH_ES_A128KW KeyManagementAlgorithm = "ECDH-ES+A128KW"
+
+	// KeyManagementAlgorithmECDH_ES_A192KW is ECDH-ES using Concat KDF and CEK wrapped with "A192KW".
+	// import github.com/shogo82148/goat/jwa/ecdhes
+	KeyManagementAlgorithmECDH_ES_A192KW KeyManagementAlgorithm = "ECDH-ES+A192KW"
+
+	// KeyManagementAlgorithmECDH_ES_A256KW is ECDH-ES using Concat KDF and CEK wrapped with "A256KW".
+	// import github.com/shogo82148/goat/jwa/ecdhes
+	KeyManagementAlgorithmECDH_ES_A256KW KeyManagementAlgorithm = "ECDH-ES+A256KW"
+
+	// KeyManagementAlgorithmA128GCMKW is Key wrapping with AES GCM using 128-bit key.
+	// import github.com/shogo82148/goat/jwa/agcmkw
+	KeyManagementAlgorithmA128GCMKW KeyManagementAlgorithm = "A128GCMKW"
+
+	// KeyManagementAlgorithmA192GCMKW is Key wrapping with AES GCM using 192-bit key.
+	// import github.com/shogo82148/goat/jwa/agcmkw
+	KeyManagementAlgorithmA192GCMKW KeyManagementAlgorithm = "A192GCMKW"
+
+	// KeyManagementAlgorithmA256GCMKW is Key wrapping with AES GCM using 256-bit key.
+	// import github.com/shogo82148/goat/jwa/agcmkw
+	KeyManagementAlgorithmA256GCMKW KeyManagementAlgorithm = "A256GCMKW"
+
+	// KeyManagementAlgorithmPBES2_HS256_A128KW is PBES2 with HMAC SHA-256 and "A128KW" wrapping.
+	// import github.com/shogo82148/goat/jwa/pbes2
+	KeyManagementAlgorithmPBES2_HS256_A128KW KeyManagementAlgorithm = "PBES2-HS256+A128KW"
+
+	// KeyManagementAlgorithmPBES2_HS384_A192KW is PBES2 with HMAC SHA-384 and "A192KW" wrapping.
+	// import github.com/shogo82148/goat/jwa/pbes2
+	KeyManagementAlgorithmPBES2_HS384_A192KW KeyManagementAlgorithm = "PBES2-HS384+A192KW"
+
+	// KeyManagementAlgorithmPBES2_HS512_A256KW is PBES2 with HMAC SHA-512 and "A256KW" wrapping.
+	// import github.com/shogo82148/goat/jwa/pbes2
+	KeyManagementAlgorithmPBES2_HS512_A256KW KeyManagementAlgorithm = "PBES2-HS512+A256KW"
 )
 
 var keyManagementAlgorithms = map[KeyManagementAlgorithm]func() keymanage.Algorithm{

--- a/jwa/jwa.go
+++ b/jwa/jwa.go
@@ -84,14 +84,23 @@ const (
 
 	// PS384 is RSASSA-PSS using SHA-384 and MGF1 with SHA-384.
 	// import github.com/shogo82148/goat/jwa/ps
+	//
+	// Deprecated: use [SignatureAlgorithmPS384] instead of PS384.
+	//go:fix inline
 	PS384 = SignatureAlgorithmPS384
 
 	// PS512 is RSASSA-PSS using SHA-512 and MGF1 with SHA-512.
 	// import github.com/shogo82148/goat/jwa/ps
+	//
+	// Deprecated: use [SignatureAlgorithmPS512] instead of PS512.
+	//go:fix inline
 	PS512 = SignatureAlgorithmPS512
 
 	// None is no digital signature or MAC performed.
 	// import github.com/shogo82148/goat/jwa/none
+	//
+	// Deprecated: use [SignatureAlgorithmNone] instead of None.
+	//go:fix inline
 	None = SignatureAlgorithmNone
 
 	// EdDSA is Edwards-Curve Digital Signature Algorithm.

--- a/jwa/jwa.go
+++ b/jwa/jwa.go
@@ -501,38 +501,85 @@ const (
 	// A128CBC_HS256 is AES_128_CBC_HMAC_SHA_256 authenticated encryption
 	// algorithm, as defined in RFC 7518 Section 5.2.3.
 	// import github.com/shogo82148/goat/jwa/acbc
-	A128CBC_HS256 EncryptionAlgorithm = "A128CBC-HS256"
+	//
+	// Deprecated: use [EncryptionAlgorithmA128CBC_HS256] instead of A128CBC_HS256.
+	//go:fix inline
+	A128CBC_HS256 = EncryptionAlgorithmA128CBC_HS256
 
 	// A192CBC_HS384 is AES_192_CBC_HMAC_SHA_384 authenticated encryption
 	// algorithm, as defined in RFC 7518 Section 5.2.4.
 	// import github.com/shogo82148/goat/jwa/acbc
-	A192CBC_HS384 EncryptionAlgorithm = "A192CBC-HS384"
+	//
+	// Deprecated: use [EncryptionAlgorithmA192CBC_HS384] instead of A192CBC_HS384.
+	//go:fix inline
+	A192CBC_HS384 = EncryptionAlgorithmA192CBC_HS384
 
 	// A256CBC_HS512 is AES_256_CBC_HMAC_SHA_512 authenticated encryption
 	// algorithm, as defined in RFC 7518 Section 5.2.5.
 	// import github.com/shogo82148/goat/jwa/acbc
-	A256CBC_HS512 EncryptionAlgorithm = "A256CBC-HS512"
+	//
+	// Deprecated: use [EncryptionAlgorithmA256CBC_HS512] instead of A256CBC_HS512.
+	//go:fix inline
+	A256CBC_HS512 = EncryptionAlgorithmA256CBC_HS512
 
 	// A128GCM is AES GCM using 128-bit key.
 	// import github.com/shogo82148/goat/jwa/agcm
-	A128GCM EncryptionAlgorithm = "A128GCM"
+	//
+	// Deprecated: use [EncryptionAlgorithmA128GCM] instead of A128GCM.
+	//go:fix inline
+	A128GCM = EncryptionAlgorithmA128GCM
 
 	// A192GCM is AES GCM using 192-bit key.
 	// import github.com/shogo82148/goat/jwa/agcm
-	A192GCM EncryptionAlgorithm = "A192GCM"
+	//
+	// Deprecated: use [EncryptionAlgorithmA192GCM] instead of A192GCM.
+	//go:fix inline
+	A192GCM = EncryptionAlgorithmA192GCM
 
 	// A256GCM is AES GCM using 256-bit key.
 	// import github.com/shogo82148/goat/jwa/agcm
-	A256GCM EncryptionAlgorithm = "A256GCM"
+	//
+	// Deprecated: use [EncryptionAlgorithmA256GCM] instead of A256GCM.
+	//go:fix inline
+	A256GCM = EncryptionAlgorithmA256GCM
+)
+
+const (
+	// EncryptionAlgorithmA128CBC_HS256 is AES_128_CBC_HMAC_SHA_256 authenticated encryption
+	// algorithm, as defined in RFC 7518 Section 5.2.3.
+	// import github.com/shogo82148/goat/jwa/acbc
+	EncryptionAlgorithmA128CBC_HS256 EncryptionAlgorithm = "A128CBC-HS256"
+
+	// EncryptionAlgorithmA192CBC_HS384 is AES_192_CBC_HMAC_SHA_384 authenticated encryption
+	// algorithm, as defined in RFC 7518 Section 5.2.4.
+	// import github.com/shogo82148/goat/jwa/acbc
+	EncryptionAlgorithmA192CBC_HS384 EncryptionAlgorithm = "A192CBC-HS384"
+
+	// EncryptionAlgorithmA256CBC_HS512 is AES_256_CBC_HMAC_SHA_512 authenticated encryption
+	// algorithm, as defined in RFC 7518 Section 5.2.5.
+	// import github.com/shogo82148/goat/jwa/acbc
+	EncryptionAlgorithmA256CBC_HS512 EncryptionAlgorithm = "A256CBC-HS512"
+
+	// EncryptionAlgorithmA128GCM is AES GCM using 128-bit key.
+	// import github.com/shogo82148/goat/jwa/agcm
+	EncryptionAlgorithmA128GCM EncryptionAlgorithm = "A128GCM"
+
+	// EncryptionAlgorithmA192GCM is AES GCM using 192-bit key.
+	// import github.com/shogo82148/goat/jwa/agcm
+	EncryptionAlgorithmA192GCM EncryptionAlgorithm = "A192GCM"
+
+	// EncryptionAlgorithmA256GCM is AES GCM using 256-bit key.
+	// import github.com/shogo82148/goat/jwa/agcm
+	EncryptionAlgorithmA256GCM EncryptionAlgorithm = "A256GCM"
 )
 
 var encryptionAlgorithm = map[EncryptionAlgorithm]func() enc.Algorithm{
-	A128CBC_HS256: nil,
-	A192CBC_HS384: nil,
-	A256CBC_HS512: nil,
-	A128GCM:       nil,
-	A192GCM:       nil,
-	A256GCM:       nil,
+	EncryptionAlgorithmA128CBC_HS256: nil,
+	EncryptionAlgorithmA192CBC_HS384: nil,
+	EncryptionAlgorithmA256CBC_HS512: nil,
+	EncryptionAlgorithmA128GCM:       nil,
+	EncryptionAlgorithmA192GCM:       nil,
+	EncryptionAlgorithmA256GCM:       nil,
 }
 
 func RegisterEncryptionAlgorithm(alg EncryptionAlgorithm, f func() enc.Algorithm) {

--- a/jwa/jwa.go
+++ b/jwa/jwa.go
@@ -780,10 +780,18 @@ func (crv EllipticCurve) String() string {
 type CompressionAlgorithm string
 
 const (
+	// DEF is compression with the DEFLATE RFC 1951 algorithm.
+	//
+	// Deprecated: use [CompressionAlgorithmDEF] instead of DEF.
+	//go:fix inline
+	DEF = CompressionAlgorithmDEF
+)
+
+const (
 	CompressionAlgorithmUnknown CompressionAlgorithm = ""
 
-	// DEF is compression with the DEFLATE RFC 1951 algorithm.
-	DEF CompressionAlgorithm = "DEF"
+	// CompressionAlgorithmDEF is compression with the DEFLATE RFC 1951 algorithm.
+	CompressionAlgorithmDEF CompressionAlgorithm = "DEF"
 )
 
 func (zip CompressionAlgorithm) String() string {

--- a/jwa/jwa.go
+++ b/jwa/jwa.go
@@ -107,7 +107,6 @@ const (
 	// import github.com/shogo82148/goat/jwa/eddsa
 	//
 	// Deprecated: use [SignatureAlgorithmEd25519] or [SignatureAlgorithmEd448] instead of EdDSA.
-	//go:fix inline
 	EdDSA = SignatureAlgorithmEdDSA
 
 	// ES256K is ECDSA using secp256k1 curve and SHA-256.

--- a/jwa/jwa.go
+++ b/jwa/jwa.go
@@ -699,28 +699,78 @@ type EllipticCurve string
 
 const (
 	// P256 is a Curve which implements NIST P-256.
-	P256 EllipticCurve = "P-256"
+	//
+	// Deprecated: use [EllipticCurveP256] instead of P256.
+	//go:fix inline
+	P256 = EllipticCurveP256
 
 	// P384 is a Curve which implements NIST P-384.
-	P384 EllipticCurve = "P-364"
+	//
+	// Deprecated: use [EllipticCurveP384] instead of P384.
+	//go:fix inline
+	P384 = EllipticCurveP384
 
 	// P521 is a Curve which implements NIST P-521.
-	P521 EllipticCurve = "P-521"
+	//
+	// Deprecated: use [EllipticCurveP521] instead of P521.
+	//go:fix inline
+	P521 = EllipticCurveP521
 
 	// Ed25519 is Ed25519 signature algorithm key pairs.
-	Ed25519 EllipticCurve = "Ed25519"
+	//
+	// Deprecated: use [EllipticCurveEd25519] instead of Ed25519.
+	//go:fix inline
+	Ed25519 = EllipticCurveEd25519
 
 	// Ed448 is Ed448 signature algorithm key pairs.
-	Ed448 EllipticCurve = "Ed448"
+	//
+	// Deprecated: use [EllipticCurveEd448] instead of Ed448.
+	//go:fix inline
+	Ed448 = EllipticCurveEd448
 
 	// X25519 is X25519 function key pairs.
-	X25519 EllipticCurve = "X25519"
+	//
+	// Deprecated: use [EllipticCurveX25519] instead of X25519.
+	//go:fix inline
+	X25519 = EllipticCurveX25519
 
 	// X448 is X448 function key pairs.
-	X448 EllipticCurve = "X448"
+	//
+	// Deprecated: use [EllipticCurveX448] instead of X448.
+	//go:fix inline
+	X448 = EllipticCurveX448
 
 	// secp256k1 is SECG secp256k1 curve.
-	Secp256k1 EllipticCurve = "secp256k1"
+	//
+	// Deprecated: use [EllipticCurveSecp256k1] instead of Secp256k1.
+	//go:fix inline
+	Secp256k1 = EllipticCurveSecp256k1
+)
+
+const (
+	// EllipticCurveP256 is a Curve which implements NIST P-256.
+	EllipticCurveP256 EllipticCurve = "P-256"
+
+	// EllipticCurveP384 is a Curve which implements NIST P-384.
+	EllipticCurveP384 EllipticCurve = "P-384"
+
+	// EllipticCurveP521 is a Curve which implements NIST P-521.
+	EllipticCurveP521 EllipticCurve = "P-521"
+
+	// EllipticCurveEd25519 is Ed25519 signature algorithm key pairs.
+	EllipticCurveEd25519 EllipticCurve = "Ed25519"
+
+	// EllipticCurveEd448 is Ed448 signature algorithm key pairs.
+	EllipticCurveEd448 EllipticCurve = "Ed448"
+
+	// EllipticCurveX25519 is X25519 function key pairs.
+	EllipticCurveX25519 EllipticCurve = "X25519"
+
+	// EllipticCurveX448 is X448 function key pairs.
+	EllipticCurveX448 EllipticCurve = "X448"
+
+	// EllipticCurveSecp256k1 is SECG secp256k1 curve.
+	EllipticCurveSecp256k1 EllipticCurve = "secp256k1"
 )
 
 func (crv EllipticCurve) String() string {

--- a/jwa/jwa.go
+++ b/jwa/jwa.go
@@ -613,17 +613,17 @@ func (enc EncryptionAlgorithm) Available() bool {
 // CEKSize returns the byte size of CEK(Content Encryption Key) for the algorithm.
 func (enc EncryptionAlgorithm) CEKSize() int {
 	switch enc {
-	case A128CBC_HS256:
+	case EncryptionAlgorithmA128CBC_HS256:
 		return 32
-	case A192CBC_HS384:
+	case EncryptionAlgorithmA192CBC_HS384:
 		return 48
-	case A256CBC_HS512:
+	case EncryptionAlgorithmA256CBC_HS512:
 		return 64
-	case A128GCM:
+	case EncryptionAlgorithmA128GCM:
 		return 16
-	case A192GCM:
+	case EncryptionAlgorithmA192GCM:
 		return 24
-	case A256GCM:
+	case EncryptionAlgorithmA256GCM:
 		return 32
 	}
 	return 0
@@ -632,9 +632,9 @@ func (enc EncryptionAlgorithm) CEKSize() int {
 // IVSice returns the byte size of IV(Initialization Vector) for the algorithm.
 func (enc EncryptionAlgorithm) IVSize() int {
 	switch enc {
-	case A128CBC_HS256, A192CBC_HS384, A256CBC_HS512:
+	case EncryptionAlgorithmA128CBC_HS256, EncryptionAlgorithmA192CBC_HS384, EncryptionAlgorithmA256CBC_HS512:
 		return 16
-	case A128GCM, A192GCM, A256GCM:
+	case EncryptionAlgorithmA128GCM, EncryptionAlgorithmA192GCM, EncryptionAlgorithmA256GCM:
 		return 12
 	}
 	return 0

--- a/jwa/jwa.go
+++ b/jwa/jwa.go
@@ -593,10 +593,10 @@ var encryptionAlgorithm = map[EncryptionAlgorithm]func() enc.Algorithm{
 func RegisterEncryptionAlgorithm(alg EncryptionAlgorithm, f func() enc.Algorithm) {
 	g, ok := encryptionAlgorithm[alg]
 	if !ok {
-		panic("jwa: RegisterKeyManagementAlgorithm of unknown algorithm")
+		panic("jwa: RegisterEncryptionAlgorithm of unknown algorithm")
 	}
 	if g != nil {
-		panic("jwa: RegisterKeyManagementAlgorithm of already registered algorithm")
+		panic("jwa: RegisterEncryptionAlgorithm of already registered algorithm")
 	}
 	encryptionAlgorithm[alg] = f
 }

--- a/jwa/jwa.go
+++ b/jwa/jwa.go
@@ -77,6 +77,10 @@ const (
 
 	// PS256 is RSASSA-PSS using SHA-256 and MGF1 with SHA-256.
 	// import github.com/shogo82148/goat/jwa/ps
+	//
+	// Deprecated: use [SignatureAlgorithmPS256] instead of PS256.
+	//go:fix inline
+	PS256 = SignatureAlgorithmPS256
 
 	// PS384 is RSASSA-PSS using SHA-384 and MGF1 with SHA-384.
 	// import github.com/shogo82148/goat/jwa/ps
@@ -430,23 +434,23 @@ const (
 )
 
 var keyManagementAlgorithms = map[KeyManagementAlgorithm]func() keymanage.Algorithm{
-	RSA1_5:             nil,
-	RSA_OAEP:           nil,
-	RSA_OAEP_256:       nil,
-	A128KW:             nil,
-	A192KW:             nil,
-	A256KW:             nil,
-	Direct:             nil,
-	ECDH_ES:            nil,
-	ECDH_ES_A128KW:     nil,
-	ECDH_ES_A192KW:     nil,
-	ECDH_ES_A256KW:     nil,
-	A128GCMKW:          nil,
-	A192GCMKW:          nil,
-	A256GCMKW:          nil,
-	PBES2_HS256_A128KW: nil,
-	PBES2_HS384_A192KW: nil,
-	PBES2_HS512_A256KW: nil,
+	KeyManagementAlgorithmRSA1_5:             nil,
+	KeyManagementAlgorithmRSA_OAEP:           nil,
+	KeyManagementAlgorithmRSA_OAEP_256:       nil,
+	KeyManagementAlgorithmA128KW:             nil,
+	KeyManagementAlgorithmA192KW:             nil,
+	KeyManagementAlgorithmA256KW:             nil,
+	KeyManagementAlgorithmDirect:             nil,
+	KeyManagementAlgorithmECDH_ES:            nil,
+	KeyManagementAlgorithmECDH_ES_A128KW:     nil,
+	KeyManagementAlgorithmECDH_ES_A192KW:     nil,
+	KeyManagementAlgorithmECDH_ES_A256KW:     nil,
+	KeyManagementAlgorithmA128GCMKW:          nil,
+	KeyManagementAlgorithmA192GCMKW:          nil,
+	KeyManagementAlgorithmA256GCMKW:          nil,
+	KeyManagementAlgorithmPBES2_HS256_A128KW: nil,
+	KeyManagementAlgorithmPBES2_HS384_A192KW: nil,
+	KeyManagementAlgorithmPBES2_HS512_A256KW: nil,
 }
 
 func RegisterKeyManagementAlgorithm(alg KeyManagementAlgorithm, f func() keymanage.Algorithm) {

--- a/jwa/none/none.go
+++ b/jwa/none/none.go
@@ -16,7 +16,7 @@ func New() sig.Algorithm {
 }
 
 func init() {
-	jwa.RegisterSignatureAlgorithm(jwa.None, New)
+	jwa.RegisterSignatureAlgorithm(jwa.SignatureAlgorithmNone, New)
 }
 
 var _ sig.Algorithm = (*algorithm)(nil)

--- a/jwa/pbes2/pbes2.go
+++ b/jwa/pbes2/pbes2.go
@@ -16,7 +16,7 @@ import (
 )
 
 var a128kw = &algorithm{
-	name: string(jwa.PBES2_HS256_A128KW),
+	name: string(jwa.KeyManagementAlgorithmPBES2_HS256_A128KW),
 	hash: crypto.SHA256.New,
 	size: 16,
 }
@@ -28,7 +28,7 @@ func NewHS256A128KW() keymanage.Algorithm {
 }
 
 var a192kw = &algorithm{
-	name: string(jwa.PBES2_HS384_A192KW),
+	name: string(jwa.KeyManagementAlgorithmPBES2_HS384_A192KW),
 	hash: crypto.SHA384.New,
 	size: 24,
 }
@@ -40,7 +40,7 @@ func NewHS384A192KW() keymanage.Algorithm {
 }
 
 var a256kw = &algorithm{
-	name: string(jwa.PBES2_HS512_A256KW),
+	name: string(jwa.KeyManagementAlgorithmPBES2_HS512_A256KW),
 	hash: crypto.SHA512.New,
 	size: 32,
 }
@@ -52,9 +52,9 @@ func NewHS512A256KW() keymanage.Algorithm {
 }
 
 func init() {
-	jwa.RegisterKeyManagementAlgorithm(jwa.PBES2_HS256_A128KW, NewHS256A128KW)
-	jwa.RegisterKeyManagementAlgorithm(jwa.PBES2_HS384_A192KW, NewHS384A192KW)
-	jwa.RegisterKeyManagementAlgorithm(jwa.PBES2_HS512_A256KW, NewHS512A256KW)
+	jwa.RegisterKeyManagementAlgorithm(jwa.KeyManagementAlgorithmPBES2_HS256_A128KW, NewHS256A128KW)
+	jwa.RegisterKeyManagementAlgorithm(jwa.KeyManagementAlgorithmPBES2_HS384_A192KW, NewHS384A192KW)
+	jwa.RegisterKeyManagementAlgorithm(jwa.KeyManagementAlgorithmPBES2_HS512_A256KW, NewHS512A256KW)
 }
 
 var _ keymanage.Algorithm = (*algorithm)(nil)

--- a/jwa/ps/ps.go
+++ b/jwa/ps/ps.go
@@ -13,7 +13,7 @@ import (
 )
 
 var ps256 = &algorithm{
-	alg:  jwa.PS256,
+	alg:  jwa.SignatureAlgorithmPS256,
 	hash: crypto.SHA256,
 }
 
@@ -52,7 +52,7 @@ func New512() sig.Algorithm {
 }
 
 var ps256w = &algorithm{
-	alg:  jwa.RS256,
+	alg:  jwa.SignatureAlgorithmRS256,
 	hash: crypto.SHA256,
 	weak: true,
 }
@@ -65,7 +65,7 @@ func New256Weak() sig.Algorithm {
 }
 
 var ps384w = &algorithm{
-	alg:  jwa.RS384,
+	alg:  jwa.SignatureAlgorithmRS384,
 	hash: crypto.SHA384,
 	weak: true,
 }
@@ -78,7 +78,7 @@ func New384Weak() sig.Algorithm {
 }
 
 var ps512w = &algorithm{
-	alg:  jwa.RS512,
+	alg:  jwa.SignatureAlgorithmRS512,
 	hash: crypto.SHA512,
 	weak: true,
 }
@@ -91,7 +91,7 @@ func New512Weak() sig.Algorithm {
 }
 
 func init() {
-	jwa.RegisterSignatureAlgorithm(jwa.PS256, New256)
+	jwa.RegisterSignatureAlgorithm(jwa.SignatureAlgorithmPS256, New256)
 	jwa.RegisterSignatureAlgorithm(jwa.PS384, New384)
 	jwa.RegisterSignatureAlgorithm(jwa.PS512, New512)
 }

--- a/jwa/ps/ps.go
+++ b/jwa/ps/ps.go
@@ -26,7 +26,7 @@ func New256() sig.Algorithm {
 }
 
 var ps384 = &algorithm{
-	alg:  jwa.PS384,
+	alg:  jwa.SignatureAlgorithmPS384,
 	hash: crypto.SHA384,
 }
 
@@ -39,7 +39,7 @@ func New384() sig.Algorithm {
 }
 
 var ps512 = &algorithm{
-	alg:  jwa.PS512,
+	alg:  jwa.SignatureAlgorithmPS512,
 	hash: crypto.SHA512,
 }
 
@@ -92,8 +92,8 @@ func New512Weak() sig.Algorithm {
 
 func init() {
 	jwa.RegisterSignatureAlgorithm(jwa.SignatureAlgorithmPS256, New256)
-	jwa.RegisterSignatureAlgorithm(jwa.PS384, New384)
-	jwa.RegisterSignatureAlgorithm(jwa.PS512, New512)
+	jwa.RegisterSignatureAlgorithm(jwa.SignatureAlgorithmPS384, New384)
+	jwa.RegisterSignatureAlgorithm(jwa.SignatureAlgorithmPS512, New512)
 }
 
 var _ sig.Algorithm = (*algorithm)(nil)

--- a/jwa/rs/rs.go
+++ b/jwa/rs/rs.go
@@ -13,7 +13,7 @@ import (
 )
 
 var rs256 = &algorithm{
-	alg:  jwa.RS256,
+	alg:  jwa.SignatureAlgorithmRS256,
 	hash: crypto.SHA256,
 }
 
@@ -26,7 +26,7 @@ func New256() sig.Algorithm {
 }
 
 var rs384 = &algorithm{
-	alg:  jwa.RS384,
+	alg:  jwa.SignatureAlgorithmRS384,
 	hash: crypto.SHA384,
 }
 
@@ -39,7 +39,7 @@ func New384() sig.Algorithm {
 }
 
 var rs512 = &algorithm{
-	alg:  jwa.RS512,
+	alg:  jwa.SignatureAlgorithmRS512,
 	hash: crypto.SHA512,
 }
 
@@ -52,7 +52,7 @@ func New512() sig.Algorithm {
 }
 
 var rs256w = &algorithm{
-	alg:  jwa.RS256,
+	alg:  jwa.SignatureAlgorithmRS256,
 	hash: crypto.SHA256,
 	weak: true,
 }
@@ -65,7 +65,7 @@ func New256Weak() sig.Algorithm {
 }
 
 var rs384w = &algorithm{
-	alg:  jwa.RS384,
+	alg:  jwa.SignatureAlgorithmRS384,
 	hash: crypto.SHA384,
 	weak: true,
 }
@@ -78,7 +78,7 @@ func New384Weak() sig.Algorithm {
 }
 
 var rs512w = &algorithm{
-	alg:  jwa.RS512,
+	alg:  jwa.SignatureAlgorithmRS512,
 	hash: crypto.SHA512,
 	weak: true,
 }
@@ -91,9 +91,9 @@ func New512Weak() sig.Algorithm {
 }
 
 func init() {
-	jwa.RegisterSignatureAlgorithm(jwa.RS256, New256)
-	jwa.RegisterSignatureAlgorithm(jwa.RS384, New384)
-	jwa.RegisterSignatureAlgorithm(jwa.RS512, New512)
+	jwa.RegisterSignatureAlgorithm(jwa.SignatureAlgorithmRS256, New256)
+	jwa.RegisterSignatureAlgorithm(jwa.SignatureAlgorithmRS384, New384)
+	jwa.RegisterSignatureAlgorithm(jwa.SignatureAlgorithmRS512, New512)
 }
 
 var _ sig.Algorithm = (*algorithm)(nil)

--- a/jwa/rsaoaep/rsaoaep.go
+++ b/jwa/rsaoaep/rsaoaep.go
@@ -31,8 +31,8 @@ func New256() keymanage.Algorithm {
 }
 
 func init() {
-	jwa.RegisterKeyManagementAlgorithm(jwa.RSA_OAEP, New)
-	jwa.RegisterKeyManagementAlgorithm(jwa.RSA_OAEP_256, New256)
+	jwa.RegisterKeyManagementAlgorithm(jwa.KeyManagementAlgorithmRSA_OAEP, New)
+	jwa.RegisterKeyManagementAlgorithm(jwa.KeyManagementAlgorithmRSA_OAEP_256, New256)
 }
 
 var _ keymanage.Algorithm = (*Algorithm)(nil)

--- a/jwa/rsapkcs1v15/rsapkcs1v15.go
+++ b/jwa/rsapkcs1v15/rsapkcs1v15.go
@@ -18,7 +18,7 @@ func New() keymanage.Algorithm {
 }
 
 func init() {
-	jwa.RegisterKeyManagementAlgorithm(jwa.RSA1_5, New)
+	jwa.RegisterKeyManagementAlgorithm(jwa.KeyManagementAlgorithmRSA1_5, New)
 }
 
 var _ keymanage.Algorithm = (*Algorithm)(nil)

--- a/jwe/jwe.go
+++ b/jwe/jwe.go
@@ -623,7 +623,7 @@ func NewMessage(enc jwa.EncryptionAlgorithm, protected *Header, plaintext []byte
 		return nil, errors.New("jwa: requested content encryption algorithm " + string(enc) + " is not available")
 	}
 
-	if protected.CompressionAlgorithm() == jwa.DEF {
+	if protected.CompressionAlgorithm() == jwa.CompressionAlgorithmDEF {
 		buf := bytes.NewBuffer(make([]byte, 0, len(plaintext)))
 		w, err := flate.NewWriter(buf, flate.BestCompression)
 		if err != nil {
@@ -683,7 +683,7 @@ func NewMessageWithKW(enc jwa.EncryptionAlgorithm, kw keymanage.KeyWrapper, prot
 		return nil, errors.New("jwa: requested content encryption algorithm " + string(enc) + " is not available")
 	}
 
-	if protected.CompressionAlgorithm() == jwa.DEF {
+	if protected.CompressionAlgorithm() == jwa.CompressionAlgorithmDEF {
 		buf := bytes.NewBuffer(make([]byte, 0, len(plaintext)))
 		w, err := flate.NewWriter(buf, flate.BestCompression)
 		if err != nil {
@@ -832,7 +832,7 @@ func (msg *Message) Decrypt(finder KeyWrapperFinder) (plaintext []byte, err erro
 		if err != nil {
 			return nil, fmt.Errorf("jwe: failed to decrypt: %w", err)
 		}
-		if merged.CompressionAlgorithm() == jwa.DEF {
+		if merged.CompressionAlgorithm() == jwa.CompressionAlgorithmDEF {
 			buf := bytes.NewBuffer(make([]byte, 0, len(plaintext)))
 			r := flate.NewReader(bytes.NewReader(plaintext))
 			if _, err := buf.ReadFrom(r); err != nil {

--- a/jwe/jwe_test.go
+++ b/jwe/jwe_test.go
@@ -330,7 +330,7 @@ func TestEncrypt(t *testing.T) {
 		key := alg.NewKeyWrapper(k)
 
 		plaintext := "The true sign of intelligence is not knowledge but imagination."
-		msg1, err := NewMessageWithKW(jwa.A256GCM, key, header, []byte(plaintext))
+		msg1, err := NewMessageWithKW(jwa.EncryptionAlgorithmA256GCM, key, header, []byte(plaintext))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -397,7 +397,7 @@ func TestEncrypt(t *testing.T) {
 		header := &Header{}
 		header.SetAlgorithm(jwa.KeyManagementAlgorithmRSA1_5)
 		plaintext := "Live long and prosper."
-		msg1, err := NewMessageWithKW(jwa.A128CBC_HS256, key, header, []byte(plaintext))
+		msg1, err := NewMessageWithKW(jwa.EncryptionAlgorithmA128CBC_HS256, key, header, []byte(plaintext))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -437,7 +437,7 @@ func TestEncrypt(t *testing.T) {
 		header := &Header{}
 		header.SetAlgorithm(jwa.KeyManagementAlgorithmA128KW)
 		plaintext := "Live long and prosper."
-		msg1, err := NewMessageWithKW(jwa.A128CBC_HS256, key, header, []byte(plaintext))
+		msg1, err := NewMessageWithKW(jwa.EncryptionAlgorithmA128CBC_HS256, key, header, []byte(plaintext))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -481,7 +481,7 @@ func TestEncrypt(t *testing.T) {
 		alg := header.Algorithm().New()
 		key := alg.NewKeyWrapper(k)
 		plaintext := "Hello JWE!\n"
-		msg1, err := NewMessageWithKW(jwa.A128GCM, key, header, []byte(plaintext))
+		msg1, err := NewMessageWithKW(jwa.EncryptionAlgorithmA128GCM, key, header, []byte(plaintext))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -525,7 +525,7 @@ func TestEncrypt(t *testing.T) {
 		alg := header.Algorithm().New()
 		key := alg.NewKeyWrapper(k)
 		plaintext := "Hello World!\n"
-		msg1, err := NewMessageWithKW(jwa.A128GCM, key, header, []byte(plaintext))
+		msg1, err := NewMessageWithKW(jwa.EncryptionAlgorithmA128GCM, key, header, []byte(plaintext))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -566,11 +566,11 @@ func TestEncrypt(t *testing.T) {
 		}
 		header := &Header{}
 		header.SetAlgorithm(jwa.KeyManagementAlgorithmA128GCMKW)
-		header.SetCompressionAlgorithm(jwa.DEF)
+		header.SetCompressionAlgorithm(jwa.CompressionAlgorithmDEF)
 		alg := header.Algorithm().New()
 		key := alg.NewKeyWrapper(k)
 		plaintext := "Hello JWE!\n"
-		msg1, err := NewMessageWithKW(jwa.A128GCM, key, header, []byte(plaintext))
+		msg1, err := NewMessageWithKW(jwa.EncryptionAlgorithmA128GCM, key, header, []byte(plaintext))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -605,10 +605,10 @@ func TestNewMessage(t *testing.T) {
 	t.Run("jwx A128GCMKW compressed", func(t *testing.T) {
 		header := &Header{}
 		header.SetAlgorithm(jwa.KeyManagementAlgorithmA128GCMKW)
-		header.SetCompressionAlgorithm(jwa.DEF)
+		header.SetCompressionAlgorithm(jwa.CompressionAlgorithmDEF)
 		alg := header.Algorithm().New()
 		plaintext := "Hello JWE!\n"
-		msg1, err := NewMessage(jwa.A128GCM, header, []byte(plaintext))
+		msg1, err := NewMessage(jwa.EncryptionAlgorithmA128GCM, header, []byte(plaintext))
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/jwe/jwe_test.go
+++ b/jwe/jwe_test.go
@@ -325,7 +325,7 @@ func TestEncrypt(t *testing.T) {
 		}
 
 		header := &Header{}
-		header.SetAlgorithm(jwa.RSA_OAEP)
+		header.SetAlgorithm(jwa.KeyManagementAlgorithmRSA_OAEP)
 		alg := header.Algorithm().New()
 		key := alg.NewKeyWrapper(k)
 
@@ -391,11 +391,11 @@ func TestEncrypt(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		alg := jwa.RSA1_5.New()
+		alg := jwa.KeyManagementAlgorithmRSA1_5.New()
 		key := alg.NewKeyWrapper(k)
 
 		header := &Header{}
-		header.SetAlgorithm(jwa.RSA1_5)
+		header.SetAlgorithm(jwa.KeyManagementAlgorithmRSA1_5)
 		plaintext := "Live long and prosper."
 		msg1, err := NewMessageWithKW(jwa.A128CBC_HS256, key, header, []byte(plaintext))
 		if err != nil {
@@ -431,11 +431,11 @@ func TestEncrypt(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		alg := jwa.A128KW.New()
+		alg := jwa.KeyManagementAlgorithmA128KW.New()
 		key := alg.NewKeyWrapper(k)
 
 		header := &Header{}
-		header.SetAlgorithm(jwa.A128KW)
+		header.SetAlgorithm(jwa.KeyManagementAlgorithmA128KW)
 		plaintext := "Live long and prosper."
 		msg1, err := NewMessageWithKW(jwa.A128CBC_HS256, key, header, []byte(plaintext))
 		if err != nil {
@@ -477,7 +477,7 @@ func TestEncrypt(t *testing.T) {
 			t.Fatal(err)
 		}
 		header := &Header{}
-		header.SetAlgorithm(jwa.A128GCMKW)
+		header.SetAlgorithm(jwa.KeyManagementAlgorithmA128GCMKW)
 		alg := header.Algorithm().New()
 		key := alg.NewKeyWrapper(k)
 		plaintext := "Hello JWE!\n"
@@ -521,7 +521,7 @@ func TestEncrypt(t *testing.T) {
 			t.Fatal(err)
 		}
 		header := &Header{}
-		header.SetAlgorithm(jwa.PBES2_HS256_A128KW)
+		header.SetAlgorithm(jwa.KeyManagementAlgorithmPBES2_HS256_A128KW)
 		alg := header.Algorithm().New()
 		key := alg.NewKeyWrapper(k)
 		plaintext := "Hello World!\n"
@@ -565,7 +565,7 @@ func TestEncrypt(t *testing.T) {
 			t.Fatal(err)
 		}
 		header := &Header{}
-		header.SetAlgorithm(jwa.A128GCMKW)
+		header.SetAlgorithm(jwa.KeyManagementAlgorithmA128GCMKW)
 		header.SetCompressionAlgorithm(jwa.DEF)
 		alg := header.Algorithm().New()
 		key := alg.NewKeyWrapper(k)
@@ -604,7 +604,7 @@ func TestNewMessage(t *testing.T) {
 	// $ jwx jwe encrypt --key oct.json --compress --key-encryption A128GCMKW --content-encryption A128GCM --output - input.txt
 	t.Run("jwx A128GCMKW compressed", func(t *testing.T) {
 		header := &Header{}
-		header.SetAlgorithm(jwa.A128GCMKW)
+		header.SetAlgorithm(jwa.KeyManagementAlgorithmA128GCMKW)
 		header.SetCompressionAlgorithm(jwa.DEF)
 		alg := header.Algorithm().New()
 		plaintext := "Hello JWE!\n"

--- a/jwk/ecdsa.go
+++ b/jwk/ecdsa.go
@@ -16,13 +16,13 @@ func parseEcdsaKey(d *jsonutils.Decoder, key *Key) {
 	var curve elliptic.Curve
 	crv := jwa.EllipticCurve(d.MustString("crv"))
 	switch crv {
-	case jwa.P256:
+	case jwa.EllipticCurveP256:
 		curve = elliptic.P256()
-	case jwa.P384:
+	case jwa.EllipticCurveP384:
 		curve = elliptic.P384()
-	case jwa.P521:
+	case jwa.EllipticCurveP521:
 		curve = elliptic.P521()
-	case jwa.Secp256k1:
+	case jwa.EllipticCurveSecp256k1:
 		curve = secp256k1.Curve()
 	default:
 		d.SaveError(fmt.Errorf("jwk: unknown crv: %q", crv))
@@ -74,16 +74,16 @@ func encodeEcdsaKey(e *jsonutils.Encoder, priv *ecdsa.PrivateKey, pub *ecdsa.Pub
 		e.SaveError(err)
 		return
 	}
-	e.Set("kty", jwa.EC.String())
+	e.Set("kty", jwa.KeyTypeEC.String())
 	switch pub.Curve {
 	case elliptic.P256():
-		e.Set("crv", jwa.P256.String())
+		e.Set("crv", jwa.EllipticCurveP256.String())
 	case elliptic.P384():
-		e.Set("crv", jwa.P384.String())
+		e.Set("crv", jwa.EllipticCurveP384.String())
 	case elliptic.P521():
-		e.Set("crv", jwa.P521.String())
+		e.Set("crv", jwa.EllipticCurveP521.String())
 	case secp256k1.Curve():
-		e.Set("crv", jwa.Secp256k1.String())
+		e.Set("crv", jwa.EllipticCurveSecp256k1.String())
 	default:
 		panic("not reach")
 	}

--- a/jwk/ecdsa_test.go
+++ b/jwk/ecdsa_test.go
@@ -20,7 +20,7 @@ func TestParseKey_ecdsa(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if want, got := key.kty, jwa.EC; want != got {
+		if want, got := key.kty, jwa.KeyTypeEC; want != got {
 			t.Errorf("unexpected key type: want %s, got %s", want, got)
 		}
 		x := newBigInt("57807358241436249728379122087876380298924820027722995515715270765240753673285")
@@ -59,7 +59,7 @@ func TestParseKey_ecdsa(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if want, got := key.kty, jwa.EC; want != got {
+		if want, got := key.kty, jwa.KeyTypeEC; want != got {
 			t.Errorf("unexpected key type: want %s, got %s", want, got)
 		}
 		x := newBigInt("6558566456959953544109522959384633002634366184193672267866407124696200040032063394775499664830638630438428532794662648623689740875293641365317574204038644132")
@@ -94,7 +94,7 @@ func TestParseKey_ecdsa(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if want, got := key.kty, jwa.EC; want != got {
+		if want, got := key.kty, jwa.KeyTypeEC; want != got {
 			t.Errorf("unexpected key type: want %s, got %s", want, got)
 		}
 		x := newBigInt("21994169848703329112137818087919262246467304847122821377551355163096090930238")
@@ -122,7 +122,7 @@ func TestParseKey_ecdsa(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if want, got := key.kty, jwa.EC; want != got {
+		if want, got := key.kty, jwa.KeyTypeEC; want != got {
 			t.Errorf("unexpected key type: want %s, got %s", want, got)
 		}
 		x := newBigInt("21994169848703329112137818087919262246467304847122821377551355163096090930238")
@@ -280,7 +280,7 @@ func TestMarshalKey_ecdsa(t *testing.T) {
 		x := newBigInt("21994169848703329112137818087919262246467304847122821377551355163096090930238")
 		y := newBigInt("101451294974385619524093058399734017814808930032421185206609461750712400090915")
 		key := &Key{
-			kty: jwa.EC,
+			kty: jwa.KeyTypeEC,
 			kid: "1",
 			use: "enc",
 			pub: &ecdsa.PublicKey{

--- a/jwk/ed25519.go
+++ b/jwk/ed25519.go
@@ -44,8 +44,8 @@ func parseEd25519Key(d *jsonutils.Decoder, key *Key) {
 }
 
 func encodeEd25519Key(e *jsonutils.Encoder, priv ed25519.PrivateKey, pub ed25519.PublicKey) {
-	e.Set("kty", jwa.OKP.String())
-	e.Set("crv", jwa.Ed25519.String())
+	e.Set("kty", jwa.KeyTypeOKP.String())
+	e.Set("crv", jwa.EllipticCurveEd25519.String())
 	e.SetBytes("x", []byte(pub))
 	if priv != nil {
 		e.SetBytes("d", []byte(priv[:ed25519.SeedSize]))

--- a/jwk/ed25519_test.go
+++ b/jwk/ed25519_test.go
@@ -16,7 +16,7 @@ func TestParseKey_Ed25519(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if key.kty != jwa.OKP {
+		if key.kty != jwa.KeyTypeOKP {
 			t.Errorf("unexpected key type: want %s, got %s", "OKP", key.kty)
 		}
 
@@ -46,7 +46,7 @@ func TestParseKey_Ed25519(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if key.kty != jwa.OKP {
+		if key.kty != jwa.KeyTypeOKP {
 			t.Errorf("unexpected key type: want %s, got %s", "OKP", key.kty)
 		}
 

--- a/jwk/ed448.go
+++ b/jwk/ed448.go
@@ -44,8 +44,8 @@ func parseEd448Key(d *jsonutils.Decoder, key *Key) {
 }
 
 func encodeEd448Key(e *jsonutils.Encoder, priv ed448.PrivateKey, pub ed448.PublicKey) {
-	e.Set("kty", jwa.OKP.String())
-	e.Set("crv", jwa.Ed448.String())
+	e.Set("kty", jwa.KeyTypeOKP.String())
+	e.Set("crv", jwa.EllipticCurveEd448.String())
 	e.SetBytes("x", []byte(pub))
 	if priv != nil {
 		e.SetBytes("d", []byte(priv[:ed448.SeedSize]))

--- a/jwk/jwk.go
+++ b/jwk/jwk.go
@@ -407,13 +407,13 @@ func ParseMap(raw map[string]any) (*Key, error) {
 	}
 
 	switch key.kty {
-	case jwa.EC:
+	case jwa.KeyTypeEC:
 		parseEcdsaKey(d, key)
-	case jwa.RSA:
+	case jwa.KeyTypeRSA:
 		parseRSAKey(d, key)
-	case jwa.OKP:
+	case jwa.KeyTypeOKP:
 		parseOKPKey(d, key)
-	case jwa.Oct:
+	case jwa.KeyTypeOct:
 		parseSymmetricKey(d, key)
 	default:
 		return nil, fmt.Errorf("jwk: unknown key type: %q", key.kty)
@@ -517,7 +517,7 @@ func NewPrivateKey(key crypto.PrivateKey) (*Key, error) {
 			return nil, err
 		}
 		return &Key{
-			kty:  jwa.EC,
+			kty:  jwa.KeyTypeEC,
 			priv: key,
 			pub:  key.Public(),
 		}, nil
@@ -526,7 +526,7 @@ func NewPrivateKey(key crypto.PrivateKey) (*Key, error) {
 			return nil, err
 		}
 		return &Key{
-			kty:  jwa.RSA,
+			kty:  jwa.KeyTypeRSA,
 			priv: key,
 			pub:  key.Public(),
 		}, nil
@@ -535,7 +535,7 @@ func NewPrivateKey(key crypto.PrivateKey) (*Key, error) {
 			return nil, err
 		}
 		return &Key{
-			kty:  jwa.OKP,
+			kty:  jwa.KeyTypeOKP,
 			priv: key,
 			pub:  key.Public(),
 		}, nil
@@ -543,7 +543,7 @@ func NewPrivateKey(key crypto.PrivateKey) (*Key, error) {
 		switch key.Curve() {
 		case ecdh.P256(), ecdh.P384(), ecdh.P521():
 			return &Key{
-				kty: jwa.EC,
+				kty: jwa.KeyTypeEC,
 				keyOps: []jwktypes.KeyOp{
 					jwktypes.KeyOpDeriveKey,
 					jwktypes.KeyOpDeriveBits,
@@ -553,7 +553,7 @@ func NewPrivateKey(key crypto.PrivateKey) (*Key, error) {
 			}, nil
 		case ecdh.X25519():
 			return &Key{
-				kty: jwa.OKP,
+				kty: jwa.KeyTypeOKP,
 				keyOps: []jwktypes.KeyOp{
 					jwktypes.KeyOpDeriveKey,
 					jwktypes.KeyOpDeriveBits,
@@ -569,7 +569,7 @@ func NewPrivateKey(key crypto.PrivateKey) (*Key, error) {
 			return nil, err
 		}
 		return &Key{
-			kty:  jwa.OKP,
+			kty:  jwa.KeyTypeOKP,
 			priv: key,
 			pub:  key.Public(),
 		}, nil
@@ -578,7 +578,7 @@ func NewPrivateKey(key crypto.PrivateKey) (*Key, error) {
 			return nil, err
 		}
 		return &Key{
-			kty:  jwa.OKP,
+			kty:  jwa.KeyTypeOKP,
 			priv: key,
 			pub:  key.Public(),
 		}, nil
@@ -587,13 +587,13 @@ func NewPrivateKey(key crypto.PrivateKey) (*Key, error) {
 			return nil, err
 		}
 		return &Key{
-			kty:  jwa.OKP,
+			kty:  jwa.KeyTypeOKP,
 			priv: key,
 			pub:  key.Public(),
 		}, nil
 	case []byte:
 		return &Key{
-			kty:  jwa.Oct,
+			kty:  jwa.KeyTypeOct,
 			priv: append([]byte(nil), key...),
 		}, nil
 	default:
@@ -612,7 +612,7 @@ func NewPublicKey(key crypto.PublicKey) (*Key, error) {
 			return nil, err
 		}
 		return &Key{
-			kty: jwa.EC,
+			kty: jwa.KeyTypeEC,
 			pub: key,
 		}, nil
 	case *rsa.PublicKey:
@@ -620,7 +620,7 @@ func NewPublicKey(key crypto.PublicKey) (*Key, error) {
 			return nil, err
 		}
 		return &Key{
-			kty: jwa.RSA,
+			kty: jwa.KeyTypeRSA,
 			pub: key,
 		}, nil
 	case ed25519.PublicKey:
@@ -628,20 +628,20 @@ func NewPublicKey(key crypto.PublicKey) (*Key, error) {
 			return nil, err
 		}
 		return &Key{
-			kty: jwa.OKP,
+			kty: jwa.KeyTypeOKP,
 			pub: key,
 		}, nil
 	case *ecdh.PublicKey:
 		switch key.Curve() {
 		case ecdh.P256(), ecdh.P384(), ecdh.P521():
 			return &Key{
-				kty:    jwa.EC,
+				kty:    jwa.KeyTypeEC,
 				keyOps: []jwktypes.KeyOp{jwktypes.KeyOpDeriveBits},
 				pub:    key,
 			}, nil
 		case ecdh.X25519():
 			return &Key{
-				kty:    jwa.OKP,
+				kty:    jwa.KeyTypeOKP,
 				keyOps: []jwktypes.KeyOp{jwktypes.KeyOpDeriveBits},
 				pub:    key,
 			}, nil
@@ -653,7 +653,7 @@ func NewPublicKey(key crypto.PublicKey) (*Key, error) {
 			return nil, err
 		}
 		return &Key{
-			kty: jwa.OKP,
+			kty: jwa.KeyTypeOKP,
 			pub: key,
 		}, nil
 	case ed448.PublicKey:
@@ -661,7 +661,7 @@ func NewPublicKey(key crypto.PublicKey) (*Key, error) {
 			return nil, err
 		}
 		return &Key{
-			kty: jwa.OKP,
+			kty: jwa.KeyTypeOKP,
 			pub: key,
 		}, nil
 	case x448.PublicKey:
@@ -669,7 +669,7 @@ func NewPublicKey(key crypto.PublicKey) (*Key, error) {
 			return nil, err
 		}
 		return &Key{
-			kty: jwa.OKP,
+			kty: jwa.KeyTypeOKP,
 			pub: key,
 		}, nil
 	default:
@@ -680,26 +680,26 @@ func NewPublicKey(key crypto.PublicKey) (*Key, error) {
 func encodeECDHKey(e *jsonutils.Encoder, priv *ecdhPrivateKey, pub *ecdhPublicKey) {
 	switch pub.Curve() {
 	case ecdh.P256():
-		e.Set("kty", jwa.EC.String())
-		e.Set("crv", jwa.P256.String())
+		e.Set("kty", jwa.KeyTypeEC.String())
+		e.Set("crv", jwa.EllipticCurveP256.String())
 		data := pub.Bytes()
 		e.SetBytes("x", data[1:32+1])
 		e.SetBytes("y", data[32+1:])
 	case ecdh.P384():
-		e.Set("kty", jwa.EC.String())
-		e.Set("crv", jwa.P384.String())
+		e.Set("kty", jwa.KeyTypeEC.String())
+		e.Set("crv", jwa.EllipticCurveP384.String())
 		data := pub.Bytes()
 		e.SetBytes("x", data[1:48+1])
 		e.SetBytes("y", data[48+1:])
 	case ecdh.P521():
-		e.Set("kty", jwa.EC.String())
-		e.Set("crv", jwa.P521.String())
+		e.Set("kty", jwa.KeyTypeEC.String())
+		e.Set("crv", jwa.EllipticCurveP521.String())
 		data := pub.Bytes()
 		e.SetBytes("x", data[1:66+1])
 		e.SetBytes("y", data[66+1:])
 	case ecdh.X25519():
-		e.Set("kty", jwa.OKP)
-		e.Set("crv", jwa.Ed25519.String())
+		e.Set("kty", jwa.KeyTypeOKP)
+		e.Set("crv", jwa.EllipticCurveEd25519.String())
 		e.SetBytes("x", pub.Bytes())
 	}
 

--- a/jwk/jwk.go
+++ b/jwk/jwk.go
@@ -699,7 +699,7 @@ func encodeECDHKey(e *jsonutils.Encoder, priv *ecdhPrivateKey, pub *ecdhPublicKe
 		e.SetBytes("y", data[66+1:])
 	case ecdh.X25519():
 		e.Set("kty", jwa.KeyTypeOKP)
-		e.Set("crv", jwa.EllipticCurveEd25519.String())
+		e.Set("crv", jwa.EllipticCurveX25519.String())
 		e.SetBytes("x", pub.Bytes())
 	}
 

--- a/jwk/jwk_test.go
+++ b/jwk/jwk_test.go
@@ -391,8 +391,8 @@ func TestNewPrivateKey_ECDH(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if key.kty != jwa.OKP {
-			t.Errorf("unexpected type type: got %s, want %s", key.kty, jwa.OKP)
+		if key.kty != jwa.KeyTypeOKP {
+			t.Errorf("unexpected type type: got %s, want %s", key.kty, jwa.KeyTypeOKP)
 		}
 		if _, err := key.MarshalJSON(); err != nil {
 			t.Fatal(err)
@@ -439,8 +439,8 @@ func TestNewPublicKey_ECDH(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if key.kty != jwa.OKP {
-			t.Errorf("unexpected type type: got %s, want %s", key.kty, jwa.OKP)
+		if key.kty != jwa.KeyTypeOKP {
+			t.Errorf("unexpected type type: got %s, want %s", key.kty, jwa.KeyTypeOKP)
 		}
 		if _, err := key.MarshalJSON(); err != nil {
 			t.Fatal(err)

--- a/jwk/okp.go
+++ b/jwk/okp.go
@@ -11,13 +11,13 @@ import (
 func parseOKPKey(d *jsonutils.Decoder, key *Key) {
 	crv := jwa.EllipticCurve(d.MustString("crv"))
 	switch crv {
-	case jwa.Ed25519:
+	case jwa.EllipticCurveEd25519:
 		parseEd25519Key(d, key)
-	case jwa.X25519:
+	case jwa.EllipticCurveX25519:
 		parseX25519Key(d, key)
-	case jwa.Ed448:
+	case jwa.EllipticCurveEd448:
 		parseEd448Key(d, key)
-	case jwa.X448:
+	case jwa.EllipticCurveX448:
 		parseX448Key(d, key)
 	default:
 		d.SaveError(fmt.Errorf("jwk: unknown crv: %q", crv))

--- a/jwk/rfc7520_test.go
+++ b/jwk/rfc7520_test.go
@@ -50,7 +50,7 @@ func TestRFC7520(t *testing.T) {
 			t.Fatal(err)
 		}
 		if key.KeyType() != jwa.KeyTypeRSA {
-			t.Errorf("unexpected key type: want %s, got %s", jwa.KeyTypeEC, key.KeyType())
+			t.Errorf("unexpected key type: want %s, got %s", jwa.KeyTypeRSA, key.KeyType())
 		}
 		if key.PublicKeyUse() != jwktypes.KeyUseSig {
 			t.Errorf("unexpected key use: want %s, got %s", jwktypes.KeyUseSig, key.PublicKeyUse())
@@ -67,7 +67,7 @@ func TestRFC7520(t *testing.T) {
 			t.Fatal(err)
 		}
 		if key.KeyType() != jwa.KeyTypeRSA {
-			t.Errorf("unexpected key type: want %s, got %s", jwa.KeyTypeEC, key.KeyType())
+			t.Errorf("unexpected key type: want %s, got %s", jwa.KeyTypeRSA, key.KeyType())
 		}
 		if key.PublicKeyUse() != jwktypes.KeyUseSig {
 			t.Errorf("unexpected key use: want %s, got %s", jwktypes.KeyUseSig, key.PublicKeyUse())
@@ -84,7 +84,7 @@ func TestRFC7520(t *testing.T) {
 			t.Fatal(err)
 		}
 		if key.KeyType() != jwa.KeyTypeOct {
-			t.Errorf("unexpected key type: want %s, got %s", jwa.KeyTypeEC, key.KeyType())
+			t.Errorf("unexpected key type: want %s, got %s", jwa.KeyTypeOct, key.KeyType())
 		}
 		if key.PublicKeyUse() != jwktypes.KeyUseSig {
 			t.Errorf("unexpected key use: want %s, got %s", jwktypes.KeyUseSig, key.PublicKeyUse())
@@ -101,7 +101,7 @@ func TestRFC7520(t *testing.T) {
 			t.Fatal(err)
 		}
 		if key.KeyType() != jwa.KeyTypeOct {
-			t.Errorf("unexpected key type: want %s, got %s", jwa.KeyTypeEC, key.KeyType())
+			t.Errorf("unexpected key type: want %s, got %s", jwa.KeyTypeOct, key.KeyType())
 		}
 		if key.PublicKeyUse() != jwktypes.KeyUseEnc {
 			t.Errorf("unexpected key use: want %s, got %s", jwktypes.KeyUseEnc, key.PublicKeyUse())

--- a/jwk/rfc7520_test.go
+++ b/jwk/rfc7520_test.go
@@ -18,8 +18,8 @@ func TestRFC7520(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if key.KeyType() != jwa.EC {
-			t.Errorf("unexpected key type: want %s, got %s", jwa.EC, key.KeyType())
+		if key.KeyType() != jwa.KeyTypeEC {
+			t.Errorf("unexpected key type: want %s, got %s", jwa.KeyTypeEC, key.KeyType())
 		}
 	})
 
@@ -32,8 +32,8 @@ func TestRFC7520(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if key.KeyType() != jwa.EC {
-			t.Errorf("unexpected key type: want %s, got %s", jwa.EC, key.KeyType())
+		if key.KeyType() != jwa.KeyTypeEC {
+			t.Errorf("unexpected key type: want %s, got %s", jwa.KeyTypeEC, key.KeyType())
 		}
 		if key.PublicKeyUse() != jwktypes.KeyUseSig {
 			t.Errorf("unexpected key use: want %s, got %s", jwktypes.KeyUseSig, key.PublicKeyUse())
@@ -49,8 +49,8 @@ func TestRFC7520(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if key.KeyType() != jwa.RSA {
-			t.Errorf("unexpected key type: want %s, got %s", jwa.EC, key.KeyType())
+		if key.KeyType() != jwa.KeyTypeRSA {
+			t.Errorf("unexpected key type: want %s, got %s", jwa.KeyTypeEC, key.KeyType())
 		}
 		if key.PublicKeyUse() != jwktypes.KeyUseSig {
 			t.Errorf("unexpected key use: want %s, got %s", jwktypes.KeyUseSig, key.PublicKeyUse())
@@ -66,8 +66,8 @@ func TestRFC7520(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if key.KeyType() != jwa.RSA {
-			t.Errorf("unexpected key type: want %s, got %s", jwa.EC, key.KeyType())
+		if key.KeyType() != jwa.KeyTypeRSA {
+			t.Errorf("unexpected key type: want %s, got %s", jwa.KeyTypeEC, key.KeyType())
 		}
 		if key.PublicKeyUse() != jwktypes.KeyUseSig {
 			t.Errorf("unexpected key use: want %s, got %s", jwktypes.KeyUseSig, key.PublicKeyUse())
@@ -83,8 +83,8 @@ func TestRFC7520(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if key.KeyType() != jwa.Oct {
-			t.Errorf("unexpected key type: want %s, got %s", jwa.EC, key.KeyType())
+		if key.KeyType() != jwa.KeyTypeOct {
+			t.Errorf("unexpected key type: want %s, got %s", jwa.KeyTypeEC, key.KeyType())
 		}
 		if key.PublicKeyUse() != jwktypes.KeyUseSig {
 			t.Errorf("unexpected key use: want %s, got %s", jwktypes.KeyUseSig, key.PublicKeyUse())
@@ -100,8 +100,8 @@ func TestRFC7520(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if key.KeyType() != jwa.Oct {
-			t.Errorf("unexpected key type: want %s, got %s", jwa.EC, key.KeyType())
+		if key.KeyType() != jwa.KeyTypeOct {
+			t.Errorf("unexpected key type: want %s, got %s", jwa.KeyTypeEC, key.KeyType())
 		}
 		if key.PublicKeyUse() != jwktypes.KeyUseEnc {
 			t.Errorf("unexpected key use: want %s, got %s", jwktypes.KeyUseEnc, key.PublicKeyUse())

--- a/jwk/rsa.go
+++ b/jwk/rsa.go
@@ -110,7 +110,7 @@ func parseRSAOthParam(d *jsonutils.Decoder, i int, v map[string]any, name string
 }
 
 func encodeRSAKey(e *jsonutils.Encoder, priv *rsa.PrivateKey, pub *rsa.PublicKey) {
-	e.Set("kty", jwa.RSA.String())
+	e.Set("kty", jwa.KeyTypeRSA.String())
 
 	if err := validateRSAPublicKey(pub); err != nil {
 		e.SaveError(err)

--- a/jwk/rsa_test.go
+++ b/jwk/rsa_test.go
@@ -106,7 +106,7 @@ func TestParseKey_RSA(t *testing.T) {
 		if want, got := jwa.RSA, key.kty; want != got {
 			t.Errorf("unexpected key type: want %s, got %s", want, got)
 		}
-		if want, got := key.alg, jwa.RS256.KeyAlgorithm(); want != got {
+		if want, got := key.alg, jwa.SignatureAlgorithmRS256.KeyAlgorithm(); want != got {
 			t.Errorf("unexpected algorithm: want %s, got %s", want, got)
 		}
 		n := newBigInt("2663454760017700891236544146403688261110463413643058169610263946307526643621694631605384564230016632" +
@@ -164,7 +164,7 @@ func TestParseKey_RSA(t *testing.T) {
 		if want, got := jwa.RSA, key.kty; want != got {
 			t.Errorf("unexpected key type: want %s, got %s", want, got)
 		}
-		if want, got := jwa.RS256.KeyAlgorithm(), key.alg; want != got {
+		if want, got := jwa.SignatureAlgorithmRS256.KeyAlgorithm(), key.alg; want != got {
 			t.Errorf("unexpected algorithm: want %s, got %s", want, got)
 		}
 		n := newBigInt("2663454760017700891236544146403688261110463413643058169610263946307526643621694631605384564230016632" +
@@ -375,7 +375,7 @@ func TestMarshalKey_RSA(t *testing.T) {
 			"06204439131004744574928756316166854835432256022350994699082769165462796818216782639701536883643596535"+
 			"4956581554819", 10)
 		key := &Key{
-			alg: jwa.RS256.KeyAlgorithm(),
+			alg: jwa.SignatureAlgorithmRS256.KeyAlgorithm(),
 			kid: "2011-04-29",
 		}
 		key.SetPublicKey(&rsa.PublicKey{
@@ -438,7 +438,7 @@ func TestMarshalKey_RSA(t *testing.T) {
 		}
 		privateKey.Precompute()
 		key := &Key{
-			alg: jwa.RS256.KeyAlgorithm(),
+			alg: jwa.SignatureAlgorithmRS256.KeyAlgorithm(),
 			kid: "2011-04-29",
 		}
 		key.SetPrivateKey(privateKey)

--- a/jwk/rsa_test.go
+++ b/jwk/rsa_test.go
@@ -44,7 +44,7 @@ func TestParseKey_RSA(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if want, got := jwa.RSA, key.kty; want != got {
+		if want, got := jwa.KeyTypeRSA, key.kty; want != got {
 			t.Errorf("unexpected key type: want %s, got %s", want, got)
 		}
 		n := newBigInt("2044670291674465456259634338875880586006520963996017350503745333127027051873224508977372301204320323" +
@@ -103,7 +103,7 @@ func TestParseKey_RSA(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if want, got := jwa.RSA, key.kty; want != got {
+		if want, got := jwa.KeyTypeRSA, key.kty; want != got {
 			t.Errorf("unexpected key type: want %s, got %s", want, got)
 		}
 		if want, got := key.alg, jwa.SignatureAlgorithmRS256.KeyAlgorithm(); want != got {
@@ -161,7 +161,7 @@ func TestParseKey_RSA(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if want, got := jwa.RSA, key.kty; want != got {
+		if want, got := jwa.KeyTypeRSA, key.kty; want != got {
 			t.Errorf("unexpected key type: want %s, got %s", want, got)
 		}
 		if want, got := jwa.SignatureAlgorithmRS256.KeyAlgorithm(), key.alg; want != got {

--- a/jwk/symmetric.go
+++ b/jwk/symmetric.go
@@ -11,6 +11,6 @@ func parseSymmetricKey(d *jsonutils.Decoder, key *Key) {
 }
 
 func encodeSymmetricKey(e *jsonutils.Encoder, priv []byte) {
-	e.Set("kty", jwa.Oct.String())
+	e.Set("kty", jwa.KeyTypeOct.String())
 	e.SetBytes("k", priv)
 }

--- a/jwk/symmetric_test.go
+++ b/jwk/symmetric_test.go
@@ -17,7 +17,7 @@ func TestParseKey_Symmetric(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if key.kty != jwa.Oct {
+		if key.kty != jwa.KeyTypeOct {
 			t.Errorf("unexpected key type: want %s, got %s", "oct", key.kty)
 		}
 		got, ok := key.PrivateKey().([]byte)
@@ -45,7 +45,7 @@ func TestParseKey_Symmetric(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if key.kty != jwa.Oct {
+		if key.kty != jwa.KeyTypeOct {
 			t.Errorf("unexpected key type: want %s, got %s", "oct", key.kty)
 		}
 		if key.alg != "A128KW" {
@@ -70,7 +70,7 @@ func TestParseKey_Symmetric(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if key.kty != jwa.Oct {
+		if key.kty != jwa.KeyTypeOct {
 			t.Errorf("unexpected key type: want %s, got %s", "oct", key.kty)
 		}
 		got, ok := key.PrivateKey().([]byte)

--- a/jwk/symmetric_test.go
+++ b/jwk/symmetric_test.go
@@ -140,7 +140,7 @@ func TestParseKey_Symmetric_Invalid(t *testing.T) {
 func TestMarshalKey_symmetric(t *testing.T) {
 	t.Run("RFC 7517 A.3. Example Symmetric Keys (A128KW)", func(t *testing.T) {
 		key := &Key{
-			alg: jwa.A128KW.KeyAlgorithm(),
+			alg: jwa.KeyManagementAlgorithmA128KW.KeyAlgorithm(),
 			priv: []byte{
 				0x19, 0xac, 0x20, 0x82, 0xe1, 0x72, 0x1a, 0xb5,
 				0x8a, 0x6a, 0xfe, 0xc0, 0x5f, 0x85, 0x4a, 0x52,

--- a/jwk/x25519.go
+++ b/jwk/x25519.go
@@ -43,8 +43,8 @@ func encodeX25519Key(e *jsonutils.Encoder, priv x25519.PrivateKey, pub x25519.Pu
 		e.SaveError(err)
 		return
 	}
-	e.Set("kty", jwa.OKP.String())
-	e.Set("crv", jwa.X25519.String())
+	e.Set("kty", jwa.KeyTypeOKP.String())
+	e.Set("crv", jwa.EllipticCurveX25519.String())
 	e.SetBytes("x", []byte(pub))
 	if priv != nil {
 		if err := validateX25519PrivateKey(priv); err != nil {

--- a/jwk/x25519_test.go
+++ b/jwk/x25519_test.go
@@ -15,7 +15,7 @@ func TestParse_X25519(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if key.kty != jwa.OKP {
+		if key.kty != jwa.KeyTypeOKP {
 			t.Errorf("unexpected key type: want %s, got %s", "OKP", key.kty)
 		}
 

--- a/jwk/x448.go
+++ b/jwk/x448.go
@@ -43,8 +43,8 @@ func encodeX448Key(e *jsonutils.Encoder, priv x448.PrivateKey, pub x448.PublicKe
 		e.SaveError(err)
 		return
 	}
-	e.Set("kty", jwa.OKP.String())
-	e.Set("crv", jwa.X448.String())
+	e.Set("kty", jwa.KeyTypeOKP.String())
+	e.Set("crv", jwa.EllipticCurveX448.String())
 	e.SetBytes("x", []byte(pub))
 	if priv != nil {
 		if err := validateX448PrivateKey(priv); err != nil {

--- a/jwk/x448_test.go
+++ b/jwk/x448_test.go
@@ -16,7 +16,7 @@ func TestParse_X448(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if key.kty != jwa.OKP {
+		if key.kty != jwa.KeyTypeOKP {
 			t.Errorf("unexpected key type: want %s, got %s", "OKP", key.kty)
 		}
 

--- a/jws/example_test.go
+++ b/jws/example_test.go
@@ -18,7 +18,7 @@ func ExampleParseCompact() {
 		log.Fatal(err)
 	}
 	v := &jws.Verifier{
-		AlgorithmVerifier: jws.AllowedAlgorithms{jwa.EdDSA},
+		AlgorithmVerifier: jws.AllowedAlgorithms{jwa.SignatureAlgorithmEdDSA},
 		KeyFinder:         &jws.JWKKeyFinder{JWK: key},
 	}
 
@@ -51,7 +51,7 @@ func ExampleVerifier_Verify() {
 		log.Fatal(err)
 	}
 	v := &jws.Verifier{
-		AlgorithmVerifier: jws.AllowedAlgorithms{jwa.EdDSA},
+		AlgorithmVerifier: jws.AllowedAlgorithms{jwa.SignatureAlgorithmEdDSA},
 		KeyFinder:         &jws.JWKKeyFinder{JWK: key},
 	}
 
@@ -85,9 +85,9 @@ func ExampleMessage_Compact() {
 		log.Fatal(err)
 	}
 	header := jws.NewHeader()
-	header.SetAlgorithm(jwa.EdDSA)
+	header.SetAlgorithm(jwa.SignatureAlgorithmEdDSA)
 	msg := jws.NewMessage([]byte("Example of Ed25519 signing"))
-	if err := msg.Sign(header, nil, jwa.EdDSA.New().NewSigningKey(key)); err != nil {
+	if err := msg.Sign(header, nil, jwa.SignatureAlgorithmEdDSA.New().NewSigningKey(key)); err != nil {
 		log.Fatal(err)
 	}
 

--- a/jws/jws_test.go
+++ b/jws/jws_test.go
@@ -247,7 +247,7 @@ func TestVerify(t *testing.T) {
 			t.Fatal(err)
 		}
 		v := &Verifier{
-			AlgorithmVerifier: AllowedAlgorithms{jwa.None},
+			AlgorithmVerifier: AllowedAlgorithms{jwa.SignatureAlgorithmNone},
 			KeyFinder: FindKeyFunc(func(ctx context.Context, header, _ *Header) (sig.SigningKey, error) {
 				return header.Algorithm().New().NewSigningKey(nil), nil
 			}),
@@ -258,7 +258,7 @@ func TestVerify(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if want, got := header.Algorithm(), jwa.None; want != got {
+		if want, got := header.Algorithm(), jwa.SignatureAlgorithmNone; want != got {
 			t.Errorf("unexpected algorithm: want %s, got %s", want, got)
 		}
 
@@ -764,12 +764,12 @@ func TestSign(t *testing.T) {
 
 	t.Run("RFC 7515 Appendix A.5 Example Unsecured JWS", func(t *testing.T) {
 		h := NewHeader()
-		h.SetAlgorithm(jwa.None)
+		h.SetAlgorithm(jwa.SignatureAlgorithmNone)
 		h.SetType("JWT")
 		payload := []byte(`{"iss":"joe",` + "\r\n" +
 			` "exp":1300819380,` + "\r\n" +
 			` "http://example.com/is_root":true}`)
-		k := jwa.None.New().NewSigningKey(nil)
+		k := jwa.SignatureAlgorithmNone.New().NewSigningKey(nil)
 		msg := NewMessage(payload)
 		if err := msg.Sign(h, nil, k); err != nil {
 			t.Fatal(err)

--- a/jws/jws_test.go
+++ b/jws/jws_test.go
@@ -36,7 +36,7 @@ func TestVerify(t *testing.T) {
 			t.Fatal(err)
 		}
 		v := &Verifier{
-			AlgorithmVerifier: AllowedAlgorithms{jwa.HS256},
+			AlgorithmVerifier: AllowedAlgorithms{jwa.SignatureAlgorithmHS256},
 			KeyFinder:         &JWKKeyFinder{JWK: key},
 		}
 
@@ -49,7 +49,7 @@ func TestVerify(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if want, got := header.Algorithm(), jwa.HS256; want != got {
+		if want, got := header.Algorithm(), jwa.SignatureAlgorithmHS256; want != got {
 			t.Errorf("unexpected algorithm: want %s, got %s", want, got)
 		}
 		if want, got := "JWT", header.Type(); want != got {
@@ -113,7 +113,7 @@ func TestVerify(t *testing.T) {
 			t.Fatal(err)
 		}
 		v := &Verifier{
-			AlgorithmVerifier: AllowedAlgorithms{jwa.RS256},
+			AlgorithmVerifier: AllowedAlgorithms{jwa.SignatureAlgorithmRS256},
 			KeyFinder:         &JWKKeyFinder{JWK: key},
 		}
 
@@ -126,7 +126,7 @@ func TestVerify(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if want, got := header.Algorithm(), jwa.RS256; want != got {
+		if want, got := header.Algorithm(), jwa.SignatureAlgorithmRS256; want != got {
 			t.Errorf("unexpected algorithm: want %s, got %s", want, got)
 		}
 
@@ -159,7 +159,7 @@ func TestVerify(t *testing.T) {
 			t.Fatal(err)
 		}
 		v := &Verifier{
-			AlgorithmVerifier: AllowedAlgorithms{jwa.ES256},
+			AlgorithmVerifier: AllowedAlgorithms{jwa.SignatureAlgorithmES256},
 			KeyFinder:         &JWKKeyFinder{JWK: key},
 		}
 
@@ -175,7 +175,7 @@ func TestVerify(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if want, got := header.Algorithm(), jwa.ES256; want != got {
+		if want, got := header.Algorithm(), jwa.SignatureAlgorithmES256; want != got {
 			t.Errorf("unexpected algorithm: want %s, got %s", want, got)
 		}
 
@@ -211,7 +211,7 @@ func TestVerify(t *testing.T) {
 			t.Fatal(err)
 		}
 		v := &Verifier{
-			AlgorithmVerifier: AllowedAlgorithms{jwa.ES512},
+			AlgorithmVerifier: AllowedAlgorithms{jwa.SignatureAlgorithmES512},
 			KeyFinder:         &JWKKeyFinder{JWK: key},
 		}
 
@@ -224,7 +224,7 @@ func TestVerify(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if want, got := header.Algorithm(), jwa.ES512; want != got {
+		if want, got := header.Algorithm(), jwa.SignatureAlgorithmES512; want != got {
 			t.Errorf("unexpected algorithm: want %s, got %s", want, got)
 		}
 
@@ -278,7 +278,7 @@ func TestVerify(t *testing.T) {
 			t.Fatal(err)
 		}
 		v := &Verifier{
-			AlgorithmVerifier: AllowedAlgorithms{jwa.EdDSA},
+			AlgorithmVerifier: AllowedAlgorithms{jwa.SignatureAlgorithmEdDSA},
 			KeyFinder:         &JWKKeyFinder{JWK: key},
 		}
 
@@ -297,7 +297,7 @@ func TestVerify(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if want, got := header.Algorithm(), jwa.EdDSA; want != got {
+		if want, got := header.Algorithm(), jwa.SignatureAlgorithmEdDSA; want != got {
 			t.Errorf("unexpected algorithm: want %s, got %s", want, got)
 		}
 
@@ -338,7 +338,7 @@ func TestUnmarshalJSON(t *testing.T) {
 		}
 
 		v := &Verifier{
-			AlgorithmVerifier: AllowedAlgorithms{jwa.RS256},
+			AlgorithmVerifier: AllowedAlgorithms{jwa.SignatureAlgorithmRS256},
 			KeyFinder: FindKeyFunc(func(_ context.Context, protected, header *Header) (sig.SigningKey, error) {
 				if header.KeyID() != "2010-12-29" {
 					return nil, errors.New("unknown key id")
@@ -392,7 +392,7 @@ func TestUnmarshalJSON(t *testing.T) {
 		}
 
 		v = &Verifier{
-			AlgorithmVerifier: AllowedAlgorithms{jwa.ES256},
+			AlgorithmVerifier: AllowedAlgorithms{jwa.SignatureAlgorithmES256},
 			KeyFinder: FindKeyFunc(func(_ context.Context, protected, header *Header) (sig.SigningKey, error) {
 				if header.KeyID() != "e9bc097a-ce51-4036-9562-d2ade882db0d" {
 					return nil, errors.New("unknown key id")
@@ -436,7 +436,7 @@ func TestUnmarshalJSON(t *testing.T) {
 			t.Fatal(err)
 		}
 		v := &Verifier{
-			AlgorithmVerifier: AllowedAlgorithms{jwa.ES256},
+			AlgorithmVerifier: AllowedAlgorithms{jwa.SignatureAlgorithmES256},
 			KeyFinder: FindKeyFunc(func(_ context.Context, protected, header *Header) (sig.SigningKey, error) {
 				if header.KeyID() != "e9bc097a-ce51-4036-9562-d2ade882db0d" {
 					return nil, errors.New("unknown key id")
@@ -481,7 +481,7 @@ func TestUnmarshalJSON(t *testing.T) {
 			t.Fatal(err)
 		}
 		v := &Verifier{
-			AlgorithmVerifier: AllowedAlgorithms{jwa.HS256},
+			AlgorithmVerifier: AllowedAlgorithms{jwa.SignatureAlgorithmHS256},
 			KeyFinder: FindKeyFunc(func(_ context.Context, protected, header *Header) (sig.SigningKey, error) {
 				rawKey := `{` +
 					`"kty":"oct",` +
@@ -513,7 +513,7 @@ func TestMarshalJSON(t *testing.T) {
 			` "http://example.com/is_root":true}`))
 
 		protected1 := NewHeader()
-		protected1.SetAlgorithm(jwa.RS256)
+		protected1.SetAlgorithm(jwa.SignatureAlgorithmRS256)
 		header1 := NewHeader()
 		header1.SetKeyID("2010-12-29")
 		rawKey1 := `{"kty":"RSA",` +
@@ -550,12 +550,12 @@ func TestMarshalJSON(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if err := msg.Sign(protected1, header1, jwa.RS256.New().NewSigningKey(key1)); err != nil {
+		if err := msg.Sign(protected1, header1, jwa.SignatureAlgorithmRS256.New().NewSigningKey(key1)); err != nil {
 			t.Fatal(err)
 		}
 
 		protected := NewHeader()
-		protected.SetAlgorithm(jwa.ES256)
+		protected.SetAlgorithm(jwa.SignatureAlgorithmES256)
 		header := NewHeader()
 		header.SetKeyID("e9bc097a-ce51-4036-9562-d2ade882db0d")
 		rawKey2 := `{"kty":"EC",` +
@@ -568,7 +568,7 @@ func TestMarshalJSON(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if err := msg.Sign(protected, header, jwa.ES256.New().NewSigningKey(key2)); err != nil {
+		if err := msg.Sign(protected, header, jwa.SignatureAlgorithmES256.New().NewSigningKey(key2)); err != nil {
 			t.Fatal(err)
 		}
 
@@ -589,7 +589,7 @@ func TestMarshalJSON(t *testing.T) {
 			` "http://example.com/is_root":true}`))
 
 		protected2 := NewHeader()
-		protected2.SetAlgorithm(jwa.ES256)
+		protected2.SetAlgorithm(jwa.SignatureAlgorithmES256)
 		header2 := NewHeader()
 		header2.SetKeyID("e9bc097a-ce51-4036-9562-d2ade882db0d")
 		rawKey2 := `{"kty":"EC",` +
@@ -602,7 +602,7 @@ func TestMarshalJSON(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if err := msg.Sign(protected2, header2, jwa.ES256.New().NewSigningKey(key2)); err != nil {
+		if err := msg.Sign(protected2, header2, jwa.SignatureAlgorithmES256.New().NewSigningKey(key2)); err != nil {
 			t.Fatal(err)
 		}
 
@@ -621,7 +621,7 @@ func TestMarshalJSON(t *testing.T) {
 	t.Run("RFC 7797 Section 4.2. Example with Header Parameters", func(t *testing.T) {
 		msg := NewRawMessage([]byte("$.02"))
 		header := NewHeader()
-		header.SetAlgorithm(jwa.HS256)
+		header.SetAlgorithm(jwa.SignatureAlgorithmHS256)
 		header.SetBase64(false)
 
 		rawKey := `{` +
@@ -634,7 +634,7 @@ func TestMarshalJSON(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if err := msg.Sign(header, nil, jwa.HS256.New().NewSigningKey(key)); err != nil {
+		if err := msg.Sign(header, nil, jwa.SignatureAlgorithmHS256.New().NewSigningKey(key)); err != nil {
 			t.Fatal(err)
 		}
 
@@ -666,9 +666,9 @@ func TestSign(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		k := jwa.HS256.New().NewSigningKey(key)
+		k := jwa.SignatureAlgorithmHS256.New().NewSigningKey(key)
 		h := NewHeader()
-		h.SetAlgorithm(jwa.HS256)
+		h.SetAlgorithm(jwa.SignatureAlgorithmHS256)
 		h.SetType("JWT")
 		payload := []byte(`{"iss":"joe",` + "\r\n" +
 			` "exp":1300819380,` + "\r\n" +
@@ -729,9 +729,9 @@ func TestSign(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		k := jwa.RS256.New().NewSigningKey(key)
+		k := jwa.SignatureAlgorithmRS256.New().NewSigningKey(key)
 		h := NewHeader()
-		h.SetAlgorithm(jwa.RS256)
+		h.SetAlgorithm(jwa.SignatureAlgorithmRS256)
 		h.SetType("JWT")
 		payload := []byte(`{"iss":"joe",` + "\r\n" +
 			` "exp":1300819380,` + "\r\n" +
@@ -800,9 +800,9 @@ func TestSign(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		k := jwa.HS256.New().NewSigningKey(key)
+		k := jwa.SignatureAlgorithmHS256.New().NewSigningKey(key)
 		h := NewHeader()
-		h.SetAlgorithm(jwa.HS256)
+		h.SetAlgorithm(jwa.SignatureAlgorithmHS256)
 		h.SetBase64(false)
 		msg := NewRawMessage([]byte("$.02"))
 		if err := msg.Sign(h, nil, k); err != nil {
@@ -850,7 +850,7 @@ func TestKeyTypeMissmatch(t *testing.T) {
 		t.Fatal(err)
 	}
 	v := &Verifier{
-		AlgorithmVerifier: AllowedAlgorithms{jwa.ES256},
+		AlgorithmVerifier: AllowedAlgorithms{jwa.SignatureAlgorithmES256},
 		KeyFinder:         &JWKKeyFinder{JWK: key},
 	}
 	msg, err := ParseCompact(raw)

--- a/jwt/example_test.go
+++ b/jwt/example_test.go
@@ -27,7 +27,7 @@ func ExampleParse() {
 		"eyJhdWQiOiJodHRwczovL2dpdGh1Yi5jb20vc2hvZ284MjE0OCIsImlzcyI6Imh0dHBzOi8vZ2l0aHViLmNvbS9zaG9nbzgyMTQ4L2dvYXQifQ." +
 		"2p0nndDnxqsA9u1unq2bLPJiJpSj0hOfCNXe1b_Dsu7LskZPj1lFxv56rptqalzYVmR8kcrMyEIrRb94gr_KBw"
 	p := &jwt.Parser{
-		AlgorithmVerifier:     jwt.AllowedAlgorithms{jwa.EdDSA},
+		AlgorithmVerifier:     jwt.AllowedAlgorithms{jwa.SignatureAlgorithmEdDSA},
 		KeyFinder:             &jwt.JWKKeyFiner{Key: key},
 		IssuerSubjectVerifier: jwt.Issuer("https://github.com/shogo82148/goat"),
 		AudienceVerifier:      jwt.Audience("https://github.com/shogo82148"),
@@ -50,11 +50,11 @@ func ExampleSign() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	signingKey := jwa.EdDSA.New().NewSigningKey(key)
+	signingKey := jwa.SignatureAlgorithmEdDSA.New().NewSigningKey(key)
 
 	// prepare the header and the claims.
 	header := jws.NewHeader()
-	header.SetAlgorithm(jwa.EdDSA)
+	header.SetAlgorithm(jwa.SignatureAlgorithmEdDSA)
 	claims := new(jwt.Claims)
 	claims.Issuer = "https://github.com/shogo82148/goat"
 	claims.Audience = []string{"https://github.com/shogo82148"}

--- a/jwt/jwt_test.go
+++ b/jwt/jwt_test.go
@@ -45,7 +45,7 @@ func TestParse(t *testing.T) {
 		}
 		p := &Parser{
 			KeyFinder:             &JWKKeyFiner{Key: key},
-			AlgorithmVerifier:     AllowedAlgorithms{jwa.HS256},
+			AlgorithmVerifier:     AllowedAlgorithms{jwa.SignatureAlgorithmHS256},
 			IssuerSubjectVerifier: Issuer("joe"),
 			AudienceVerifier:      UnsecureAnyAudience,
 		}
@@ -168,10 +168,10 @@ func TestSign(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		sigKey := jwa.HS256.New().NewSigningKey(key)
+		sigKey := jwa.SignatureAlgorithmHS256.New().NewSigningKey(key)
 
 		header := jws.NewHeader()
-		header.SetAlgorithm(jwa.HS256)
+		header.SetAlgorithm(jwa.SignatureAlgorithmHS256)
 		header.SetType("JWT")
 		claims := &Claims{
 			Issuer:         "joe",
@@ -251,7 +251,7 @@ func BenchmarkParse(b *testing.B) {
 	}
 	p := &Parser{
 		KeyFinder:             &JWKKeyFiner{Key: key},
-		AlgorithmVerifier:     AllowedAlgorithms{jwa.HS256},
+		AlgorithmVerifier:     AllowedAlgorithms{jwa.SignatureAlgorithmHS256},
 		IssuerSubjectVerifier: Issuer("joe"),
 		AudienceVerifier:      UnsecureAnyAudience,
 	}

--- a/jwt/jwt_test.go
+++ b/jwt/jwt_test.go
@@ -79,7 +79,7 @@ func TestParse(t *testing.T) {
 				alg := header.Algorithm().New()
 				return alg.NewSigningKey(nil), nil
 			}),
-			AlgorithmVerifier:     AllowedAlgorithms{jwa.None},
+			AlgorithmVerifier:     AllowedAlgorithms{jwa.SignatureAlgorithmNone},
 			IssuerSubjectVerifier: Issuer("joe"),
 			AudienceVerifier:      UnsecureAnyAudience,
 		}
@@ -109,10 +109,10 @@ func TestParse_Claims(t *testing.T) {
 
 	p := &Parser{
 		KeyFinder: FindKeyFunc(func(_ context.Context, header *jws.Header) (sig.SigningKey, error) {
-			alg := jwa.None.New()
+			alg := jwa.SignatureAlgorithmNone.New()
 			return alg.NewSigningKey(nil), nil
 		}),
-		AlgorithmVerifier:     AllowedAlgorithms{jwa.None},
+		AlgorithmVerifier:     AllowedAlgorithms{jwa.SignatureAlgorithmNone},
 		IssuerSubjectVerifier: UnsecureAnyIssuerSubject,
 		AudienceVerifier:      UnsecureAnyAudience,
 	}
@@ -199,9 +199,9 @@ func TestSign(t *testing.T) {
 	})
 
 	t.Run("RFC 7519 Section 6.1. Example Unsecured JWT", func(t *testing.T) {
-		sigKey := jwa.None.New().NewSigningKey(nil)
+		sigKey := jwa.SignatureAlgorithmNone.New().NewSigningKey(nil)
 		header := jws.NewHeader()
-		header.SetAlgorithm(jwa.None)
+		header.SetAlgorithm(jwa.SignatureAlgorithmNone)
 		header.SetType("JWT")
 		claims := &Claims{
 			Issuer:         "joe",


### PR DESCRIPTION
Since the names of the Ed25519 signature algorithm and the Ed25519 elliptic curve overlapped, we have revised the naming convention to distinguish clearly between the two.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated and renamed cryptographic algorithm, key-management, encryption, key-type and curve identifiers to explicit, namespaced canonical forms; deprecated aliases preserved for compatibility.
  * Core JWE/JWS/JWT/JWK behavior and examples updated to consistently use the new canonical identifiers.

* **Documentation**
  * Marked the eddsa package as deprecated; guidance added to use ed25519 or ed448 instead.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->