### PR TITLE
Fix lint warnings 2026 04 26 2

### DIFF
--- a/internal/curve256k1/curve256k1.go
+++ b/internal/curve256k1/curve256k1.go
@@ -188,6 +188,34 @@ func (p *Point) ToBig(x, y *big.Int) (xx, yy *big.Int) {
 	return x, y
 }
 
+// Bytes returns the uncompressed encoding of p.
+func (p *Point) Bytes() []byte {
+	var buf [65]byte
+	buf[0] = 0x04 // uncompressed form
+	xBytes := p.x.Bytes()
+	yBytes := p.y.Bytes()
+	copy(buf[1+32-len(xBytes):33], xBytes)
+	copy(buf[33+32-len(yBytes):], yBytes)
+	return buf[:]
+}
+
+// SetBytes decodes p from the uncompressed encoding. It returns an error if the encoding is invalid.
+func (p *Point) SetBytes(data []byte) (*Point, error) {
+	if len(data) != 65 || data[0] != 0x04 {
+		return nil, errors.New("curve256k1: invalid point encoding")
+	}
+	if err := p.x.SetBytes(data[1:33]); err != nil {
+		return nil, err
+	}
+	if err := p.y.SetBytes(data[33:]); err != nil {
+		return nil, err
+	}
+	if !IsOnCurve(p) {
+		return nil, errors.New("curve256k1: point is not on the curve")
+	}
+	return p, nil
+}
+
 // Add set p = a + b.
 func (p *PointJacobian) Add(a, b *PointJacobian) *PointJacobian {
 	// See https://hyperelliptic.org/EFD/g1p/auto-shortw-jacobian-3.html#addition-add-2007-bl

--- a/internal/curve256k1/curve256k1.go
+++ b/internal/curve256k1/curve256k1.go
@@ -93,6 +93,12 @@ func (p *Point) Set(q *Point) *Point {
 	return p
 }
 
+// Equal reports whether p and q have the same value.
+// It returns 1 if they are equal, and 0 otherwise.
+func (p *Point) Equal(q *Point) int {
+	return p.x.Equal(&q.x) & p.y.Equal(&q.y)
+}
+
 type PointJacobian struct {
 	// X = x/z^2, Y = y/z^3
 	x, y, z field.Element

--- a/internal/curve256k1/curve256k1_test.go
+++ b/internal/curve256k1/curve256k1_test.go
@@ -209,8 +209,7 @@ func BenchmarkAdd(b *testing.B) {
 	p2.y.Set(hex2element("f76e500a3ccd0cbd5e27bd746ceee92898d6f6fd5804c370ea2f14c0bbc47cbb"))
 	p2.z.Set(hex2element("721ce4b29855911c8fa0edeb95a00400a994a2fcf14aea11179a804deff71e2f"))
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		p3.Add(&p1, &p2)
 	}
 }
@@ -221,8 +220,7 @@ func BenchmarkAddDouble(b *testing.B) {
 	p1.y.Set(hex2element("483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8"))
 	p1.z.Set(hex2element("0000000000000000000000000000000000000000000000000000000000000001"))
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		p3.Add(&p1, &p1)
 	}
 }
@@ -281,8 +279,7 @@ func BenchmarkDouble(b *testing.B) {
 	p1.y.Set(hex2element("483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8"))
 	p1.z.Set(hex2element("0000000000000000000000000000000000000000000000000000000000000001"))
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		p3.Double(&p1)
 	}
 }

--- a/internal/curve256k1/scalarmult_test.go
+++ b/internal/curve256k1/scalarmult_test.go
@@ -92,8 +92,7 @@ func BenchmarkScalarMult1(b *testing.B) {
 	q.z.Set(hex2element("0000000000000000000000000000000000000000000000000000000000000001"))
 	k := decodeHex("0000000000000000000000000000000000000000000000000000000000000001")
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		q.ScalarMult(&q, k)
 	}
 }
@@ -105,8 +104,7 @@ func BenchmarkScalarMultMinus1(b *testing.B) {
 	q.z.Set(hex2element("0000000000000000000000000000000000000000000000000000000000000001"))
 	k := decodeHex("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364140")
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		q.ScalarMult(&q, k)
 	}
 }

--- a/jwa/eddsa/eddsa.go
+++ b/jwa/eddsa/eddsa.go
@@ -20,7 +20,7 @@ func New() sig.Algorithm {
 }
 
 func init() {
-	jwa.RegisterSignatureAlgorithm(jwa.SignatureAlgorithmEdDSA, New)
+	jwa.RegisterSignatureAlgorithm(jwa.SignatureAlgorithmEdDSA, New) //nolint:staticcheck // EdDSA is still supported for backward compatibility.
 }
 
 type algorithm struct{}

