### PR TITLE
migrate "golang.org/x/crypto/ed25519" to "crypto/ed25519"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/google/go-cmp v0.7.0
 	github.com/shogo82148/go-cbor v0.2.1
 	github.com/shogo82148/memoize v0.1.0
-	golang.org/x/crypto v0.50.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -8,5 +8,3 @@ github.com/shogo82148/ints v0.1.1 h1:iPDeMnkMIQmuCPYhwbzg/7Zhx1O9ImlP3YS5fEqjcBc
 github.com/shogo82148/ints v0.1.1/go.mod h1:gbLl66XIaav9DKkYMj9/I6DtV+ZcwWHPqpcFnLq3ANM=
 github.com/shogo82148/memoize v0.1.0 h1:MGLpdCv+5xDZyqo6wJLuI+Fk038vlidjjg8GMMVqLUo=
 github.com/shogo82148/memoize v0.1.0/go.mod h1:sOsvhOlJGVR2nHgCzUchvbEeYB6jNvSP9o4SPHgb+bY=
-golang.org/x/crypto v0.50.0 h1:zO47/JPrL6vsNkINmLoo/PH1gcxpls50DNogFvB5ZGI=
-golang.org/x/crypto v0.50.0/go.mod h1:3muZ7vA7PBCE6xgPX7nkzzjiUq87kRItoJQM1Yo8S+Q=

--- a/jwk/jwk_test.go
+++ b/jwk/jwk_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"crypto/ecdh"
 	"crypto/ecdsa"
+	"crypto/ed25519"
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/rsa"
@@ -16,7 +17,6 @@ import (
 	"github.com/shogo82148/goat/jwa"
 	"github.com/shogo82148/goat/x25519"
 	"github.com/shogo82148/goat/x448"
-	"golang.org/x/crypto/ed25519"
 )
 
 func newBigInt(s string) *big.Int {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified project dependencies by removing an external cryptographic library and utilizing Go's standard library implementation instead.
  * Updated test suite to align with standard library conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->