### PR TITLE
Fix OIDC metadata check

### DIFF
--- a/oidc/config.go
+++ b/oidc/config.go
@@ -102,5 +102,11 @@ func (c *Client) getConfig(ctx context.Context, configURL string) (*Config, time
 	if err := json.Unmarshal(buf, &config); err != nil {
 		return nil, time.Time{}, err
 	}
+
+	// validate
+	if config.Issuer != c.issuer {
+		return nil, time.Time{}, fmt.Errorf("oidc: issuer mismatch: expected %q, got %q", c.issuer, config.Issuer)
+	}
+
 	return &config, expiresAt, nil
 }

--- a/oidc/config.go
+++ b/oidc/config.go
@@ -94,7 +94,7 @@ func (c *Client) getConfig(ctx context.Context, configURL string) (*Config, time
 	}
 
 	// parse the response body
-	buf, err := io.ReadAll(resp.Body)
+	buf, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20)) // limit to 1MB
 	if err != nil {
 		return nil, time.Time{}, err
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced OIDC provider validation with explicit issuer verification to prevent configuration mismatches
  * Added 1MB size limit on discovery responses to protect against resource exhaustion

<!-- end of auto-generated comment: release notes by coderabbit.ai -->