--- a/jwa/jwa.go
+++ b/jwa/jwa.go
@@ -374,6 +374,8 @@ const (
 
 	// KeyManagementAlgorithmRSA1_5 is RSAES-PKCS1-v1_5.
 	// import github.com/shogo82148/goat/jwa/rsapkcs1v15
+	//
+	// Deprecated: RSAES-PKCS1-v1_5 is not recommended, use [KeyManagementAlgorithmRSA_OAEP] instead.
 	KeyManagementAlgorithmRSA1_5 KeyManagementAlgorithm = "RSA1_5"
 
 	// KeyManagementAlgorithmRSA_OAEP is RSAES OAEP.

--- a/jwa/rsapkcs1v15/rsapkcs1v15.go
+++ b/jwa/rsapkcs1v15/rsapkcs1v15.go
@@ -1,4 +1,6 @@
-// Package rsaoaep provides the RSAES-PKCS1-v1_5 key encryption algorithm.
+// Package rsapkcs1v15 provides the RSAES-PKCS1-v1_5 key encryption algorithm.
+//
+// Deprecated: RSAES-PKCS1-v1_5 is not recommended, use RSA-OAEP instead of RSAES-PKCS1-v1_5.
 package rsapkcs1v15
 
 import (
@@ -68,12 +70,12 @@ func (w *KeyWrapper) WrapKey(cek []byte, opts any) ([]byte, error) {
 	if !w.canWrap {
 		return nil, fmt.Errorf("rsapkcs1v15: key wrapping operation is not allowed")
 	}
-	return rsa.EncryptPKCS1v15(rand.Reader, w.pub, cek)
+	return rsa.EncryptPKCS1v15(rand.Reader, w.pub, cek) //nolint:staticcheck // RSAES-PKCS1-v1_5 is not recommended, but it is still supported for backward compatibility.
 }
 
 func (w *KeyWrapper) UnwrapKey(data []byte, opts any) ([]byte, error) {
 	if !w.canUnwrap {
 		return nil, fmt.Errorf("rsapkcs1v15: key unwrapping operation is not allowed")
 	}
-	return rsa.DecryptPKCS1v15(rand.Reader, w.priv, data)
+	return rsa.DecryptPKCS1v15(rand.Reader, w.priv, data) //nolint:staticcheck // RSAES-PKCS1-v1_5 is not recommended, but it is still supported for backward compatibility.
 }

--- a/jwa/rsapkcs1v15/rsapkcs1v15.go
+++ b/jwa/rsapkcs1v15/rsapkcs1v15.go
@@ -20,7 +20,7 @@ func New() keymanage.Algorithm {
 }
 
 func init() {
-	jwa.RegisterKeyManagementAlgorithm(jwa.KeyManagementAlgorithmRSA1_5, New)
+	jwa.RegisterKeyManagementAlgorithm(jwa.KeyManagementAlgorithmRSA1_5, New) //nolint:staticcheck // RSA1_5 is deprecated, but it is still supported for backward compatibility.
 }
 
 var _ keymanage.Algorithm = (*Algorithm)(nil)

--- a/jwe/jwe_test.go
+++ b/jwe/jwe_test.go
@@ -13,7 +13,7 @@ import (
 	_ "github.com/shogo82148/goat/jwa/akw"
 	_ "github.com/shogo82148/goat/jwa/pbes2"
 	_ "github.com/shogo82148/goat/jwa/rsaoaep"
-	_ "github.com/shogo82148/goat/jwa/rsapkcs1v15"
+	_ "github.com/shogo82148/goat/jwa/rsapkcs1v15" //nolint:staticcheck // for testing RSAES-PKCS1-v1_5
 	"github.com/shogo82148/goat/jwk"
 	"github.com/shogo82148/goat/keymanage"
 )

--- a/jwe/jwe_test.go
+++ b/jwe/jwe_test.go
@@ -391,11 +391,11 @@ func TestEncrypt(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		alg := jwa.KeyManagementAlgorithmRSA1_5.New()
+		alg := jwa.KeyManagementAlgorithmRSA1_5.New() //nolint:staticcheck // RSA1_5 is deprecated, but we want to test the example in the RFC
 		key := alg.NewKeyWrapper(k)
 
 		header := &Header{}
-		header.SetAlgorithm(jwa.KeyManagementAlgorithmRSA1_5)
+		header.SetAlgorithm(jwa.KeyManagementAlgorithmRSA1_5) //nolint:staticcheck // RSA1_5 is deprecated, but we want to test the example in the RFC
 		plaintext := "Live long and prosper."
 		msg1, err := NewMessageWithKW(jwa.EncryptionAlgorithmA128CBC_HS256, key, header, []byte(plaintext))
 		if err != nil {

--- a/jwk/ecdsa.go
+++ b/jwk/ecdsa.go
@@ -1,6 +1,7 @@
 package jwk
 
 import (
+	"crypto/ecdh"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"errors"
@@ -11,122 +12,167 @@ import (
 	"github.com/shogo82148/goat/secp256k1"
 )
 
+var errInvalidECDSAParameter = errors.New("jwk: invalid parameter of ecdsa")
+
 // RFC 7518 Section 6.2.2. Parameters for Elliptic Curve Private Keys
 func parseEcdsaKey(d *jsonutils.Decoder, key *Key) {
 	var curve elliptic.Curve
+	var size int
 	crv := jwa.EllipticCurve(d.MustString("crv"))
 	switch crv {
 	case jwa.EllipticCurveP256:
 		curve = elliptic.P256()
+		size = 32
 	case jwa.EllipticCurveP384:
 		curve = elliptic.P384()
+		size = 48
 	case jwa.EllipticCurveP521:
 		curve = elliptic.P521()
+		size = 66
 	case jwa.EllipticCurveSecp256k1:
 		curve = secp256k1.Curve()
+		// TODO: implement parsing of secp256k1 keys.
+		d.SaveError(errors.New("jwk: not implemented"))
+		return
 	default:
 		d.SaveError(fmt.Errorf("jwk: unknown crv: %q", crv))
 		return
 	}
 
+	// parameters for private key
+	var priv *ecdsa.PrivateKey
+	if dd, ok := d.GetBytes("d"); ok {
+		var err error
+		priv, err = ecdsa.ParseRawPrivateKey(curve, dd)
+		if err != nil {
+			d.SaveError(errInvalidECDSAParameter)
+			return
+		}
+		key.priv = priv
+	}
+
 	// parameters for public key
-	x := d.MustBigInt("x")
-	y := d.MustBigInt("y")
+	x := d.MustBytes("x")
+	y := d.MustBytes("y")
 	if err := d.Err(); err != nil {
 		return
 	}
-	pub := ecdsa.PublicKey{
-		Curve: curve,
-		X:     x,
-		Y:     y,
-	}
-	key.pub = &pub
-	if err := validateEcdsaPublicKey(&pub); err != nil {
-		d.SaveError(err)
+	if len(x) != size || len(y) != size {
+		d.SaveError(errInvalidECDSAParameter)
 		return
 	}
+	buf := make([]byte, 1+2*size)
+	buf[0] = 0x04 // uncompressed form
+	copy(buf[1:1+size], x)
+	copy(buf[1+size:], y)
+	pub, err := ecdsa.ParseUncompressedPublicKey(curve, buf)
+	if err != nil {
+		d.SaveError(errInvalidECDSAParameter)
+		return
+	}
+	key.pub = pub
 
-	// parameters for private key
-	if dd, ok := d.GetBigInt("d"); ok {
-		priv := ecdsa.PrivateKey{
-			PublicKey: pub,
-			D:         dd,
-		}
-		if err := validateEcdsaPrivateKey(&priv); err != nil {
-			d.SaveError(err)
+	// sanity check of the key pair.
+	if priv != nil {
+		if !priv.PublicKey.Equal(pub) {
+			d.SaveError(errInvalidECDSAParameter)
 			return
 		}
-		key.priv = &priv
 	}
 
-	// sanity check of the certificate
+	// sanity check of the certificate.
 	if certs := key.x5c; len(certs) > 0 {
 		cert := certs[0]
 		if !pub.Equal(cert.PublicKey) {
-			d.SaveError(errors.New("jwk: public keys are mismatch"))
+			d.SaveError(errInvalidECDSAParameter)
+			return
 		}
 	}
 }
 
 // RFC 7518 Section 6.2.2. Parameters for Elliptic Curve Private Keys
 func encodeEcdsaKey(e *jsonutils.Encoder, priv *ecdsa.PrivateKey, pub *ecdsa.PublicKey) {
-	if err := validateEcdsaPublicKey(pub); err != nil {
-		e.SaveError(err)
-		return
-	}
+	var size int
 	e.Set("kty", jwa.KeyTypeEC.String())
 	switch pub.Curve {
 	case elliptic.P256():
 		e.Set("crv", jwa.EllipticCurveP256.String())
+		size = 32
 	case elliptic.P384():
 		e.Set("crv", jwa.EllipticCurveP384.String())
+		size = 48
 	case elliptic.P521():
 		e.Set("crv", jwa.EllipticCurveP521.String())
+		size = 66
 	case secp256k1.Curve():
 		e.Set("crv", jwa.EllipticCurveSecp256k1.String())
+		// TODO: implement encoding of secp256k1 keys.
+		e.SaveError(errors.New("jwk: not implemented"))
+		return
 	default:
-		panic("not reach")
+		e.SaveError(fmt.Errorf("jwk: unknown crv: %q", pub.Curve.Params().Name))
+		return
 	}
-	size := (pub.Curve.Params().BitSize + 7) / 8
-	e.SetFixedBigInt("x", pub.X, size)
-	e.SetFixedBigInt("y", pub.Y, size)
+
+	// encode the public key.
+	data, err := pub.Bytes()
+	if err != nil {
+		e.SaveError(errInvalidECDSAParameter)
+		return
+	}
+	if len(data) != 1+2*size || data[0] != 0x04 {
+		e.SaveError(errInvalidECDSAParameter)
+		return
+	}
+	e.SetBytes("x", data[1:1+size])
+	e.SetBytes("y", data[1+size:])
+
+	// encode the private key.
 	if priv != nil {
 		if !priv.PublicKey.Equal(pub) {
-			e.SaveError(errors.New("jwk: invalid ecdsa key pair"))
+			e.SaveError(errInvalidECDSAParameter)
 			return
 		}
-		if err := validateEcdsaPrivateKey(priv); err != nil {
-			e.SaveError(err)
+		data, err := priv.Bytes()
+		if err != nil {
+			e.SaveError(errInvalidECDSAParameter)
 			return
 		}
-		e.SetFixedBigInt("d", priv.D, size)
+		if len(data) != size {
+			e.SaveError(errInvalidECDSAParameter)
+			return
+		}
+		e.SetBytes("d", data)
 	}
 }
 
-// sanity check of private key
-func validateEcdsaPrivateKey(key *ecdsa.PrivateKey) error {
-	if err := validateEcdsaPublicKey(&key.PublicKey); err != nil {
-		return err
+func encodeECDHKey(e *jsonutils.Encoder, priv *ecdhPrivateKey, pub *ecdhPublicKey) {
+	switch pub.Curve() {
+	case ecdh.P256():
+		e.Set("kty", jwa.KeyTypeEC.String())
+		e.Set("crv", jwa.EllipticCurveP256.String())
+		data := pub.Bytes()
+		e.SetBytes("x", data[1:32+1])
+		e.SetBytes("y", data[32+1:])
+	case ecdh.P384():
+		e.Set("kty", jwa.KeyTypeEC.String())
+		e.Set("crv", jwa.EllipticCurveP384.String())
+		data := pub.Bytes()
+		e.SetBytes("x", data[1:48+1])
+		e.SetBytes("y", data[48+1:])
+	case ecdh.P521():
+		e.Set("kty", jwa.KeyTypeEC.String())
+		e.Set("crv", jwa.EllipticCurveP521.String())
+		data := pub.Bytes()
+		e.SetBytes("x", data[1:66+1])
+		e.SetBytes("y", data[66+1:])
+	case ecdh.X25519():
+		e.Set("kty", jwa.KeyTypeOKP)
+		e.Set("crv", jwa.EllipticCurveX25519.String())
+		e.SetBytes("x", pub.Bytes())
 	}
-	xx, yy := key.ScalarBaseMult(key.D.Bytes())
-	if xx.Cmp(key.X) != 0 || yy.Cmp(key.Y) != 0 {
-		return errors.New("jwk: invalid ecdsa key pair")
-	}
-	return nil
-}
 
-// sanity check of public key
-func validateEcdsaPublicKey(key *ecdsa.PublicKey) error {
-	switch key.Curve {
-	case elliptic.P256():
-	case elliptic.P384():
-	case elliptic.P521():
-	case secp256k1.Curve():
-	default:
-		return errors.New("jwk: unknown elliptic curve of ecdsa public key")
+	if priv != nil {
+		e.SetBytes("d", priv.Bytes())
 	}
-	if key.X.Sign() == 0 || key.Y.Sign() == 0 || !key.Curve.IsOnCurve(key.X, key.Y) {
-		return fmt.Errorf("jwk: invalid parameter of ecdsa public key")
-	}
-	return nil
 }

--- a/jwk/ecdsa.go
+++ b/jwk/ecdsa.go
@@ -167,7 +167,7 @@ func encodeECDHKey(e *jsonutils.Encoder, priv *ecdhPrivateKey, pub *ecdhPublicKe
 		e.SetBytes("x", data[1:66+1])
 		e.SetBytes("y", data[66+1:])
 	case ecdh.X25519():
-		e.Set("kty", jwa.KeyTypeOKP)
+		e.Set("kty", jwa.KeyTypeOKP.String())
 		e.Set("crv", jwa.EllipticCurveX25519.String())
 		e.SetBytes("x", pub.Bytes())
 	}

--- a/jwk/ecdsa.go
+++ b/jwk/ecdsa.go
@@ -170,6 +170,9 @@ func encodeECDHKey(e *jsonutils.Encoder, priv *ecdhPrivateKey, pub *ecdhPublicKe
 		e.Set("kty", jwa.KeyTypeOKP.String())
 		e.Set("crv", jwa.EllipticCurveX25519.String())
 		e.SetBytes("x", pub.Bytes())
+	default:
+		e.SaveError(errors.New("jwk: unknown crv"))
+		return
 	}
 
 	if priv != nil {

--- a/jwk/ecdsa_test.go
+++ b/jwk/ecdsa_test.go
@@ -3,6 +3,7 @@ package jwk
 import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
+	"encoding/hex"
 	"testing"
 
 	"github.com/shogo82148/goat/jwa"
@@ -10,6 +11,7 @@ import (
 
 func TestParseKey_ecdsa(t *testing.T) {
 	t.Run("RFC 7515 Appendix A.3 Example JWS Using ECDSA P-256 SHA-256", func(t *testing.T) {
+		// parse JWK
 		rawKey := `{"kty":"EC",` +
 			`"crv":"P-256",` +
 			`"x":"f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvRVEU",` +
@@ -20,32 +22,31 @@ func TestParseKey_ecdsa(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+
+		// expected private key
+		data, err := hex.DecodeString("8e9b109e719098bf980487df1f5d77e9cb29606ebed2263b5f57c213df84f4b2")
+		if err != nil {
+			t.Fatal(err)
+		}
+		priv, err := ecdsa.ParseRawPrivateKey(elliptic.P256(), data)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// verify
 		if want, got := key.kty, jwa.KeyTypeEC; want != got {
 			t.Errorf("unexpected key type: want %s, got %s", want, got)
 		}
-		x := newBigInt("57807358241436249728379122087876380298924820027722995515715270765240753673285")
-		y := newBigInt("90436541859143682268950424386863654389577770182238183823381687388274600502701")
-		want := &ecdsa.PublicKey{
-			Curve: elliptic.P256(),
-			X:     x,
-			Y:     y,
+		if !priv.PublicKey.Equal(key.PublicKey()) {
+			t.Errorf("unexpected public key: want %v, got %v", priv.PublicKey, key.PublicKey())
 		}
-		got := key.PublicKey()
-		if !want.Equal(got) {
-			t.Errorf("unexpected public key: want %v, got %v", want, got)
-		}
-
-		d := newBigInt("64502400493437371358766275827725703314178640739253280897215993954599262549170")
-		privateKey := &ecdsa.PrivateKey{
-			PublicKey: *want,
-			D:         d,
-		}
-		if !privateKey.Equal(key.PrivateKey()) {
-			t.Errorf("unexpected private key: want %v, got %v", privateKey, key.PrivateKey())
+		if !priv.Equal(key.PrivateKey()) {
+			t.Errorf("unexpected private key: want %v, got %v", priv, key.PrivateKey())
 		}
 	})
 
 	t.Run("RFC 7515 Appendix A.4 Example JWS Using ECDSA P-521 SHA-512", func(t *testing.T) {
+		// parse JWK
 		rawKey := `{"kty":"EC",` +
 			`"crv":"P-521",` +
 			`"x":"AekpBQ8ST8a8VcfVOTNl353vSrDCLLJXmPk06wTjxrrjcBpXp5EOnYG_` +
@@ -59,31 +60,31 @@ func TestParseKey_ecdsa(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+
+		// expected private key
+		data, err := hex.DecodeString("018e696fb034505881dd110b483eb87d32ce495fe36b3745edf2d8cae4f0f2539f4615a0e98eab52b3c0c5eac4ce075185a8e7bb47deac1d1de77bccf66135e63d82")
+		if err != nil {
+			t.Fatal(err)
+		}
+		priv, err := ecdsa.ParseRawPrivateKey(elliptic.P521(), data)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// verify
 		if want, got := key.kty, jwa.KeyTypeEC; want != got {
 			t.Errorf("unexpected key type: want %s, got %s", want, got)
 		}
-		x := newBigInt("6558566456959953544109522959384633002634366184193672267866407124696200040032063394775499664830638630438428532794662648623689740875293641365317574204038644132")
-		y := newBigInt("705914061082973601048865942513844186912223650952616397119610620188911564288314145208762412315826061109317770515164005156360031161563418113875601542699600118")
-		publicKey := &ecdsa.PublicKey{
-			Curve: elliptic.P521(),
-			X:     x,
-			Y:     y,
+		if !priv.PublicKey.Equal(key.PublicKey()) {
+			t.Errorf("unexpected public key: want %v, got %v", priv.PublicKey, key.PublicKey())
 		}
-		if !publicKey.Equal(key.PublicKey()) {
-			t.Errorf("unexpected public key: want %v, got %v", publicKey, key.PublicKey())
-		}
-
-		d := newBigInt("5341829702302574813496892344628933729576493483297373613204193688404465422472930583369539336694834830511678939023627363969939187661870508700291259319376559490")
-		privateKey := &ecdsa.PrivateKey{
-			PublicKey: *publicKey,
-			D:         d,
-		}
-		if !privateKey.Equal(key.PrivateKey()) {
-			t.Errorf("unexpected private key: want %v, got %v", privateKey, key.PrivateKey())
+		if !priv.Equal(key.PrivateKey()) {
+			t.Errorf("unexpected private key: want %v, got %v", priv, key.PrivateKey())
 		}
 	})
 
 	t.Run("RFC 7517 A.1. Example Public Keys (EC)", func(t *testing.T) {
+		// parse JWK
 		rawKey := `{"kty":"EC",` +
 			`"crv":"P-256",` +
 			`"x":"MKBCTNIcKUSDii11ySs3526iDZ8AiTo7Tu6KPAqv7D4",` +
@@ -94,23 +95,29 @@ func TestParseKey_ecdsa(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+
+		// expected public key
+		buf, err := hex.DecodeString("0430a0424cd21c2944838a2d75c92b37e76ea20d9f00893a3b4eee8a3c0aafec3ee04b65e92456d9888b52b379bdfbd51ee869ef1f0fc65b6659695b6cce081723")
+		if err != nil {
+			t.Fatal(err)
+		}
+		pub, err := ecdsa.ParseUncompressedPublicKey(elliptic.P256(), buf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// verify
 		if want, got := key.kty, jwa.KeyTypeEC; want != got {
 			t.Errorf("unexpected key type: want %s, got %s", want, got)
 		}
-		x := newBigInt("21994169848703329112137818087919262246467304847122821377551355163096090930238")
-		y := newBigInt("101451294974385619524093058399734017814808930032421185206609461750712400090915")
-		want := &ecdsa.PublicKey{
-			Curve: elliptic.P256(),
-			X:     x,
-			Y:     y,
-		}
 		got := key.PublicKey()
-		if !want.Equal(got) {
-			t.Errorf("unexpected public key: want %v, got %v", want, got)
+		if !pub.Equal(got) {
+			t.Errorf("unexpected public key: want %v, got %v", pub, got)
 		}
 	})
 
 	t.Run("RFC 7517 A.2. Example Private Keys (EC)", func(t *testing.T) {
+		// parse JWK
 		rawKey := `{"kty":"EC",` +
 			`"crv":"P-256",` +
 			`"x":"MKBCTNIcKUSDii11ySs3526iDZ8AiTo7Tu6KPAqv7D4",` +
@@ -122,28 +129,26 @@ func TestParseKey_ecdsa(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+
+		// expected private key
+		data, err := hex.DecodeString("f3bd0c07a81fb932781ed52752f60cc89a6be5e51934fe01938ddb55d8f77801")
+		if err != nil {
+			t.Fatal(err)
+		}
+		priv, err := ecdsa.ParseRawPrivateKey(elliptic.P256(), data)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// verify
 		if want, got := key.kty, jwa.KeyTypeEC; want != got {
 			t.Errorf("unexpected key type: want %s, got %s", want, got)
 		}
-		x := newBigInt("21994169848703329112137818087919262246467304847122821377551355163096090930238")
-		y := newBigInt("101451294974385619524093058399734017814808930032421185206609461750712400090915")
-		want := &ecdsa.PublicKey{
-			Curve: elliptic.P256(),
-			X:     x,
-			Y:     y,
+		if !priv.PublicKey.Equal(key.PublicKey()) {
+			t.Errorf("unexpected public key: want %v, got %v", priv.PublicKey, key.PublicKey())
 		}
-		got := key.PublicKey()
-		if !want.Equal(got) {
-			t.Errorf("unexpected public key: want %v, got %v", want, got)
-		}
-
-		d := newBigInt("110246039328358150430804407946042381407500908316371398015658902487828646033409")
-		privateKey := &ecdsa.PrivateKey{
-			PublicKey: *want,
-			D:         d,
-		}
-		if !privateKey.Equal(key.PrivateKey()) {
-			t.Errorf("unexpected private key: want %v, got %v", privateKey, key.PrivateKey())
+		if !priv.Equal(key.PrivateKey()) {
+			t.Errorf("unexpected private key: want %v, got %v", priv, key.PrivateKey())
 		}
 	})
 }
@@ -277,22 +282,28 @@ func TestParseKey_ecdsa_invalid(t *testing.T) {
 
 func TestMarshalKey_ecdsa(t *testing.T) {
 	t.Run("RFC 7517 A.1. Example Public Keys (EC)", func(t *testing.T) {
-		x := newBigInt("21994169848703329112137818087919262246467304847122821377551355163096090930238")
-		y := newBigInt("101451294974385619524093058399734017814808930032421185206609461750712400090915")
+		buf, err := hex.DecodeString("0430a0424cd21c2944838a2d75c92b37e76ea20d9f00893a3b4eee8a3c0aafec3ee04b65e92456d9888b52b379bdfbd51ee869ef1f0fc65b6659695b6cce081723")
+		if err != nil {
+			t.Fatal(err)
+		}
+		pub, err := ecdsa.ParseUncompressedPublicKey(elliptic.P256(), buf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// encode JWK
 		key := &Key{
 			kty: jwa.KeyTypeEC,
 			kid: "1",
 			use: "enc",
-			pub: &ecdsa.PublicKey{
-				Curve: elliptic.P256(),
-				X:     x,
-				Y:     y,
-			},
+			pub: pub,
 		}
 		got, err := key.MarshalJSON()
 		if err != nil {
 			t.Fatal(err)
 		}
+
+		// verify
 		want := `{"crv":"P-256",` +
 			`"kid":"1",` +
 			`"kty":"EC",` +
@@ -306,30 +317,29 @@ func TestMarshalKey_ecdsa(t *testing.T) {
 	})
 
 	t.Run("RFC 7517 A.2. Example Private Keys (EC)", func(t *testing.T) {
-		x := newBigInt("21994169848703329112137818087919262246467304847122821377551355163096090930238")
-		y := newBigInt("101451294974385619524093058399734017814808930032421185206609461750712400090915")
-		d := newBigInt("110246039328358150430804407946042381407500908316371398015658902487828646033409")
+		// expected private key
+		data, err := hex.DecodeString("f3bd0c07a81fb932781ed52752f60cc89a6be5e51934fe01938ddb55d8f77801")
+		if err != nil {
+			t.Fatal(err)
+		}
+		priv, err := ecdsa.ParseRawPrivateKey(elliptic.P256(), data)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// encode JWK
 		key := &Key{
-			priv: &ecdsa.PrivateKey{
-				PublicKey: ecdsa.PublicKey{
-					Curve: elliptic.P256(),
-					X:     x,
-					Y:     y,
-				},
-				D: d,
-			},
-			pub: &ecdsa.PublicKey{
-				Curve: elliptic.P256(),
-				X:     x,
-				Y:     y,
-			},
-			use: "enc",
-			kid: "1",
+			priv: priv,
+			pub:  &priv.PublicKey,
+			use:  "enc",
+			kid:  "1",
 		}
 		got, err := key.MarshalJSON()
 		if err != nil {
 			t.Fatal(err)
 		}
+
+		// verify
 		want := `{"crv":"P-256",` +
 			`"d":"870MB6gfuTJ4HtUnUvYMyJpr5eUZNP4Bk43bVdj3eAE",` +
 			`"kid":"1",` +
@@ -344,28 +354,26 @@ func TestMarshalKey_ecdsa(t *testing.T) {
 	})
 
 	t.Run("RFC 7515 Appendix A.4 Example JWS Using ECDSA P-521 SHA-512", func(t *testing.T) {
-		x := newBigInt("6558566456959953544109522959384633002634366184193672267866407124696200040032063394775499664830638630438428532794662648623689740875293641365317574204038644132")
-		y := newBigInt("705914061082973601048865942513844186912223650952616397119610620188911564288314145208762412315826061109317770515164005156360031161563418113875601542699600118")
-		d := newBigInt("5341829702302574813496892344628933729576493483297373613204193688404465422472930583369539336694834830511678939023627363969939187661870508700291259319376559490")
+		data, err := hex.DecodeString("018e696fb034505881dd110b483eb87d32ce495fe36b3745edf2d8cae4f0f2539f4615a0e98eab52b3c0c5eac4ce075185a8e7bb47deac1d1de77bccf66135e63d82")
+		if err != nil {
+			t.Fatal(err)
+		}
+		priv, err := ecdsa.ParseRawPrivateKey(elliptic.P521(), data)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// encode JWK
 		key := &Key{
-			priv: &ecdsa.PrivateKey{
-				PublicKey: ecdsa.PublicKey{
-					Curve: elliptic.P521(),
-					X:     x,
-					Y:     y,
-				},
-				D: d,
-			},
-			pub: &ecdsa.PublicKey{
-				Curve: elliptic.P521(),
-				X:     x,
-				Y:     y,
-			},
+			priv: priv,
+			pub:  &priv.PublicKey,
 		}
 		got, err := key.MarshalJSON()
 		if err != nil {
 			t.Fatal(err)
 		}
+
+		// verify
 		want := `{"crv":"P-521",` +
 			`"d":"AY5pb7A0UFiB3RELSD64fTLOSV_jazdF7fLYyuTw8lOfRhWg6Y6rUrPA` +
 			`xerEzgdRhajnu0ferB0d53vM9mE15j2C",` +

--- a/jwk/jwk.go
+++ b/jwk/jwk.go
@@ -7,6 +7,7 @@ import (
 	"crypto/ecdh"
 	"crypto/ecdsa"
 	"crypto/ed25519"
+	"crypto/elliptic"
 	"crypto/rsa"
 	"crypto/sha1"
 	"crypto/sha256"
@@ -513,7 +514,15 @@ type ecdhPublicKey = ecdh.PublicKey
 func NewPrivateKey(key crypto.PrivateKey) (*Key, error) {
 	switch key := key.(type) {
 	case *ecdsa.PrivateKey:
-		if err := validateEcdsaPrivateKey(key); err != nil {
+		switch key.Curve {
+		case elliptic.P256():
+		case elliptic.P384():
+		case elliptic.P521():
+			// supported curves for EC keys
+		default:
+			return nil, fmt.Errorf("jwk: unknown crv: %q", key.Curve.Params().Name)
+		}
+		if _, err := key.Bytes(); err != nil {
 			return nil, err
 		}
 		return &Key{
@@ -608,7 +617,15 @@ func NewPrivateKey(key crypto.PrivateKey) (*Key, error) {
 func NewPublicKey(key crypto.PublicKey) (*Key, error) {
 	switch key := key.(type) {
 	case *ecdsa.PublicKey:
-		if err := validateEcdsaPublicKey(key); err != nil {
+		switch key.Curve {
+		case elliptic.P256():
+		case elliptic.P384():
+		case elliptic.P521():
+			// supported curves for EC keys
+		default:
+			return nil, fmt.Errorf("jwk: unknown crv: %q", key.Curve.Params().Name)
+		}
+		if _, err := key.Bytes(); err != nil {
 			return nil, err
 		}
 		return &Key{
@@ -674,36 +691,5 @@ func NewPublicKey(key crypto.PublicKey) (*Key, error) {
 		}, nil
 	default:
 		return nil, fmt.Errorf("jwk: unknown public key type: %T", key)
-	}
-}
-
-func encodeECDHKey(e *jsonutils.Encoder, priv *ecdhPrivateKey, pub *ecdhPublicKey) {
-	switch pub.Curve() {
-	case ecdh.P256():
-		e.Set("kty", jwa.KeyTypeEC.String())
-		e.Set("crv", jwa.EllipticCurveP256.String())
-		data := pub.Bytes()
-		e.SetBytes("x", data[1:32+1])
-		e.SetBytes("y", data[32+1:])
-	case ecdh.P384():
-		e.Set("kty", jwa.KeyTypeEC.String())
-		e.Set("crv", jwa.EllipticCurveP384.String())
-		data := pub.Bytes()
-		e.SetBytes("x", data[1:48+1])
-		e.SetBytes("y", data[48+1:])
-	case ecdh.P521():
-		e.Set("kty", jwa.KeyTypeEC.String())
-		e.Set("crv", jwa.EllipticCurveP521.String())
-		data := pub.Bytes()
-		e.SetBytes("x", data[1:66+1])
-		e.SetBytes("y", data[66+1:])
-	case ecdh.X25519():
-		e.Set("kty", jwa.KeyTypeOKP)
-		e.Set("crv", jwa.EllipticCurveX25519.String())
-		e.SetBytes("x", pub.Bytes())
-	}
-
-	if priv != nil {
-		e.SetBytes("d", priv.Bytes())
 	}
 }

--- a/jwk/rsa.go
+++ b/jwk/rsa.go
@@ -22,7 +22,7 @@ func parseRSAKey(d *jsonutils.Decoder, key *Key) {
 		d.SaveError(errors.New("jwk: invalid rsa parameter e"))
 		return
 	}
-	privateKey.PublicKey.E = int(e.Int64())
+	privateKey.E = int(e.Int64())
 	n := d.MustBigInt("n")
 	pub := rsa.PublicKey{
 		E: int(e.Int64()),

--- a/jws/example_test.go
+++ b/jws/example_test.go
@@ -6,6 +6,7 @@ import (
 	"log"
 
 	"github.com/shogo82148/goat/jwa"
+	_ "github.com/shogo82148/goat/jwa/ed25519"
 	"github.com/shogo82148/goat/jwk"
 	"github.com/shogo82148/goat/jws"
 )
@@ -18,16 +19,15 @@ func ExampleParseCompact() {
 		log.Fatal(err)
 	}
 	v := &jws.Verifier{
-		AlgorithmVerifier: jws.AllowedAlgorithms{jwa.SignatureAlgorithmEdDSA},
+		AlgorithmVerifier: jws.AllowedAlgorithms{jwa.SignatureAlgorithmEd25519},
 		KeyFinder:         &jws.JWKKeyFinder{JWK: key},
 	}
 
-	raw := "eyJhbGciOiJFZERTQSJ9" +
+	raw := "eyJhbGciOiJFZDI1NTE5In0" +
 		"." +
 		"RXhhbXBsZSBvZiBFZDI1NTE5IHNpZ25pbmc" +
 		"." +
-		"hgyY0il_MGCjP0JzlnLWG1PPOt7-09PGcvMg3AIbQR6dWbhijcNR4ki4iylGjg5BhVsPt" +
-		"9g7sVvpAr_MuM0KAg"
+		"UxhIYLHGg39NVCLpQAVD_UcfOmnGSCzLFZoXYkLiIbFccmOb_qObsgjzLKsfJw-4NlccUgvYrEHrRbNV0HcZAQ"
 
 	msg, err := jws.ParseCompact([]byte(raw))
 	if err != nil {
@@ -51,16 +51,15 @@ func ExampleVerifier_Verify() {
 		log.Fatal(err)
 	}
 	v := &jws.Verifier{
-		AlgorithmVerifier: jws.AllowedAlgorithms{jwa.SignatureAlgorithmEdDSA},
+		AlgorithmVerifier: jws.AllowedAlgorithms{jwa.SignatureAlgorithmEd25519},
 		KeyFinder:         &jws.JWKKeyFinder{JWK: key},
 	}
 
-	raw := "eyJhbGciOiJFZERTQSJ9" +
+	raw := "eyJhbGciOiJFZDI1NTE5In0" +
 		"." +
 		"RXhhbXBsZSBvZiBFZDI1NTE5IHNpZ25pbmc" +
 		"." +
-		"hgyY0il_MGCjP0JzlnLWG1PPOt7-09PGcvMg3AIbQR6dWbhijcNR4ki4iylGjg5BhVsPt" +
-		"9g7sVvpAr_MuM0KAg"
+		"UxhIYLHGg39NVCLpQAVD_UcfOmnGSCzLFZoXYkLiIbFccmOb_qObsgjzLKsfJw-4NlccUgvYrEHrRbNV0HcZAQ"
 
 	msg, err := jws.ParseCompact([]byte(raw))
 	if err != nil {
@@ -85,9 +84,9 @@ func ExampleMessage_Compact() {
 		log.Fatal(err)
 	}
 	header := jws.NewHeader()
-	header.SetAlgorithm(jwa.SignatureAlgorithmEdDSA)
+	header.SetAlgorithm(jwa.SignatureAlgorithmEd25519)
 	msg := jws.NewMessage([]byte("Example of Ed25519 signing"))
-	if err := msg.Sign(header, nil, jwa.SignatureAlgorithmEdDSA.New().NewSigningKey(key)); err != nil {
+	if err := msg.Sign(header, nil, jwa.SignatureAlgorithmEd25519.New().NewSigningKey(key)); err != nil {
 		log.Fatal(err)
 	}
 
@@ -97,5 +96,5 @@ func ExampleMessage_Compact() {
 	}
 	fmt.Println(string(data))
 	// Output:
-	// eyJhbGciOiJFZERTQSJ9.RXhhbXBsZSBvZiBFZDI1NTE5IHNpZ25pbmc.hgyY0il_MGCjP0JzlnLWG1PPOt7-09PGcvMg3AIbQR6dWbhijcNR4ki4iylGjg5BhVsPt9g7sVvpAr_MuM0KAg
+	// eyJhbGciOiJFZDI1NTE5In0.RXhhbXBsZSBvZiBFZDI1NTE5IHNpZ25pbmc.UxhIYLHGg39NVCLpQAVD_UcfOmnGSCzLFZoXYkLiIbFccmOb_qObsgjzLKsfJw-4NlccUgvYrEHrRbNV0HcZAQ
 }

--- a/jws/fuzz_test.go
+++ b/jws/fuzz_test.go
@@ -6,7 +6,7 @@ import (
 	"errors"
 	"testing"
 
-	_ "github.com/shogo82148/goat/jwa/eddsa" // for Ed25519
+	_ "github.com/shogo82148/goat/jwa/eddsa" //nolint:staticcheck // for Ed25519
 	_ "github.com/shogo82148/goat/jwa/es"    // for ECDSA
 	_ "github.com/shogo82148/goat/jwa/hs"    // for HMAC SHA-256
 	_ "github.com/shogo82148/goat/jwa/rs"    // for RSASSA-PKCS1-v1_5 SHA-256

--- a/jws/jws_test.go
+++ b/jws/jws_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	"github.com/shogo82148/goat/jwa"
-	_ "github.com/shogo82148/goat/jwa/eddsa" // for Ed25519
+	_ "github.com/shogo82148/goat/jwa/eddsa" //nolint:staticcheck // for Ed25519
 	_ "github.com/shogo82148/goat/jwa/es"    // for ECDSA
 	_ "github.com/shogo82148/goat/jwa/hs"    // for HMAC SHA-256
 	_ "github.com/shogo82148/goat/jwa/none"  // for none

--- a/jws/jws_test.go
+++ b/jws/jws_test.go
@@ -171,9 +171,6 @@ func TestVerify(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if err != nil {
-			t.Fatal(err)
-		}
 
 		if want, got := header.Algorithm(), jwa.SignatureAlgorithmES256; want != got {
 			t.Errorf("unexpected algorithm: want %s, got %s", want, got)

--- a/jws/jws_test.go
+++ b/jws/jws_test.go
@@ -275,7 +275,7 @@ func TestVerify(t *testing.T) {
 			t.Fatal(err)
 		}
 		v := &Verifier{
-			AlgorithmVerifier: AllowedAlgorithms{jwa.SignatureAlgorithmEdDSA},
+			AlgorithmVerifier: AllowedAlgorithms{jwa.SignatureAlgorithmEdDSA}, //nolint:staticcheck // SignatureAlgorithmEdDSA is deprecated, but we need it for testing RFC example.
 			KeyFinder:         &JWKKeyFinder{JWK: key},
 		}
 
@@ -294,7 +294,7 @@ func TestVerify(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if want, got := header.Algorithm(), jwa.SignatureAlgorithmEdDSA; want != got {
+		if want, got := header.Algorithm(), jwa.SignatureAlgorithmEdDSA; want != got { //nolint:staticcheck // SignatureAlgorithmEdDSA is deprecated, but we need it for testing RFC example.
 			t.Errorf("unexpected algorithm: want %s, got %s", want, got)
 		}
 

--- a/jws/rfc7520_test.go
+++ b/jws/rfc7520_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/shogo82148/goat/jwa"
-	_ "github.com/shogo82148/goat/jwa/eddsa" // for Ed25519
+	_ "github.com/shogo82148/goat/jwa/eddsa" //nolint:staticcheck // for testing Ed25519
 	_ "github.com/shogo82148/goat/jwa/es"    // for ECDSA
 	_ "github.com/shogo82148/goat/jwa/hs"    // for HMAC SHA-256
 	_ "github.com/shogo82148/goat/jwa/ps"    // for RSASSA-PKCS1-v1_5 SHA-256

--- a/jwt/example_test.go
+++ b/jwt/example_test.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/shogo82148/goat/jwa"
-	_ "github.com/shogo82148/goat/jwa/eddsa" // for jwa.EdDSA
+	_ "github.com/shogo82148/goat/jwa/ed25519" // for ed25519 support
 	"github.com/shogo82148/goat/jwk"
 	"github.com/shogo82148/goat/jws"
 	"github.com/shogo82148/goat/jwt"
@@ -23,11 +23,11 @@ func ExampleParse() {
 		log.Fatal(err)
 	}
 
-	data := "eyJhbGciOiJFZERTQSJ9." +
+	data := "eyJhbGciOiJFZDI1NTE5In0." +
 		"eyJhdWQiOiJodHRwczovL2dpdGh1Yi5jb20vc2hvZ284MjE0OCIsImlzcyI6Imh0dHBzOi8vZ2l0aHViLmNvbS9zaG9nbzgyMTQ4L2dvYXQifQ." +
-		"2p0nndDnxqsA9u1unq2bLPJiJpSj0hOfCNXe1b_Dsu7LskZPj1lFxv56rptqalzYVmR8kcrMyEIrRb94gr_KBw"
+		"j8oZhXeyAJEZK9TC1a_8QZtw2aoXtG_VEA7OZceE5z7ipbkhmFt_qtIpwWFT_f2wNYfnaTAzteV5KwacbSqTCg"
 	p := &jwt.Parser{
-		AlgorithmVerifier:     jwt.AllowedAlgorithms{jwa.SignatureAlgorithmEdDSA},
+		AlgorithmVerifier:     jwt.AllowedAlgorithms{jwa.SignatureAlgorithmEd25519},
 		KeyFinder:             &jwt.JWKKeyFiner{Key: key},
 		IssuerSubjectVerifier: jwt.Issuer("https://github.com/shogo82148/goat"),
 		AudienceVerifier:      jwt.Audience("https://github.com/shogo82148"),
@@ -50,11 +50,11 @@ func ExampleSign() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	signingKey := jwa.SignatureAlgorithmEdDSA.New().NewSigningKey(key)
+	signingKey := jwa.SignatureAlgorithmEd25519.New().NewSigningKey(key)
 
 	// prepare the header and the claims.
 	header := jws.NewHeader()
-	header.SetAlgorithm(jwa.SignatureAlgorithmEdDSA)
+	header.SetAlgorithm(jwa.SignatureAlgorithmEd25519)
 	claims := new(jwt.Claims)
 	claims.Issuer = "https://github.com/shogo82148/goat"
 	claims.Audience = []string{"https://github.com/shogo82148"}
@@ -67,7 +67,7 @@ func ExampleSign() {
 	fmt.Println(string(token))
 
 	// Output:
-	// eyJhbGciOiJFZERTQSJ9.eyJhdWQiOiJodHRwczovL2dpdGh1Yi5jb20vc2hvZ284MjE0OCIsImlzcyI6Imh0dHBzOi8vZ2l0aHViLmNvbS9zaG9nbzgyMTQ4L2dvYXQifQ.2p0nndDnxqsA9u1unq2bLPJiJpSj0hOfCNXe1b_Dsu7LskZPj1lFxv56rptqalzYVmR8kcrMyEIrRb94gr_KBw
+	// eyJhbGciOiJFZDI1NTE5In0.eyJhdWQiOiJodHRwczovL2dpdGh1Yi5jb20vc2hvZ284MjE0OCIsImlzcyI6Imh0dHBzOi8vZ2l0aHViLmNvbS9zaG9nbzgyMTQ4L2dvYXQifQ.j8oZhXeyAJEZK9TC1a_8QZtw2aoXtG_VEA7OZceE5z7ipbkhmFt_qtIpwWFT_f2wNYfnaTAzteV5KwacbSqTCg
 }
 
 func ExampleClaims_DecodeCustom() {

--- a/oidc/config.go
+++ b/oidc/config.go
@@ -87,7 +87,7 @@ func (c *Client) getConfig(ctx context.Context, configURL string) (*Config, time
 	if err != nil {
 		return nil, time.Time{}, err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck // ignore error because we can't do anything about it.
 
 	if resp.StatusCode != http.StatusOK {
 		return nil, time.Time{}, fmt.Errorf("oidc: unexpected response code: %d", resp.StatusCode)

--- a/oidc/jwk.go
+++ b/oidc/jwk.go
@@ -51,7 +51,7 @@ func (c *Client) getJWKS(ctx context.Context, url string) (*jwk.Set, time.Time, 
 	if err != nil {
 		return nil, time.Time{}, err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck // ignore error because we can't do anything about it.
 
 	if resp.StatusCode != http.StatusOK {
 		return nil, time.Time{}, fmt.Errorf("oidc: unexpected response code: %d", resp.StatusCode)

--- a/secp256k1/openssl_test.go
+++ b/secp256k1/openssl_test.go
@@ -97,13 +97,7 @@ func testVerifyOpenSSL(t *testing.T) {
 
 	sum := sha256.Sum256(message)
 	if !ecdsa.Verify(&priv.PublicKey, sum[:], r, s) {
-		t.Errorf("verify failed:\n"+
-			"message: %x\n"+
-			"X: %x\n"+
-			"Y: %x\n"+
-			"D: %x\n"+
-			"R: %x\n"+
-			"S: %x", message, priv.X, priv.Y, priv.D, r, s)
+		t.Errorf("verify failed:\nmessage: %q", message)
 	}
 }
 
@@ -149,13 +143,7 @@ func testSignOpenSSL(t *testing.T) {
 
 	// verify
 	if err := verifyWithOpenSSL(pubkeyPath, signaturePath, messagePath); err != nil {
-		t.Errorf("verify failed: %v\n"+
-			"message: %x\n"+
-			"X: %x\n"+
-			"Y: %x\n"+
-			"D: %x\n"+
-			"R: %x\n"+
-			"S: %x", err, message, priv.X, priv.Y, priv.D, r, s)
+		t.Errorf("verify failed: %v\nmessage: %q\n", err, message)
 	}
 }
 

--- a/secp256k1/secp256k1.go
+++ b/secp256k1/secp256k1.go
@@ -2,7 +2,7 @@
 package secp256k1
 
 // based on https://tech.ginco.io/post/secp256k1-golang-implementation/
-// https://github.com/GincoInc/go-crypto/blob/master/secp256k1.go
+// https://github.com/GincoInc/go-crypto/blob/f40651045f442b48b7b70e835532df09b4e2ecfa/secp256k1.go
 
 import (
 	"crypto/elliptic"

--- a/secp256k1/secp256k1.go
+++ b/secp256k1/secp256k1.go
@@ -10,6 +10,7 @@ import (
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/subtle"
+	"errors"
 	"math/big"
 	"sync"
 
@@ -32,6 +33,19 @@ func GenerateKey() *PrivateKey {
 			return &PrivateKey{d: buf}
 		}
 	}
+}
+
+// ParseRawPrivateKey parses a private key from a fixed-length big-endian integer.
+func ParseRawPrivateKey(data []byte) (*PrivateKey, error) {
+	if len(data) != 32 {
+		return nil, errors.New("secp256k1: invalid private key length")
+	}
+	var buf [32]byte
+	copy(buf[:], data)
+	if isZero(&buf) || overflow(&buf) {
+		return nil, errors.New("secp256k1: invalid private key")
+	}
+	return &PrivateKey{d: buf}, nil
 }
 
 func isZero(buf *[32]byte) bool {
@@ -70,6 +84,11 @@ func (key *PrivateKey) PublicKey() *PublicKey {
 	return &PublicKey{p: ret}
 }
 
+// Bytes encodes the private key as a fixed-length big-endian integer.
+func (key *PrivateKey) Bytes() ([]byte, error) {
+	return bytes.Clone(key.d[:]), nil
+}
+
 // PublicKey represents a secp256k1 public key.
 type PublicKey struct {
 	p curve256k1.Point
@@ -82,6 +101,23 @@ func (pub *PublicKey) Equal(x crypto.PublicKey) bool {
 		return false
 	}
 	return pub.p.Equal(&xx.p) == 1
+}
+
+// ParseUncompressedPublicKey parses a public key from an uncompressed point encoding.
+func ParseUncompressedPublicKey(data []byte) (*PublicKey, error) {
+	if len(data) != 65 || data[0] != 0x04 {
+		return nil, errors.New("secp256k1: invalid public key encoding")
+	}
+	var p curve256k1.Point
+	if _, err := p.SetBytes(data); err != nil {
+		return nil, err
+	}
+	return &PublicKey{p: p}, nil
+}
+
+// Bytes encodes the public key as an uncompressed point.
+func (pub *PublicKey) Bytes() ([]byte, error) {
+	return pub.p.Bytes(), nil
 }
 
 var initonce sync.Once

--- a/secp256k1/secp256k1.go
+++ b/secp256k1/secp256k1.go
@@ -5,12 +5,84 @@ package secp256k1
 // https://github.com/GincoInc/go-crypto/blob/f40651045f442b48b7b70e835532df09b4e2ecfa/secp256k1.go
 
 import (
+	"bytes"
+	"crypto"
 	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/subtle"
 	"math/big"
 	"sync"
 
 	"github.com/shogo82148/goat/internal/curve256k1"
 )
+
+var paramN = [32]byte{0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFE, 0xBA, 0xAE, 0xDC, 0xE6, 0xAF, 0x48, 0xA0, 0x3B, 0xBF, 0xD2, 0x5E, 0x8C, 0xD0, 0x36, 0x41, 0x41}
+
+// PrivateKey represents a secp256k1 private key.
+type PrivateKey struct {
+	d [32]byte
+}
+
+// GenerateKey generates a new private key.
+func GenerateKey() *PrivateKey {
+	for {
+		var buf [32]byte
+		rand.Read(buf[:])
+		if !isZero(&buf) && !overflow(&buf) {
+			return &PrivateKey{d: buf}
+		}
+	}
+}
+
+func isZero(buf *[32]byte) bool {
+	for _, b := range buf {
+		if b != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func overflow(buf *[32]byte) bool {
+	return bytes.Compare(buf[:], paramN[:]) >= 0
+}
+
+// Equal reports whether priv and x have the same value.
+func (priv *PrivateKey) Equal(x crypto.PrivateKey) bool {
+	xx, ok := x.(*PrivateKey)
+	if !ok {
+		return false
+	}
+	return subtle.ConstantTimeCompare(priv.d[:], xx.d[:]) == 1
+}
+
+// Public returns the corresponding public key.
+func (key *PrivateKey) Public() crypto.PublicKey {
+	return key.PublicKey()
+}
+
+// PublicKey returns the corresponding public key.
+func (key *PrivateKey) PublicKey() *PublicKey {
+	var ret curve256k1.Point
+	var retj curve256k1.PointJacobian
+	retj.ScalarBaseMult(key.d[:])
+	ret.FromJacobian(&retj)
+	return &PublicKey{p: ret}
+}
+
+// PublicKey represents a secp256k1 public key.
+type PublicKey struct {
+	p curve256k1.Point
+}
+
+// Equal reports whether pub and x have the same value.
+func (pub *PublicKey) Equal(x crypto.PublicKey) bool {
+	xx, ok := x.(*PublicKey)
+	if !ok {
+		return false
+	}
+	return pub.p.Equal(&xx.p) == 1
+}
 
 var initonce sync.Once
 var curve secp256k1

--- a/secp256k1/secp256k1_test.go
+++ b/secp256k1/secp256k1_test.go
@@ -34,6 +34,38 @@ func TestPublicKey_Equal(t *testing.T) {
 	}
 }
 
+func TestPrivateKey_Bytes(t *testing.T) {
+	priv1 := GenerateKey()
+	b, err := priv1.Bytes()
+	if err != nil {
+		t.Fatal(err)
+	}
+	priv2, err := ParseRawPrivateKey(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !priv1.Equal(priv2) {
+		t.Error("expected keys to be equal")
+	}
+}
+
+func TestPublicKey_Bytes(t *testing.T) {
+	pub1 := GenerateKey().PublicKey()
+	b, err := pub1.Bytes()
+	if err != nil {
+		t.Fatal(err)
+	}
+	pub2, err := ParseUncompressedPublicKey(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !pub1.Equal(pub2) {
+		t.Error("expected keys to be equal")
+	}
+}
+
 func decodeHex(s string) []byte {
 	data, err := hex.DecodeString(s)
 	if err != nil {

--- a/secp256k1/secp256k1_test.go
+++ b/secp256k1/secp256k1_test.go
@@ -8,6 +8,32 @@ import (
 	"testing"
 )
 
+func TestPrivateKey_Equal(t *testing.T) {
+	priv1 := GenerateKey()
+	priv2 := GenerateKey()
+
+	if !priv1.Equal(priv1) {
+		t.Error("expected keys to be equal")
+	}
+
+	if priv1.Equal(priv2) {
+		t.Error("expected keys to be different")
+	}
+}
+
+func TestPublicKey_Equal(t *testing.T) {
+	pub1 := GenerateKey().PublicKey()
+	pub2 := GenerateKey().PublicKey()
+
+	if !pub1.Equal(pub1) {
+		t.Error("expected keys to be equal")
+	}
+
+	if pub1.Equal(pub2) {
+		t.Error("expected keys to be different")
+	}
+}
+
 func decodeHex(s string) []byte {
 	data, err := hex.DecodeString(s)
 	if err != nil {

--- a/secp256k1/secp256k1_test.go
+++ b/secp256k1/secp256k1_test.go
@@ -148,7 +148,7 @@ func TestIsOnCurve(t *testing.T) {
 		x := bigHex(p.x)
 		y := bigHex(p.y)
 		crv := Curve()
-		if !crv.IsOnCurve(x, y) {
+		if !crv.IsOnCurve(x, y) { //nolint:staticcheck // test IsOnCurve for backward compatibility.
 			t.Error("(x,y) is not on curve")
 		}
 	}
@@ -159,8 +159,8 @@ func BenchmarkIsOnCurve(b *testing.B) {
 	y := bigHex("d39752c01275ea9b61c67990069243c158373d754a54b9acd2e8e6c5db677fbb")
 	crv := Curve()
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		crv.IsOnCurve(x, y)
+	for b.Loop() {
+		crv.IsOnCurve(x, y) //nolint:staticcheck // test IsOnCurve for backward compatibility.
 	}
 }
 
@@ -171,7 +171,7 @@ func TestAdd(t *testing.T) {
 	gy := bigHex("483ADA7726A3C4655DA4FBFC0E1108A8FD17B448A68554199C47D08FFB10D4B8")
 	crv := Curve()
 
-	xx, yy := crv.Add(x, y, gx, gy)
+	xx, yy := crv.Add(x, y, gx, gy) //nolint:staticcheck // test Add for backward compatibility.
 	if xx.String() != "103398873363144253748994332925483235365773458200442655046283530549491799842290" {
 		t.Errorf("want 103398873363144253748994332925483235365773458200442655046283530549491799842290, got %s", xx)
 	}
@@ -188,8 +188,8 @@ func BenchmarkAdd(b *testing.B) {
 	crv := Curve()
 
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		crv.Add(x, y, gx, gy)
+	for b.Loop() {
+		crv.Add(x, y, gx, gy) //nolint:staticcheck // test Add for backward compatibility.
 	}
 }
 
@@ -198,7 +198,7 @@ func TestDouble(t *testing.T) {
 	y := bigHex("d39752c01275ea9b61c67990069243c158373d754a54b9acd2e8e6c5db677fbb")
 	crv := Curve()
 
-	xx, yy := crv.Double(x, y)
+	xx, yy := crv.Double(x, y) //nolint:staticcheck // test Double for backward compatibility.
 	if xx.String() != "3253853896651542241016013980011516465233588677473825707395430701990395674578" {
 		t.Errorf("want 3253853896651542241016013980011516465233588677473825707395430701990395674578, got %s", xx)
 	}
@@ -212,8 +212,8 @@ func BenchmarkDouble(b *testing.B) {
 	y := bigHex("d39752c01275ea9b61c67990069243c158373d754a54b9acd2e8e6c5db677fbb")
 	crv := Curve()
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		crv.Double(x, y)
+	for b.Loop() {
+		crv.Double(x, y) //nolint:staticcheck // test Double for backward compatibility.
 	}
 }
 
@@ -223,7 +223,7 @@ func TestScalarMult1(t *testing.T) {
 	k, _ := hex.DecodeString("0000000000000000000000000000000000000000000000000000000000000001")
 	crv := Curve()
 
-	xx, yy := crv.ScalarMult(x, y, k)
+	xx, yy := crv.ScalarMult(x, y, k) //nolint:staticcheck // test ScalarMult for backward compatibility.
 	if xx.String() != "55042608044612121400613053601674605111304023047002903551681986042062204131860" {
 		t.Errorf("want 55042608044612121400613053601674605111304023047002903551681986042062204131860, got %s", xx)
 	}
@@ -238,7 +238,7 @@ func TestScalarMultMinus1(t *testing.T) {
 	k := decodeHex("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364140")
 	crv := Curve()
 
-	xx, yy := crv.ScalarMult(x, y, k)
+	xx, yy := crv.ScalarMult(x, y, k) //nolint:staticcheck // test ScalarMult for backward compatibility.
 	if xx.String() != "55042608044612121400613053601674605111304023047002903551681986042062204131860" {
 		t.Errorf("want 55042608044612121400613053601674605111304023047002903551681986042062204131860, got %s", xx)
 	}
@@ -253,8 +253,8 @@ func BenchmarkMult1(b *testing.B) {
 	k := decodeHex("0000000000000000000000000000000000000000000000000000000000000001")
 	crv := Curve()
 
-	for i := 0; i < b.N; i++ {
-		crv.ScalarMult(x, y, k)
+	for b.Loop() {
+		crv.ScalarMult(x, y, k) //nolint:staticcheck // test ScalarMult for backward compatibility.
 	}
 }
 
@@ -264,8 +264,8 @@ func BenchmarkMultMinus1(b *testing.B) {
 	k := decodeHex("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364140")
 	crv := Curve()
 
-	for i := 0; i < b.N; i++ {
-		crv.ScalarMult(x, y, k)
+	for b.Loop() {
+		crv.ScalarMult(x, y, k) //nolint:staticcheck // test ScalarMult for backward compatibility.
 	}
 }
 
@@ -273,7 +273,7 @@ func TestScalarBaseMult1(t *testing.T) {
 	k, _ := hex.DecodeString("0000000000000000000000000000000000000000000000000000000000000001")
 	crv := Curve()
 
-	xx, yy := crv.ScalarBaseMult(k)
+	xx, yy := crv.ScalarBaseMult(k) //nolint:staticcheck // test ScalarBaseMult for backward compatibility.
 	if xx.String() != "55066263022277343669578718895168534326250603453777594175500187360389116729240" {
 		t.Errorf("want 55066263022277343669578718895168534326250603453777594175500187360389116729240, got %s", xx)
 	}
@@ -286,7 +286,7 @@ func TestScalarBaseMultMinus1(t *testing.T) {
 	k, _ := hex.DecodeString("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364140")
 	crv := Curve()
 
-	xx, yy := crv.ScalarBaseMult(k)
+	xx, yy := crv.ScalarBaseMult(k) //nolint:staticcheck // test ScalarBaseMult for backward compatibility.
 	if xx.String() != "55066263022277343669578718895168534326250603453777594175500187360389116729240" {
 		t.Errorf("want 55066263022277343669578718895168534326250603453777594175500187360389116729240, got %s", xx)
 	}
@@ -299,8 +299,8 @@ func BenchmarkScalarBaseMult1(b *testing.B) {
 	k := decodeHex("0000000000000000000000000000000000000000000000000000000000000001")
 	crv := Curve()
 
-	for i := 0; i < b.N; i++ {
-		crv.ScalarBaseMult(k)
+	for b.Loop() {
+		crv.ScalarBaseMult(k) //nolint:staticcheck // test ScalarBaseMult for backward compatibility.
 	}
 }
 
@@ -308,8 +308,8 @@ func BenchmarkScalarBaseMultMinus1(b *testing.B) {
 	k := decodeHex("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364140")
 	crv := Curve()
 
-	for i := 0; i < b.N; i++ {
-		crv.ScalarBaseMult(k)
+	for b.Loop() {
+		crv.ScalarBaseMult(k) //nolint:staticcheck // test ScalarBaseMult for backward compatibility.
 	}
 }
 
@@ -359,7 +359,7 @@ func BenchmarkCombinedMult1(b *testing.B) {
 	y := bigHex("d39752c01275ea9b61c67990069243c158373d754a54b9acd2e8e6c5db677fbb")
 	crv := Curve().(*secp256k1)
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		crv.CombinedMult(x, y, k, k)
 	}
 }
@@ -370,7 +370,7 @@ func BenchmarkCombinedMultMinus1(b *testing.B) {
 	y := bigHex("d39752c01275ea9b61c67990069243c158373d754a54b9acd2e8e6c5db677fbb")
 	crv := Curve().(*secp256k1)
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		crv.CombinedMult(x, y, k, k)
 	}
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated examples and tests to use Ed25519 and updated sample JWT/JWS outputs.
  * Marked RSAES-PKCS1-v1_5 as deprecated and recommend RSA-OAEP.

* **Tests**
  * Adjusted test vectors and imports for Ed25519; removed a redundant error check.

* **Bug Fixes**
  * Reworked ECDSA JWK parsing/serialization with stricter curve/key validations and clearer errors.

* **Chores**
  * Added targeted linter suppression comments (staticcheck/errcheck) across code and tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->