### PR TITLE
Optimize secp256k1

### DIFF
--- a/internal/curve256k1/curve256k1.go
+++ b/internal/curve256k1/curve256k1.go
@@ -183,8 +183,12 @@ func (p *PointJacobian) Equal(v *PointJacobian) int {
 }
 
 func (p *Point) ToBig(x, y *big.Int) (xx, yy *big.Int) {
-	x.SetBytes(p.x.Bytes())
-	y.SetBytes(p.y.Bytes())
+	if x != nil {
+		x.SetBytes(p.x.Bytes())
+	}
+	if y != nil {
+		y.SetBytes(p.y.Bytes())
+	}
 	return x, y
 }
 

--- a/secp256k1/secp256k1.go
+++ b/secp256k1/secp256k1.go
@@ -228,12 +228,17 @@ func VerifyASN1(pub *PublicKey, hash, sig []byte) bool {
 	u2 := w.Mul(r, w)
 	u2.Mod(u2, N)
 
-	x1, y1 := curve.ScalarBaseMult(u1.Bytes())
+	var pj1 curve256k1.PointJacobian
+	pj1.ScalarBaseMult(u1.Bytes())
+
+	var pj2 curve256k1.PointJacobian
+	pj2.ScalarMult(&pub.pj, u2.Bytes())
+
 	var p curve256k1.Point
-	p.FromJacobian(&pub.pj)
+	var pj curve256k1.PointJacobian
+	pj.Add(&pj1, &pj2)
+	p.FromJacobian(&pj)
 	x, y := p.ToBig(new(big.Int), new(big.Int))
-	x2, y2 := curve.ScalarMult(x, y, u2.Bytes())
-	x, y = curve.Add(x1, y1, x2, y2)
 
 	if x.Sign() == 0 && y.Sign() == 0 {
 		return false

--- a/secp256k1/secp256k1.go
+++ b/secp256k1/secp256k1.go
@@ -163,7 +163,11 @@ func SignASN1(priv *PrivateKey, hash []byte) ([]byte, error) {
 			k = randFieldElement()
 			kInv = new(big.Int).ModInverse(k, N)
 
-			r, _ = curve.ScalarBaseMult(k.Bytes())
+			var p curve256k1.Point
+			var pj curve256k1.PointJacobian
+			pj.ScalarBaseMult(k.Bytes())
+			p.FromJacobian(&pj)
+			r, _ = p.ToBig(k, nil)
 			r.Mod(r, N)
 			if r.Sign() != 0 {
 				break
@@ -172,7 +176,7 @@ func SignASN1(priv *PrivateKey, hash []byte) ([]byte, error) {
 
 		e := new(big.Int).SetBytes(hash)
 		d := new(big.Int).SetBytes(priv.d[:])
-		s = new(big.Int).Mul(d, r)
+		s = d.Mul(d, r)
 		s.Add(s, e)
 		s.Mul(s, kInv)
 		s.Mod(s, N)


### PR DESCRIPTION
```plain
goos: darwin
goarch: arm64
pkg: github.com/shogo82148/goat/secp256k1
cpu: Apple M1 Pro
          │  .old.txt   │              .new.txt               │
          │   sec/op    │   sec/op     vs base                │
Verify-10   248.4µ ± 1%   217.0µ ± 2%  -12.65% (p=0.000 n=10)

          │   .old.txt   │               .new.txt               │
          │     B/op     │     B/op      vs base                │
Verify-10   2.148Ki ± 0%   1.398Ki ± 0%  -34.91% (p=0.000 n=10)

          │  .old.txt  │              .new.txt              │
          │ allocs/op  │ allocs/op   vs base                │
Verify-10   45.00 ± 0%   27.00 ± 0%  -40.00% (p=0.000 n=10)
```

```plain
goos: darwin
goarch: arm64
pkg: github.com/shogo82148/goat/secp256k1
cpu: Apple M1 Pro
        │  .old.txt   │           .new.txt            │
        │   sec/op    │   sec/op     vs base          │
Sign-10   72.37µ ± 1%   72.29µ ± 1%  ~ (p=0.315 n=10)

        │   .old.txt   │               .new.txt               │
        │     B/op     │     B/op      vs base                │
Sign-10   1.938Ki ± 0%   1.720Ki ± 0%  -11.28% (p=0.000 n=10)

        │  .old.txt  │              .new.txt              │
        │ allocs/op  │ allocs/op   vs base                │
Sign-10   43.00 ± 2%   38.00 ± 3%  -11.63% (p=0.000 n=10)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed nil pointer handling to prevent crashes in point operations.

* **Refactoring**
  * Optimized signing and verification operations for improved performance through streamlined cryptographic computations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->