### PR TITLE
fix: replace crypto.PrivateKey and crypto.PublicKey with goat.PrivateKey and goat.PublicKey

### DIFF
--- a/cose/key.go
+++ b/cose/key.go
@@ -2,13 +2,13 @@ package cose
 
 import (
 	"bytes"
-	"crypto"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"errors"
 	"fmt"
 
 	"github.com/shogo82148/go-cbor"
+	"github.com/shogo82148/goat"
 	"github.com/shogo82148/goat/internal/cborutils"
 )
 
@@ -126,8 +126,8 @@ type Key struct {
 	kty KeyType
 	kid []byte
 
-	priv crypto.PrivateKey
-	pub  crypto.PublicKey
+	priv goat.PrivateKey
+	pub  goat.PublicKey
 }
 
 // KeyType returns the key type of the key.
@@ -141,12 +141,12 @@ func (key *Key) KeyID() []byte {
 }
 
 // PrivateKey returns the private key of the key.
-func (key *Key) PrivateKey() crypto.PrivateKey {
+func (key *Key) PrivateKey() goat.PrivateKey {
 	return key.priv
 }
 
 // PublicKey returns the public key of the key.
-func (key *Key) PublicKey() crypto.PublicKey {
+func (key *Key) PublicKey() goat.PublicKey {
 	return key.pub
 }
 

--- a/goat.go
+++ b/goat.go
@@ -1,3 +1,11 @@
 // Package goat is Go Authentication Toolkit.
 // It provides utils for authentication.
 package goat
+
+// PrivateKey represents a private key using an unspecified algorithm.
+// It is one of [crypto.PrivateKey], [crypto.Decapsulator] or []byte.
+type PrivateKey any
+
+// PublicKey represents a public key using an unspecified algorithm.
+// It is one of [crypto.PublicKey], [crypto.Encapsulator].
+type PublicKey any

--- a/jwa/agcmkw/agcmkw_test.go
+++ b/jwa/agcmkw/agcmkw_test.go
@@ -1,9 +1,10 @@
 package agcmkw
 
 import (
-	"crypto"
 	"crypto/subtle"
 	"testing"
+
+	"github.com/shogo82148/goat"
 )
 
 type options struct {
@@ -29,11 +30,11 @@ func (opts *options) SetAuthenticationTag(tag []byte) {
 
 type bytesKey []byte
 
-func (k bytesKey) PrivateKey() crypto.PrivateKey {
+func (k bytesKey) PrivateKey() goat.PrivateKey {
 	return []byte(k)
 }
 
-func (k bytesKey) PublicKey() crypto.PublicKey {
+func (k bytesKey) PublicKey() goat.PublicKey {
 	return nil
 }
 

--- a/jwa/dir/dir_test.go
+++ b/jwa/dir/dir_test.go
@@ -1,17 +1,18 @@
 package dir
 
 import (
-	"crypto"
 	"testing"
+
+	"github.com/shogo82148/goat"
 )
 
 type rawKey []byte
 
-func (k rawKey) PrivateKey() crypto.PrivateKey {
+func (k rawKey) PrivateKey() goat.PrivateKey {
 	return []byte(k)
 }
 
-func (k rawKey) PublicKey() crypto.PublicKey {
+func (k rawKey) PublicKey() goat.PublicKey {
 	return nil
 }
 

--- a/jwa/ecdhes/ecdhes.go
+++ b/jwa/ecdhes/ecdhes.go
@@ -12,6 +12,7 @@ import (
 	"hash"
 	"io"
 
+	"github.com/shogo82148/goat"
 	"github.com/shogo82148/goat/jwa"
 	"github.com/shogo82148/goat/jwa/akw"
 	"github.com/shogo82148/goat/jwa/dir"
@@ -103,11 +104,11 @@ func (alg *algorithm) NewKeyWrapper(key keymanage.Key) keymanage.KeyWrapper {
 
 type bytesKey []byte
 
-func (k bytesKey) PrivateKey() crypto.PrivateKey {
+func (k bytesKey) PrivateKey() goat.PrivateKey {
 	return []byte(k)
 }
 
-func (k bytesKey) PublicKey() crypto.PublicKey {
+func (k bytesKey) PublicKey() goat.PublicKey {
 	return nil
 }
 

--- a/jwa/ed25519/ed25519_test.go
+++ b/jwa/ed25519/ed25519_test.go
@@ -1,10 +1,11 @@
 package ed25519
 
 import (
-	"crypto"
 	"crypto/ed25519"
 	"crypto/subtle"
 	"testing"
+
+	"github.com/shogo82148/goat"
 )
 
 type rawKey struct {
@@ -12,11 +13,11 @@ type rawKey struct {
 	pub  ed25519.PublicKey
 }
 
-func (k *rawKey) PrivateKey() crypto.PrivateKey {
+func (k *rawKey) PrivateKey() goat.PrivateKey {
 	return k.priv
 }
 
-func (k *rawKey) PublicKey() crypto.PublicKey {
+func (k *rawKey) PublicKey() goat.PublicKey {
 	return k.pub
 }
 

--- a/jwa/ed448/ed448_test.go
+++ b/jwa/ed448/ed448_test.go
@@ -1,11 +1,11 @@
 package ed448
 
 import (
-	"crypto"
 	"crypto/subtle"
 	"fmt"
 	"testing"
 
+	"github.com/shogo82148/goat"
 	"github.com/shogo82148/goat/ed448"
 )
 
@@ -14,11 +14,11 @@ type rawKey struct {
 	pub  ed448.PublicKey
 }
 
-func (k *rawKey) PrivateKey() crypto.PrivateKey {
+func (k *rawKey) PrivateKey() goat.PrivateKey {
 	return k.priv
 }
 
-func (k *rawKey) PublicKey() crypto.PublicKey {
+func (k *rawKey) PublicKey() goat.PublicKey {
 	return k.pub
 }
 

--- a/jwa/eddsa/eddsa_test.go
+++ b/jwa/eddsa/eddsa_test.go
@@ -1,10 +1,11 @@
 package eddsa
 
 import (
-	"crypto"
 	"crypto/ed25519"
 	"crypto/subtle"
 	"testing"
+
+	"github.com/shogo82148/goat"
 )
 
 type rawKey struct {
@@ -12,11 +13,11 @@ type rawKey struct {
 	pub  ed25519.PublicKey
 }
 
-func (k *rawKey) PrivateKey() crypto.PrivateKey {
+func (k *rawKey) PrivateKey() goat.PrivateKey {
 	return k.priv
 }
 
-func (k *rawKey) PublicKey() crypto.PublicKey {
+func (k *rawKey) PublicKey() goat.PublicKey {
 	return k.pub
 }
 

--- a/jwa/es/es_test.go
+++ b/jwa/es/es_test.go
@@ -1,13 +1,13 @@
 package es
 
 import (
-	"crypto"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
 	"encoding/hex"
 	"testing"
 
+	"github.com/shogo82148/goat"
 	"github.com/shogo82148/goat/secp256k1"
 	"github.com/shogo82148/goat/sig"
 )
@@ -82,11 +82,11 @@ type rawKey struct {
 	pub  *ecdsa.PublicKey
 }
 
-func (k *rawKey) PrivateKey() crypto.PrivateKey {
+func (k *rawKey) PrivateKey() goat.PrivateKey {
 	return k.priv
 }
 
-func (k *rawKey) PublicKey() crypto.PublicKey {
+func (k *rawKey) PublicKey() goat.PublicKey {
 	return k.pub
 }
 
@@ -137,11 +137,11 @@ type rawSecp256k1Key struct {
 	pub  *secp256k1.PublicKey
 }
 
-func (k *rawSecp256k1Key) PrivateKey() crypto.PrivateKey {
+func (k *rawSecp256k1Key) PrivateKey() goat.PrivateKey {
 	return k.priv
 }
 
-func (k *rawSecp256k1Key) PublicKey() crypto.PublicKey {
+func (k *rawSecp256k1Key) PublicKey() goat.PublicKey {
 	return k.pub
 }
 

--- a/jwa/hs/hs_test.go
+++ b/jwa/hs/hs_test.go
@@ -1,7 +1,6 @@
 package hs
 
 import (
-	"crypto"
 	"crypto/hmac"
 	"crypto/rand"
 	_ "crypto/sha256"
@@ -10,6 +9,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/shogo82148/goat"
 	"github.com/shogo82148/goat/sig"
 )
 
@@ -323,11 +323,11 @@ var tests = []struct {
 
 type rawKey []byte
 
-func (k rawKey) PrivateKey() crypto.PrivateKey {
+func (k rawKey) PrivateKey() goat.PrivateKey {
 	return []byte(k)
 }
 
-func (k rawKey) PublicKey() crypto.PublicKey {
+func (k rawKey) PublicKey() goat.PublicKey {
 	return nil
 }
 

--- a/jwa/none/none_test.go
+++ b/jwa/none/none_test.go
@@ -2,14 +2,15 @@ package none
 
 import (
 	"bytes"
-	"crypto"
 	"testing"
+
+	"github.com/shogo82148/goat"
 )
 
 type dummyKey struct{}
 
-func (k *dummyKey) PrivateKey() crypto.PrivateKey { return nil }
-func (k *dummyKey) PublicKey() crypto.PublicKey   { return nil }
+func (k *dummyKey) PrivateKey() goat.PrivateKey { return nil }
+func (k *dummyKey) PublicKey() goat.PublicKey   { return nil }
 
 func TestSign(t *testing.T) {
 	alg := New()

--- a/jwa/pbes2/pbse2_test.go
+++ b/jwa/pbes2/pbse2_test.go
@@ -1,9 +1,10 @@
 package pbes2
 
 import (
-	"crypto"
 	"crypto/subtle"
 	"testing"
+
+	"github.com/shogo82148/goat"
 )
 
 type options struct {
@@ -21,11 +22,11 @@ func (opts *options) PBES2Count() int {
 
 type rawKey []byte
 
-func (k rawKey) PrivateKey() crypto.PrivateKey {
+func (k rawKey) PrivateKey() goat.PrivateKey {
 	return []byte(k)
 }
 
-func (k rawKey) PublicKey() crypto.PublicKey {
+func (k rawKey) PublicKey() goat.PublicKey {
 	return nil
 }
 

--- a/jwa/ps/ps_test.go
+++ b/jwa/ps/ps_test.go
@@ -1,12 +1,12 @@
 package ps
 
 import (
-	"crypto"
 	"crypto/rand"
 	"crypto/rsa"
 	"math/big"
 	"testing"
 
+	"github.com/shogo82148/goat"
 	"github.com/shogo82148/goat/sig"
 )
 
@@ -101,11 +101,11 @@ type rawKey struct {
 	pub  *rsa.PublicKey
 }
 
-func (k *rawKey) PrivateKey() crypto.PrivateKey {
+func (k *rawKey) PrivateKey() goat.PrivateKey {
 	return k.priv
 }
 
-func (k *rawKey) PublicKey() crypto.PublicKey {
+func (k *rawKey) PublicKey() goat.PublicKey {
 	return k.pub
 }
 

--- a/jwa/rs/rs_test.go
+++ b/jwa/rs/rs_test.go
@@ -1,13 +1,13 @@
 package rs
 
 import (
-	"crypto"
 	"crypto/hmac"
 	"crypto/rand"
 	"crypto/rsa"
 	"math/big"
 	"testing"
 
+	"github.com/shogo82148/goat"
 	"github.com/shogo82148/goat/sig"
 )
 
@@ -105,11 +105,11 @@ type rawKey struct {
 	pub  *rsa.PublicKey
 }
 
-func (k *rawKey) PrivateKey() crypto.PrivateKey {
+func (k *rawKey) PrivateKey() goat.PrivateKey {
 	return k.priv
 }
 
-func (k *rawKey) PublicKey() crypto.PublicKey {
+func (k *rawKey) PublicKey() goat.PublicKey {
 	return k.pub
 }
 

--- a/jwk/jwk.go
+++ b/jwk/jwk.go
@@ -22,6 +22,7 @@ import (
 	"net/url"
 	"reflect"
 
+	"github.com/shogo82148/goat"
 	"github.com/shogo82148/goat/ed448"
 	"github.com/shogo82148/goat/internal/jsonutils"
 	"github.com/shogo82148/goat/jwa"
@@ -46,8 +47,8 @@ type Key struct {
 	x5c     []*x509.Certificate
 	x5t     []byte
 	x5tS256 []byte
-	priv    crypto.PrivateKey
-	pub     crypto.PublicKey
+	priv    goat.PrivateKey
+	pub     goat.PublicKey
 }
 
 // KeyType returns RFC 7517 Section 4.1. "kty" (Key Type) Parameter.
@@ -378,13 +379,13 @@ func (key *Key) Thumbprint(h hash.Hash) ([]byte, error) {
 
 // PrivateKey returns the private key.
 // If the key doesn't contain any private key, it returns nil.
-func (key *Key) PrivateKey() crypto.PrivateKey {
+func (key *Key) PrivateKey() goat.PrivateKey {
 	return key.priv
 }
 
 // SetPrivateKey sets the private key.
 // If priv has Public() method, it sets the public key as well.
-func (key *Key) SetPrivateKey(priv crypto.PrivateKey) {
+func (key *Key) SetPrivateKey(priv goat.PrivateKey) {
 	key.priv = priv
 	if pub, ok := priv.(interface{ Public() crypto.PublicKey }); ok {
 		key.pub = pub.Public()
@@ -395,12 +396,12 @@ func (key *Key) SetPrivateKey(priv crypto.PrivateKey) {
 
 // PublicKey returns the public key.
 // If the key doesn't contain any public key, it returns nil.
-func (key *Key) PublicKey() crypto.PublicKey {
+func (key *Key) PublicKey() goat.PublicKey {
 	return key.pub
 }
 
 // SetPublicKey sets the public key, and removes the private key.
-func (key *Key) SetPublicKey(pub crypto.PublicKey) {
+func (key *Key) SetPublicKey(pub goat.PublicKey) {
 	key.priv = nil
 	key.pub = pub
 }
@@ -520,7 +521,7 @@ type ecdhPublicKey = ecdh.PublicKey
 // key must be one of [*crypto/ecdsa.PrivateKey], [*crypto/rsa.PrivateKey], [crypto/ed25519.PrivateKey], [*crypto/ecdh.PrivateKey],
 // [x25519.PrivateKey], [ed448.PrivateKey],
 // [x448.PrivateKey], [*secp256k1.PrivateKey] or []byte.
-func NewPrivateKey(key crypto.PrivateKey) (*Key, error) {
+func NewPrivateKey(key goat.PrivateKey) (*Key, error) {
 	switch key := key.(type) {
 	case *ecdsa.PrivateKey:
 		switch key.Curve {
@@ -629,7 +630,7 @@ func NewPrivateKey(key crypto.PrivateKey) (*Key, error) {
 //
 // key must be one of [*crypto/ecdsa.PublicKey], [*crypto/rsa.PublicKey], [crypto/ed25519.PublicKey], [*crypto/ecdh.PublicKey],
 // [x25519.PublicKey], [ed448.PublicKey], [x448.PublicKey] or [*secp256k1.PublicKey].
-func NewPublicKey(key crypto.PublicKey) (*Key, error) {
+func NewPublicKey(key goat.PublicKey) (*Key, error) {
 	switch key := key.(type) {
 	case *ecdsa.PublicKey:
 		switch key.Curve {

--- a/keymanage/keymanage.go
+++ b/keymanage/keymanage.go
@@ -1,12 +1,14 @@
 // Package keymanage defines the interface of Key Management Algorithms.
 package keymanage
 
-import "crypto"
+import (
+	"github.com/shogo82148/goat"
+)
 
 // Key is a key for wrapping or unwrapping Content Encryption Key (CEK).
 type Key interface {
-	PrivateKey() crypto.PrivateKey
-	PublicKey() crypto.PublicKey
+	PrivateKey() goat.PrivateKey
+	PublicKey() goat.PublicKey
 }
 
 // Algorithm is an algorithm for wrapping or unwrapping Content Encryption Key (CEK).

--- a/secp256k1/secp256k1.go
+++ b/secp256k1/secp256k1.go
@@ -16,6 +16,7 @@ import (
 	"math/big"
 	"sync"
 
+	"github.com/shogo82148/goat"
 	"github.com/shogo82148/goat/internal/curve256k1"
 )
 
@@ -79,7 +80,7 @@ func (priv *PrivateKey) Equal(x crypto.PrivateKey) bool {
 }
 
 // Public returns the corresponding public key.
-func (key *PrivateKey) Public() crypto.PublicKey {
+func (key *PrivateKey) Public() goat.PublicKey {
 	return key.PublicKey()
 }
 

--- a/secp256k1/secp256k1.go
+++ b/secp256k1/secp256k1.go
@@ -16,7 +16,6 @@ import (
 	"math/big"
 	"sync"
 
-	"github.com/shogo82148/goat"
 	"github.com/shogo82148/goat/internal/curve256k1"
 )
 
@@ -80,7 +79,7 @@ func (priv *PrivateKey) Equal(x crypto.PrivateKey) bool {
 }
 
 // Public returns the corresponding public key.
-func (key *PrivateKey) Public() goat.PublicKey {
+func (key *PrivateKey) Public() crypto.PublicKey {
 	return key.PublicKey()
 }
 

--- a/sig/sig.go
+++ b/sig/sig.go
@@ -2,14 +2,15 @@
 package sig
 
 import (
-	"crypto"
 	"errors"
 	"reflect"
+
+	"github.com/shogo82148/goat"
 )
 
 type Key interface {
-	PrivateKey() crypto.PrivateKey
-	PublicKey() crypto.PublicKey
+	PrivateKey() goat.PrivateKey
+	PublicKey() goat.PublicKey
 }
 
 // Algorithm is an algorithm for signing.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated key handling infrastructure to use custom key type interfaces. This is a breaking change for code that directly uses exported key getter or setter methods. Functionality remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->