### PR TITLE
Fix lint warnings

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,6 @@ jobs:
         go:
           - "stable"
           - "1.26"
-          - "1.25"
         os:
           - ubuntu-latest
         goarch:

--- a/ed448/ed448.go
+++ b/ed448/ed448.go
@@ -163,7 +163,9 @@ func sign(signature, privateKey, message []byte) {
 	mh.Write(prefix)
 	mh.Write(message)
 	messageDigest := make([]byte, 114)
-	mh.Read(messageDigest)
+	if _, err := mh.Read(messageDigest); err != nil {
+		panic(err)
+	}
 	r, err := edwards448.NewScalar().SetUniformBytes(messageDigest)
 	if err != nil {
 		panic("ed448: internal error: setting scalar failed")
@@ -177,7 +179,9 @@ func sign(signature, privateKey, message []byte) {
 	kh.Write(publicKey)
 	kh.Write(message)
 	hramDigest := make([]byte, 114)
-	kh.Read(hramDigest)
+	if _, err := kh.Read(hramDigest); err != nil {
+		panic(err)
+	}
 	k, err := edwards448.NewScalar().SetUniformBytes(hramDigest)
 	if err != nil {
 		panic("ed448: internal error: setting scalar failed")

--- a/ed448/ed448.go
+++ b/ed448/ed448.go
@@ -216,7 +216,9 @@ func Verify(publicKey PublicKey, message, sig []byte) bool {
 	kh.Write(publicKey)
 	kh.Write(message)
 	hramDigest := make([]byte, 114)
-	kh.Read(hramDigest)
+	if _, err := kh.Read(hramDigest); err != nil {
+		panic(err)
+	}
 	k, err := edwards448.NewScalar().SetUniformBytes(hramDigest)
 	if err != nil {
 		panic("ed448: internal error: setting scalar failed")

--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,11 @@
 module github.com/shogo82148/goat
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/google/go-cmp v0.7.0
 	github.com/shogo82148/go-cbor v0.2.1
 	github.com/shogo82148/memoize v0.1.0
-	github.com/shogo82148/pointer v1.4.0
 	golang.org/x/crypto v0.50.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,6 @@ github.com/shogo82148/ints v0.1.1 h1:iPDeMnkMIQmuCPYhwbzg/7Zhx1O9ImlP3YS5fEqjcBc
 github.com/shogo82148/ints v0.1.1/go.mod h1:gbLl66XIaav9DKkYMj9/I6DtV+ZcwWHPqpcFnLq3ANM=
 github.com/shogo82148/memoize v0.1.0 h1:MGLpdCv+5xDZyqo6wJLuI+Fk038vlidjjg8GMMVqLUo=
 github.com/shogo82148/memoize v0.1.0/go.mod h1:sOsvhOlJGVR2nHgCzUchvbEeYB6jNvSP9o4SPHgb+bY=
-github.com/shogo82148/pointer v1.4.0 h1:mEpe+gtEWGP4cX8o5YJdmKAbSsYBCqfMQ70RarPJKGE=
-github.com/shogo82148/pointer v1.4.0/go.mod h1:agZ5JFpavFPXznbWonIvbG78NDfvDTFppe+7o53up5w=
 golang.org/x/crypto v0.50.0 h1:zO47/JPrL6vsNkINmLoo/PH1gcxpls50DNogFvB5ZGI=
 golang.org/x/crypto v0.50.0/go.mod h1:3muZ7vA7PBCE6xgPX7nkzzjiUq87kRItoJQM1Yo8S+Q=
 golang.org/x/sys v0.43.0 h1:Rlag2XtaFTxp19wS8MXlJwTvoh8ArU6ezoyFsMyCTNI=

--- a/internal/curve256k1/table.go
+++ b/internal/curve256k1/table.go
@@ -24,7 +24,7 @@ func (v *lookupTable) SelectInto(dest *PointJacobian, x uint8) {
 		panic("curve256k1: out-of-bounds: " + strconv.Itoa(int(x)))
 	}
 	dest.Zero()
-	for i := uint8(1); i < 16; i++ {
+	for i := uint8(1); i < 16; i++ { //nolint:staticcheck // bug of staticcheck? it reports SA4008.
 		cond := subtle.ConstantTimeByteEq(x, i)
 		dest.Select(&v.points[i-1], dest, cond)
 	}

--- a/internal/curve256k1/table_test.go
+++ b/internal/curve256k1/table_test.go
@@ -98,9 +98,15 @@ func TestTable(t *testing.T) {
 	for i := range 16 {
 		var want, got PointJacobian
 		table.SelectInto(&got, uint8(i))
-		want.x.SetBytes(decodeHex(myTable[i].x))
-		want.y.SetBytes(decodeHex(myTable[i].y))
-		want.z.SetBytes(decodeHex(myTable[i].z))
+		if err := want.x.SetBytes(decodeHex(myTable[i].x)); err != nil {
+			t.Fatalf("table[%d].x: invalid hex: %v", i, err)
+		}
+		if err := want.y.SetBytes(decodeHex(myTable[i].y)); err != nil {
+			t.Fatalf("table[%d].y: invalid hex: %v", i, err)
+		}
+		if err := want.z.SetBytes(decodeHex(myTable[i].z)); err != nil {
+			t.Fatalf("table[%d].z: invalid hex: %v", i, err)
+		}
 		if want.Equal(&got) == 0 {
 			t.Errorf("table[%d].x: want %x, got %x", i, want.x.Bytes(), got.x.Bytes())
 			t.Errorf("table[%d].y: want %x, got %x", i, want.y.Bytes(), got.y.Bytes())

--- a/internal/edwards448/scalar_test.go
+++ b/internal/edwards448/scalar_test.go
@@ -1058,9 +1058,18 @@ func TestMulAdd_Check(t *testing.T) {
 	l, _ := new(big.Int).SetString("181709681073901722637330951972001133588410340171829515070372549795146003961539585716195755291692375963310293709091662304773755859649779", 10)
 	f := func(a, b, c [57]byte) bool {
 		var v, s, q, r Scalar
-		s.SetBytesWithClamping(a[:])
-		q.SetBytesWithClamping(b[:])
-		r.SetBytesWithClamping(c[:])
+		if _, err := s.SetBytesWithClamping(a[:]); err != nil {
+			t.Error(err)
+			return false
+		}
+		if _, err := q.SetBytesWithClamping(b[:]); err != nil {
+			t.Error(err)
+			return false
+		}
+		if _, err := r.SetBytesWithClamping(c[:]); err != nil {
+			t.Error(err)
+			return false
+		}
 		v.MulAdd(&s, &q, &r)
 		got := v.toBig(new(big.Int))
 

--- a/internal/edwards448/table.go
+++ b/internal/edwards448/table.go
@@ -55,7 +55,7 @@ func (v *lookupTable) SelectInto(dest *Point, x int8) {
 	xabs := uint8((x + xmask) ^ xmask)
 
 	dest.Zero()
-	for i := 1; i <= 8; i++ {
+	for i := 1; i <= 8; i++ { //nolint:staticcheck // bug of staticcheck? it reports SA4008.
 		// Set dest = i*Q if |x| = i
 		cond := subtle.ConstantTimeByteEq(xabs, uint8(i))
 		dest.Select(&v.points[i-1], dest, cond)

--- a/jwa/acbc/fuzz_test.go
+++ b/jwa/acbc/fuzz_test.go
@@ -35,7 +35,7 @@ func FuzzDecrypt(f *testing.F) {
 
 	f.Fuzz(func(t *testing.T, cek, iv, aad, ciphertext, authTag []byte) {
 		enc := New128HS256()
-		enc.Decrypt(cek, iv, aad, ciphertext, authTag)
+		_, _ = enc.Decrypt(cek, iv, aad, ciphertext, authTag)
 	})
 }
 

--- a/jwk/rsa.go
+++ b/jwk/rsa.go
@@ -3,7 +3,6 @@ package jwk
 import (
 	"crypto/rsa"
 	"errors"
-	"fmt"
 	"math"
 	"math/big"
 
@@ -50,30 +49,11 @@ func parseRSAKey(d *jsonutils.Decoder, key *Key) {
 		}
 
 		// precomputed values
-		crtValues := []rsa.CRTValue{}
-		if oth, ok := d.GetArray("oth"); ok {
-			crtValues = make([]rsa.CRTValue, 0, len(oth))
-			for i, v := range oth {
-				u, ok := v.(map[string]any)
-				if !ok {
-					d.SaveError(fmt.Errorf("jwk: want map[string]any for the parameter oth[%d] but got %T", i, v))
-					return
-				}
-				r := parseRSAOthParam(d, i, u, "r")
-				privateKey.Primes = append(privateKey.Primes, r)
-				crtValues = append(crtValues, rsa.CRTValue{
-					Exp:   parseRSAOthParam(d, i, u, "d"),
-					Coeff: parseRSAOthParam(d, i, u, "t"),
-					R:     r,
-				})
-			}
-		}
 		if d.Has("dp") && d.Has("dq") && d.Has("qi") {
 			privateKey.Precomputed = rsa.PrecomputedValues{
-				Dp:        d.MustBigInt("dp"),
-				Dq:        d.MustBigInt("dq"),
-				Qinv:      d.MustBigInt("qi"),
-				CRTValues: crtValues,
+				Dp:   d.MustBigInt("dp"),
+				Dq:   d.MustBigInt("dq"),
+				Qinv: d.MustBigInt("qi"),
 			}
 		}
 		if err := d.Err(); err != nil {
@@ -95,18 +75,6 @@ func parseRSAKey(d *jsonutils.Decoder, key *Key) {
 			d.SaveError(errors.New("jwk: public keys are mismatch"))
 		}
 	}
-}
-
-func parseRSAOthParam(d *jsonutils.Decoder, i int, v map[string]any, name string) *big.Int {
-	u, ok := v[name]
-	if !ok {
-		return nil
-	}
-	w, ok := u.(string)
-	if !ok {
-		return nil
-	}
-	return new(big.Int).SetBytes(d.Decode(w, fmt.Sprintf("oth[%d].%s", i, name)))
 }
 
 func encodeRSAKey(e *jsonutils.Encoder, priv *rsa.PrivateKey, pub *rsa.PublicKey) {

--- a/jwk/rsa.go
+++ b/jwk/rsa.go
@@ -140,17 +140,6 @@ func encodeRSAKey(e *jsonutils.Encoder, priv *rsa.PrivateKey, pub *rsa.PublicKey
 			e.SetBigInt("dp", priv.Precomputed.Dp)
 			e.SetBigInt("dq", priv.Precomputed.Dq)
 			e.SetBigInt("qi", priv.Precomputed.Qinv)
-			oth := make([]map[string]string, 0, len(priv.Precomputed.CRTValues))
-			for _, v := range priv.Precomputed.CRTValues {
-				u := make(map[string]string)
-				u["d"] = e.Encode(v.Exp.Bytes())
-				u["t"] = e.Encode(v.Coeff.Bytes())
-				u["r"] = e.Encode(v.R.Bytes())
-				oth = append(oth, u)
-			}
-			if len(oth) > 0 {
-				e.Set("oth", oth)
-			}
 		}
 	}
 }

--- a/jwk/rsa_test.go
+++ b/jwk/rsa_test.go
@@ -397,9 +397,6 @@ func TestMarshalKey_RSA(t *testing.T) {
 			`SD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqb` +
 			`w0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw"` +
 			`}`
-		if err != nil {
-			t.Fatal(err)
-		}
 		if string(got) != want {
 			t.Errorf("want %q, got %q", want, got)
 		}

--- a/jwt/custom_decode_test.go
+++ b/jwt/custom_decode_test.go
@@ -7,8 +7,6 @@ import (
 	"reflect"
 	"testing"
 	"time"
-
-	"github.com/shogo82148/pointer"
 )
 
 func TestDecodeCustom(t *testing.T) {
@@ -210,7 +208,7 @@ func TestDecodeCustom(t *testing.T) {
 			want: &struct {
 				Ptr *****string `jwt:"ptr"`
 			}{
-				Ptr: pointer.Ptr(pointer.Ptr(pointer.Ptr(pointer.Ptr(pointer.Ptr("value"))))),
+				Ptr: new(new(new(new(new("value"))))),
 			},
 		},
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Minimum Go language version raised to 1.26+
  * Removed an external pointer helper dependency

* **Tests**
  * Strengthened tests to fail fast on parsing/initialization errors across cryptographic components
  * Fuzz tests ignore unused return values to avoid spurious failures

* **CI**
  * Simplified test matrix to run against the updated Go versions only

* **Bug Fixes**
  * Signing and verification now detect digest read failures and fail loudly
  * RSA JWK output no longer emits legacy extra CRT entries

* **Style**
  * Added linter suppressions for constant-time selection checks
<!-- end of auto-generated comment: release notes by coderabbit.ai -->