### PR TITLE
migrate "golang.org/x/crypto/sha3" to "crypto/sha3"

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,13 @@
+# configuration for golangci-lint.
+# see https://golangci-lint.run/docs/configuration/file/ for more details.
+
+version: "2"
+
+linters:
+  settings:
+    errcheck:
+      exclude-functions:
+        # https://github.com/kisielk/errcheck/pull/276
+        - (*crypto/sha3.SHA3).Write
+        - (*crypto/sha3.SHAKE).Read
+        - (*crypto/sha3.SHAKE).Write

--- a/ed448/ed448.go
+++ b/ed448/ed448.go
@@ -11,13 +11,13 @@ import (
 	"bytes"
 	"crypto"
 	cryptorand "crypto/rand"
+	"crypto/sha3"
 	"crypto/subtle"
 	"errors"
 	"io"
 	"strconv"
 
 	"github.com/shogo82148/goat/internal/edwards448"
-	"golang.org/x/crypto/sha3"
 )
 
 const (
@@ -120,8 +120,7 @@ func newKeyFromSeed(privateKey, seed []byte) {
 		panic("x448: bad seed length: " + strconv.Itoa(l))
 	}
 
-	h := make([]byte, 114)
-	sha3.ShakeSum256(h, seed)
+	h := sha3.SumSHAKE256(seed, 114)
 
 	s, err := edwards448.NewScalar().SetBytesWithClamping(h[:57])
 	if err != nil {
@@ -150,15 +149,14 @@ var sigEd448 = []byte("SigEd448" +
 func sign(signature, privateKey, message []byte) {
 	seed, publicKey := privateKey[:SeedSize], privateKey[SeedSize:]
 
-	h := make([]byte, 114)
-	sha3.ShakeSum256(h, seed)
+	h := sha3.SumSHAKE256(seed, 114)
 	s, err := edwards448.NewScalar().SetBytesWithClamping(h[:57])
 	if err != nil {
 		panic("ed448: internal error: setting scalar failed")
 	}
 	prefix := h[57:]
 
-	mh := sha3.NewShake256()
+	mh := sha3.NewSHAKE256()
 	mh.Write(sigEd448)
 	mh.Write(prefix)
 	mh.Write(message)
@@ -173,15 +171,13 @@ func sign(signature, privateKey, message []byte) {
 
 	R := new(edwards448.Point).ScalarBaseMult(r)
 
-	kh := sha3.NewShake256()
+	kh := sha3.NewSHAKE256()
 	kh.Write(sigEd448)
 	kh.Write(R.Bytes())
 	kh.Write(publicKey)
 	kh.Write(message)
 	hramDigest := make([]byte, 114)
-	if _, err := kh.Read(hramDigest); err != nil {
-		panic(err)
-	}
+	kh.Read(hramDigest)
 	k, err := edwards448.NewScalar().SetUniformBytes(hramDigest)
 	if err != nil {
 		panic("ed448: internal error: setting scalar failed")
@@ -210,15 +206,13 @@ func Verify(publicKey PublicKey, message, sig []byte) bool {
 		return false
 	}
 
-	kh := sha3.NewShake256()
+	kh := sha3.NewSHAKE256()
 	kh.Write(sigEd448)
 	kh.Write(sig[:57])
 	kh.Write(publicKey)
 	kh.Write(message)
 	hramDigest := make([]byte, 114)
-	if _, err := kh.Read(hramDigest); err != nil {
-		panic(err)
-	}
+	kh.Read(hramDigest)
 	k, err := edwards448.NewScalar().SetUniformBytes(hramDigest)
 	if err != nil {
 		panic("ed448: internal error: setting scalar failed")

--- a/go.mod
+++ b/go.mod
@@ -12,5 +12,4 @@ require (
 require (
 	github.com/shogo82148/floats v0.3.0 // indirect
 	github.com/shogo82148/ints v0.1.1 // indirect
-	golang.org/x/sys v0.43.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -10,5 +10,3 @@ github.com/shogo82148/memoize v0.1.0 h1:MGLpdCv+5xDZyqo6wJLuI+Fk038vlidjjg8GMMVq
 github.com/shogo82148/memoize v0.1.0/go.mod h1:sOsvhOlJGVR2nHgCzUchvbEeYB6jNvSP9o4SPHgb+bY=
 golang.org/x/crypto v0.50.0 h1:zO47/JPrL6vsNkINmLoo/PH1gcxpls50DNogFvB5ZGI=
 golang.org/x/crypto v0.50.0/go.mod h1:3muZ7vA7PBCE6xgPX7nkzzjiUq87kRItoJQM1Yo8S+Q=
-golang.org/x/sys v0.43.0 h1:Rlag2XtaFTxp19wS8MXlJwTvoh8ArU6ezoyFsMyCTNI=
-golang.org/x/sys v0.43.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Switched cryptographic primitives to Go's standard library SHA3/SHAKE implementations for improved alignment with core tooling.

* **Chores**
  * Removed an indirect dependency to simplify the dependency set.
  * Added lint configuration to suppress spurious error-check warnings for selected SHA3/SHAKE operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->