### PR TITLE
Refactor file path handling in tests to use filepath.Join

### DIFF
--- a/cose/key_test.go
+++ b/cose/key_test.go
@@ -3,13 +3,14 @@ package cose
 import (
 	"bytes"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/shogo82148/go-cbor"
 )
 
 func TestParseMap(t *testing.T) {
-	data, err := os.ReadFile("testdata/cose-wg-examples/KeySet.txt")
+	data, err := os.ReadFile(filepath.Join("testdata", "cose-wg-examples", "KeySet.txt"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/jwk/fuzz_test.go
+++ b/jwk/fuzz_test.go
@@ -2,6 +2,7 @@ package jwk
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -178,22 +179,22 @@ func FuzzJWK(f *testing.F) {
 		`"x":"3p7bfXt9wbTTW2HC7OQ1Nz-DQ8hbeGdNrfx-FG-IK08"}`)
 
 	// RFC 7520 Example JWKs
-	if data, err := os.ReadFile("testdata/rfc7520/3_1.ec_public_key.json"); err == nil {
+	if data, err := os.ReadFile(filepath.Join("testdata", "rfc7520", "3_1.ec_public_key.json")); err == nil {
 		f.Add(string(data))
 	}
-	if data, err := os.ReadFile("testdata/rfc7520/3_2.ec_private_key.json"); err == nil {
+	if data, err := os.ReadFile(filepath.Join("testdata", "rfc7520", "3_2.ec_private_key.json")); err == nil {
 		f.Add(string(data))
 	}
-	if data, err := os.ReadFile("testdata/rfc7520/3_3.rsa_public_key.json"); err == nil {
+	if data, err := os.ReadFile(filepath.Join("testdata", "rfc7520", "3_3.rsa_public_key.json")); err == nil {
 		f.Add(string(data))
 	}
-	if data, err := os.ReadFile("testdata/rfc7520/3_4.rsa_private_key.json"); err == nil {
+	if data, err := os.ReadFile(filepath.Join("testdata", "rfc7520", "3_4.rsa_private_key.json")); err == nil {
 		f.Add(string(data))
 	}
-	if data, err := os.ReadFile("testdata/rfc7520/3_5.symmetric_key_mac_computation.json"); err == nil {
+	if data, err := os.ReadFile(filepath.Join("testdata", "rfc7520", "3_5.symmetric_key_mac_computation.json")); err == nil {
 		f.Add(string(data))
 	}
-	if data, err := os.ReadFile("testdata/rfc7520/3_6.symmetric_key_encryption.json"); err == nil {
+	if data, err := os.ReadFile(filepath.Join("testdata", "rfc7520", "3_6.symmetric_key_encryption.json")); err == nil {
 		f.Add(string(data))
 	}
 

--- a/jwk/rfc7520_test.go
+++ b/jwk/rfc7520_test.go
@@ -2,6 +2,7 @@ package jwk
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/shogo82148/goat/jwa"
@@ -10,7 +11,7 @@ import (
 
 func TestRFC7520(t *testing.T) {
 	t.Run("3.1. EC Public Key", func(t *testing.T) {
-		data, err := os.ReadFile("../testdata/ietf-jose-cookbook/jwk/3_1.ec_public_key.json")
+		data, err := os.ReadFile(filepath.Join("..", "testdata", "ietf-jose-cookbook", "jwk", "3_1.ec_public_key.json"))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -24,7 +25,7 @@ func TestRFC7520(t *testing.T) {
 	})
 
 	t.Run("3.2. EC Private Key", func(t *testing.T) {
-		data, err := os.ReadFile("../testdata/ietf-jose-cookbook/jwk/3_2.ec_private_key.json")
+		data, err := os.ReadFile(filepath.Join("..", "testdata", "ietf-jose-cookbook", "jwk", "3_2.ec_private_key.json"))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -41,7 +42,7 @@ func TestRFC7520(t *testing.T) {
 	})
 
 	t.Run("3.3. RSA Public Key", func(t *testing.T) {
-		data, err := os.ReadFile("../testdata/ietf-jose-cookbook/jwk/3_3.rsa_public_key.json")
+		data, err := os.ReadFile(filepath.Join("..", "testdata", "ietf-jose-cookbook", "jwk", "3_3.rsa_public_key.json"))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -58,7 +59,7 @@ func TestRFC7520(t *testing.T) {
 	})
 
 	t.Run("3.4. RSA Private Key", func(t *testing.T) {
-		data, err := os.ReadFile("../testdata/ietf-jose-cookbook/jwk/3_4.rsa_private_key.json")
+		data, err := os.ReadFile(filepath.Join("..", "testdata", "ietf-jose-cookbook", "jwk", "3_4.rsa_private_key.json"))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -75,7 +76,7 @@ func TestRFC7520(t *testing.T) {
 	})
 
 	t.Run("3.5. Symmetric Key (MAC Computation)", func(t *testing.T) {
-		data, err := os.ReadFile("../testdata/ietf-jose-cookbook/jwk/3_5.symmetric_key_mac_computation.json")
+		data, err := os.ReadFile(filepath.Join("..", "testdata", "ietf-jose-cookbook", "jwk", "3_5.symmetric_key_mac_computation.json"))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -92,7 +93,7 @@ func TestRFC7520(t *testing.T) {
 	})
 
 	t.Run("3.6. Symmetric Key (Encryption) ", func(t *testing.T) {
-		data, err := os.ReadFile("../testdata/ietf-jose-cookbook/jwk/3_6.symmetric_key_encryption.json")
+		data, err := os.ReadFile(filepath.Join("..", "testdata", "ietf-jose-cookbook", "jwk", "3_6.symmetric_key_encryption.json"))
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/jws/rfc7520_test.go
+++ b/jws/rfc7520_test.go
@@ -42,7 +42,7 @@ type testVectorOutput struct {
 }
 
 func TestRFC7520(t *testing.T) {
-	files, err := filepath.Glob("../testdata/ietf-jose-cookbook/jws/*.json")
+	files, err := filepath.Glob(filepath.Join("..", "testdata", "ietf-jose-cookbook", "jws", "*.json"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/oidc/config_test.go
+++ b/oidc/config_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -26,7 +27,7 @@ var platforms = []string{
 
 func TestConfig(t *testing.T) {
 	for _, platform := range platforms {
-		data, err := os.ReadFile(fmt.Sprintf("testdata/%s-openid-configuration.json", platform))
+		data, err := os.ReadFile(filepath.Join("testdata", fmt.Sprintf("%s-openid-configuration.json", platform)))
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/oidc/jwk_test.go
+++ b/oidc/jwk_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"testing"
 )
 
@@ -21,7 +22,7 @@ func testJWKS(t *testing.T, platform string) {
 		if got, want := r.URL.Path, "/.well-known/jwks"; got != want {
 			t.Errorf("unexpected path: want %q, got %q", want, got)
 		}
-		http.ServeFile(rw, r, "testdata/"+platform+"-jwks.json")
+		http.ServeFile(rw, r, filepath.Join("testdata", platform+"-jwks.json"))
 	}))
 	defer ts.Close()
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved path handling in test files to be cross-platform compatible using OS-appropriate path separators instead of hardcoded relative paths across multiple test suites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->