### PR TITLE
fix: optimize Equal method for PublicKey using constant-time comparison

### DIFF
--- a/x25519/x25519.go
+++ b/x25519/x25519.go
@@ -3,7 +3,6 @@
 package x25519
 
 import (
-	"bytes"
 	"crypto"
 	"crypto/ecdh"
 	cryptorand "crypto/rand"
@@ -34,7 +33,7 @@ func (pub PublicKey) Equal(x crypto.PublicKey) bool {
 	if !ok {
 		return false
 	}
-	return bytes.Equal(pub, xx)
+	return subtle.ConstantTimeCompare(pub, xx) == 1
 }
 
 // PrivateKey is the type of X25519 private keys.

--- a/x448/x448.go
+++ b/x448/x448.go
@@ -3,7 +3,6 @@
 package x448
 
 import (
-	"bytes"
 	"crypto"
 	cryptorand "crypto/rand"
 	"crypto/subtle"
@@ -45,7 +44,7 @@ func (pub PublicKey) Equal(x crypto.PublicKey) bool {
 	if !ok {
 		return false
 	}
-	return bytes.Equal(pub, xx)
+	return subtle.ConstantTimeCompare(pub, xx) == 1
 }
 
 // PrivateKey is the type of X448 private keys.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated public key equality checks in x25519 and x448 modules to use constant-time comparison for consistency and improved security handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->