### PR TITLE
fix: correct algorithm type for HS512 in New384Weak and hs512

### DIFF
--- a/jwa/hs/hs.go
+++ b/jwa/hs/hs.go
@@ -38,7 +38,7 @@ func New384() sig.Algorithm {
 }
 
 var hs512 = &algorithm{
-	alg:  jwa.SignatureAlgorithmHS256,
+	alg:  jwa.SignatureAlgorithmHS512,
 	hash: crypto.SHA512,
 }
 
@@ -77,7 +77,7 @@ func New384Weak() sig.Algorithm {
 }
 
 var hs512w = &algorithm{
-	alg:  jwa.SignatureAlgorithmHS256,
+	alg:  jwa.SignatureAlgorithmHS512,
 	hash: crypto.SHA512,
 	weak: true,
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed incorrect algorithm identification for HS512-based HMAC operations. HS512 keys were previously incorrectly identified as HS256 and now correctly identify as HS512, ensuring accurate algorithm reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->